### PR TITLE
fix: add graceful error handling for background goroutines

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -5,9 +5,11 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -317,16 +319,26 @@ func (a *App) startBackgroundJobs(subscriptionsService *hrisservice.Subscription
 	a.backgroundCancel = cancel
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("background job panicked", "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
+
 		ticker := time.NewTicker(24 * time.Hour)
 		defer ticker.Stop()
 
-		_ = subscriptionsService.GenerateSubscriptionAlerts(ctx, time.Now())
+		if err := subscriptionsService.GenerateSubscriptionAlerts(ctx, time.Now()); err != nil {
+			slog.Error("subscription alert generation failed", "error", err)
+		}
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case tickAt := <-ticker.C:
-				_ = subscriptionsService.GenerateSubscriptionAlerts(ctx, tickAt)
+				if err := subscriptionsService.GenerateSubscriptionAlerts(ctx, tickAt); err != nil {
+					slog.Error("subscription alert generation failed", "error", err, "tick", tickAt)
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
## Summary
- Add `recover()` with stack trace logging to the subscription alert background goroutine — prevents silent process crash on panic
- Log errors from `GenerateSubscriptionAlerts` via `slog.Error` instead of silently discarding with `_ =`
- Include tick timestamp in error logs for easier debugging

Closes #13