### PR TITLE
feat: add database connectivity check to readiness endpoint

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -258,6 +258,17 @@ func (a *App) buildRouter(
 			"status": "ok",
 		}, nil)
 	})
+	router.Get("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		if err := a.db.Ping(ctx); err != nil {
+			response.WriteError(w, http.StatusServiceUnavailable, "DB_UNHEALTHY", "Database is not reachable", nil)
+			return
+		}
+		response.WriteJSON(w, http.StatusOK, map[string]string{
+			"status": "ok",
+		}, nil)
+	})
 	router.Route("/api/v1", func(r chi.Router) {
 		r.Route("/auth", authHandler.RegisterRoutes)
 		r.Get("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
       - uploads_data:/app/data/uploads
     expose:
       - "8080"
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/readyz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   frontend:
     build:
@@ -46,7 +51,7 @@ services:
     restart: unless-stopped
     depends_on:
       backend:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "3000:80"
 


### PR DESCRIPTION
## Summary
- Add `GET /readyz` readiness probe that pings PostgreSQL with a 2s timeout — returns 503 if DB is unreachable
- Keep `GET /healthz` as a simple liveness probe (process is running)
- Add healthcheck to backend service in docker-compose using `/readyz`
- Upgrade frontend `depends_on` to `service_healthy` so it waits for backend readiness

Closes #9