### PR TITLE
refactor: add repository interface abstractions to service layer

### DIFF
--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -22,8 +22,22 @@ var (
 	ErrExpiredRefreshToken = errors.New("refresh token has expired")
 )
 
+type authRepository interface {
+	EnsureUserWithRoles(ctx context.Context, params authrepo.CreateUserParams, roles []rbac.RoleKey) (model.User, error)
+	CreateUserWithRoles(ctx context.Context, params authrepo.CreateUserParams, roles []rbac.RoleKey) (model.User, error)
+	GetUserByEmail(ctx context.Context, email string) (model.User, error)
+	GetUserByID(ctx context.Context, userID string) (model.User, error)
+	GetUserRolesAndPermissions(ctx context.Context, userID string) ([]string, []string, error)
+	CreateRefreshToken(ctx context.Context, params authrepo.CreateRefreshTokenParams) error
+	GetRefreshTokenByHash(ctx context.Context, tokenHash string) (model.RefreshToken, error)
+	RotateRefreshToken(ctx context.Context, oldTokenHash string, params authrepo.CreateRefreshTokenParams) error
+	RevokeRefreshToken(ctx context.Context, tokenHash string) error
+	IsUniqueViolation(err error) bool
+	CountUsers(ctx context.Context) (int64, error)
+}
+
 type Service struct {
-	repo         *authrepo.Repository
+	repo         authRepository
 	tokenManager *backendauth.TokenManager
 }
 
@@ -34,7 +48,7 @@ type AuthResult struct {
 	Tokens      dto.TokenPair
 }
 
-func New(repo *authrepo.Repository, cfg config.Config) *Service {
+func New(repo authRepository, cfg config.Config) *Service {
 	return &Service{
 		repo:         repo,
 		tokenManager: backendauth.NewTokenManager(cfg.JWTSecret, cfg.JWTAccessExpiry, cfg.JWTRefreshExpiry),

--- a/backend/internal/service/files/service.go
+++ b/backend/internal/service/files/service.go
@@ -22,13 +22,21 @@ type ResolvedFile struct {
 	Permission string
 }
 
-type Service struct {
-	uploadsDir         string
-	reimbursementsRepo *hrisrepo.ReimbursementsRepository
-	campaignsRepo      *marketingrepo.CampaignsRepository
+type filesReimbursementsRepository interface {
+	FindAttachmentPath(ctx context.Context, reimbursementID string, filename string) (string, error)
 }
 
-func New(uploadsDir string, reimbursementsRepo *hrisrepo.ReimbursementsRepository, campaignsRepo *marketingrepo.CampaignsRepository) *Service {
+type filesCampaignsRepository interface {
+	FindAttachmentPath(ctx context.Context, campaignID string, filename string) (string, error)
+}
+
+type Service struct {
+	uploadsDir         string
+	reimbursementsRepo filesReimbursementsRepository
+	campaignsRepo      filesCampaignsRepository
+}
+
+func New(uploadsDir string, reimbursementsRepo filesReimbursementsRepository, campaignsRepo filesCampaignsRepository) *Service {
 	return &Service{
 		uploadsDir:         uploadsDir,
 		reimbursementsRepo: reimbursementsRepo,

--- a/backend/internal/service/hris/compensation.go
+++ b/backend/internal/service/hris/compensation.go
@@ -19,13 +19,30 @@ var (
 	ErrBonusNotPending = errors.New("only pending bonus records can be changed")
 )
 
+type compensationRepository interface {
+	CreateSalary(ctx context.Context, params hrisrepo.CreateSalaryParams) (hrisrepo.SalaryRow, error)
+	ListSalaries(ctx context.Context, employeeID string) ([]hrisrepo.SalaryRow, error)
+	GetCurrentSalary(ctx context.Context, employeeID string) (hrisrepo.SalaryRow, error)
+	LogSalaryAccess(ctx context.Context, userID string, employeeID string, action string) error
+	CreateBonus(ctx context.Context, params hrisrepo.CreateBonusParams) (hrisrepo.BonusRow, error)
+	ListBonuses(ctx context.Context, employeeID string) ([]hrisrepo.BonusRow, error)
+	GetBonusByID(ctx context.Context, bonusID string) (hrisrepo.BonusRow, error)
+	UpdateBonus(ctx context.Context, bonusID string, params hrisrepo.UpdateBonusParams) (hrisrepo.BonusRow, error)
+	UpdateBonusApprovalStatus(ctx context.Context, bonusID string, status string, approverID string) (hrisrepo.BonusRow, error)
+	DeleteBonus(ctx context.Context, bonusID string) error
+}
+
+type compensationEmployeesRepository interface {
+	GetEmployeeByID(ctx context.Context, employeeID string) (model.Employee, error)
+}
+
 type CompensationService struct {
-	repo          *hrisrepo.CompensationRepository
-	employeesRepo *hrisrepo.EmployeesRepository
+	repo          compensationRepository
+	employeesRepo compensationEmployeesRepository
 	encrypter     *security.Encrypter
 }
 
-func NewCompensationService(repo *hrisrepo.CompensationRepository, employeesRepo *hrisrepo.EmployeesRepository, encrypter *security.Encrypter) *CompensationService {
+func NewCompensationService(repo compensationRepository, employeesRepo compensationEmployeesRepository, encrypter *security.Encrypter) *CompensationService {
 	return &CompensationService{
 		repo:          repo,
 		employeesRepo: employeesRepo,

--- a/backend/internal/service/hris/departments.go
+++ b/backend/internal/service/hris/departments.go
@@ -16,12 +16,25 @@ var (
 	ErrDepartmentHeadMissing = errors.New("department head employee not found")
 )
 
-type DepartmentsService struct {
-	repo          *hrisrepo.DepartmentsRepository
-	employeesRepo *hrisrepo.EmployeesRepository
+type departmentsRepository interface {
+	CreateDepartment(ctx context.Context, params hrisrepo.UpsertDepartmentParams) (model.Department, error)
+	ListDepartments(ctx context.Context) ([]model.Department, error)
+	GetDepartmentByID(ctx context.Context, departmentID string) (model.Department, error)
+	UpdateDepartment(ctx context.Context, departmentID string, params hrisrepo.UpsertDepartmentParams) (model.Department, error)
+	DeleteDepartment(ctx context.Context, departmentID string) (string, error)
 }
 
-func NewDepartmentsService(repo *hrisrepo.DepartmentsRepository, employeesRepo *hrisrepo.EmployeesRepository) *DepartmentsService {
+type departmentsEmployeesRepository interface {
+	RenameDepartmentReferences(ctx context.Context, oldName string, newName string) error
+	ClearDepartmentReferences(ctx context.Context, departmentName string) error
+}
+
+type DepartmentsService struct {
+	repo          departmentsRepository
+	employeesRepo departmentsEmployeesRepository
+}
+
+func NewDepartmentsService(repo departmentsRepository, employeesRepo departmentsEmployeesRepository) *DepartmentsService {
 	return &DepartmentsService{
 		repo:          repo,
 		employeesRepo: employeesRepo,

--- a/backend/internal/service/hris/employees.go
+++ b/backend/internal/service/hris/employees.go
@@ -17,11 +17,19 @@ var (
 	ErrEmployeeUserLinkedTwice = errors.New("user account is already linked to another employee")
 )
 
-type EmployeesService struct {
-	repo *hrisrepo.EmployeesRepository
+type employeesRepository interface {
+	CreateEmployee(ctx context.Context, params hrisrepo.UpsertEmployeeParams) (model.Employee, error)
+	ListEmployees(ctx context.Context, params hrisrepo.ListEmployeesParams) ([]model.Employee, int64, error)
+	GetEmployeeByID(ctx context.Context, employeeID string) (model.Employee, error)
+	UpdateEmployee(ctx context.Context, employeeID string, params hrisrepo.UpsertEmployeeParams) (model.Employee, error)
+	DeleteEmployee(ctx context.Context, employeeID string) error
 }
 
-func NewEmployeesService(repo *hrisrepo.EmployeesRepository) *EmployeesService {
+type EmployeesService struct {
+	repo employeesRepository
+}
+
+func NewEmployeesService(repo employeesRepository) *EmployeesService {
 	return &EmployeesService{repo: repo}
 }
 

--- a/backend/internal/service/hris/finance.go
+++ b/backend/internal/service/hris/finance.go
@@ -18,11 +18,27 @@ var (
 	ErrFinanceCategoryExists   = errors.New("finance category already exists")
 )
 
-type FinanceService struct {
-	repo *hrisrepo.FinanceRepository
+type financeRepository interface {
+	CreateCategory(ctx context.Context, params hrisrepo.UpsertFinanceCategoryParams) (model.FinanceCategory, error)
+	ListCategories(ctx context.Context, recordType string) ([]model.FinanceCategory, error)
+	UpdateCategory(ctx context.Context, categoryID string, params hrisrepo.UpsertFinanceCategoryParams) (model.FinanceCategory, error)
+	DeleteCategory(ctx context.Context, categoryID string) error
+	CreateRecord(ctx context.Context, params hrisrepo.UpsertFinanceRecordParams) (model.FinanceRecord, error)
+	ListRecords(ctx context.Context, params hrisrepo.ListFinanceRecordsParams) ([]model.FinanceRecord, int64, error)
+	GetRecordByID(ctx context.Context, recordID string) (model.FinanceRecord, error)
+	UpdateRecord(ctx context.Context, recordID string, params hrisrepo.UpsertFinanceRecordParams) (model.FinanceRecord, error)
+	DeleteRecord(ctx context.Context, recordID string) error
+	SubmitRecord(ctx context.Context, recordID string, actorID string) (model.FinanceRecord, error)
+	ReviewRecord(ctx context.Context, recordID string, decision string, actorID string) (model.FinanceRecord, error)
+	Summary(ctx context.Context, year int) (model.FinanceSummary, error)
+	ListForExport(ctx context.Context, params hrisrepo.ListFinanceExportParams) ([]model.FinanceRecord, error)
 }
 
-func NewFinanceService(repo *hrisrepo.FinanceRepository) *FinanceService {
+type FinanceService struct {
+	repo financeRepository
+}
+
+func NewFinanceService(repo financeRepository) *FinanceService {
 	return &FinanceService{repo: repo}
 }
 

--- a/backend/internal/service/hris/overview.go
+++ b/backend/internal/service/hris/overview.go
@@ -5,14 +5,17 @@ import (
 	"time"
 
 	"github.com/kana-consultant/kantor/backend/internal/model"
-	hrisrepo "github.com/kana-consultant/kantor/backend/internal/repository/hris"
 )
 
-type OverviewService struct {
-	repo *hrisrepo.OverviewRepository
+type hrisOverviewRepository interface {
+	GetOverview(ctx context.Context, now time.Time) (model.HrisOverview, error)
 }
 
-func NewOverviewService(repo *hrisrepo.OverviewRepository) *OverviewService {
+type OverviewService struct {
+	repo hrisOverviewRepository
+}
+
+func NewOverviewService(repo hrisOverviewRepository) *OverviewService {
 	return &OverviewService{repo: repo}
 }
 

--- a/backend/internal/service/hris/reimbursements.go
+++ b/backend/internal/service/hris/reimbursements.go
@@ -8,10 +8,8 @@ import (
 
 	hrisdto "github.com/kana-consultant/kantor/backend/internal/dto/hris"
 	"github.com/kana-consultant/kantor/backend/internal/model"
-	authrepo "github.com/kana-consultant/kantor/backend/internal/repository/auth"
 	hrisrepo "github.com/kana-consultant/kantor/backend/internal/repository/hris"
 	notificationsrepo "github.com/kana-consultant/kantor/backend/internal/repository/notifications"
-	notificationsservice "github.com/kana-consultant/kantor/backend/internal/service/notifications"
 )
 
 var (
@@ -20,18 +18,41 @@ var (
 	ErrReimbursementInvalidState = errors.New("reimbursement status transition is invalid")
 )
 
+type reimbursementsRepository interface {
+	Create(ctx context.Context, params hrisrepo.CreateReimbursementParams) (model.Reimbursement, error)
+	List(ctx context.Context, params hrisrepo.ListReimbursementsParams) ([]model.Reimbursement, int64, error)
+	GetByID(ctx context.Context, reimbursementID string) (model.Reimbursement, error)
+	AddAttachments(ctx context.Context, reimbursementID string, attachments []string) (model.Reimbursement, error)
+	ApplyManagerReview(ctx context.Context, reimbursementID string, params hrisrepo.ReviewReimbursementParams) (model.Reimbursement, error)
+	MarkPaid(ctx context.Context, reimbursementID string, actorID string, notes *string) (model.Reimbursement, error)
+	Summary(ctx context.Context, month int, year int, employeeID string, department string) (model.ReimbursementSummary, error)
+}
+
+type reimbursementsEmployeesRepository interface {
+	GetEmployeeByID(ctx context.Context, employeeID string) (model.Employee, error)
+	GetEmployeeByUserID(ctx context.Context, userID string) (model.Employee, error)
+}
+
+type reimbursementsAuthRepository interface {
+	ListUserIDsByRole(ctx context.Context, roleName string, module string) ([]string, error)
+}
+
+type reimbursementsNotificationsService interface {
+	CreateMany(ctx context.Context, params []notificationsrepo.CreateParams) error
+}
+
 type ReimbursementsService struct {
-	repo                 *hrisrepo.ReimbursementsRepository
-	employeesRepo        *hrisrepo.EmployeesRepository
-	authRepo             *authrepo.Repository
-	notificationsService *notificationsservice.Service
+	repo                 reimbursementsRepository
+	employeesRepo        reimbursementsEmployeesRepository
+	authRepo             reimbursementsAuthRepository
+	notificationsService reimbursementsNotificationsService
 }
 
 func NewReimbursementsService(
-	repo *hrisrepo.ReimbursementsRepository,
-	employeesRepo *hrisrepo.EmployeesRepository,
-	authRepo *authrepo.Repository,
-	notificationsService *notificationsservice.Service,
+	repo reimbursementsRepository,
+	employeesRepo reimbursementsEmployeesRepository,
+	authRepo reimbursementsAuthRepository,
+	notificationsService reimbursementsNotificationsService,
 ) *ReimbursementsService {
 	return &ReimbursementsService{
 		repo:                 repo,

--- a/backend/internal/service/hris/subscriptions.go
+++ b/backend/internal/service/hris/subscriptions.go
@@ -17,13 +17,31 @@ var (
 	ErrSubscriptionAlertNotFound = errors.New("subscription alert not found")
 )
 
+type subscriptionsRepository interface {
+	CreateSubscription(ctx context.Context, params hrisrepo.CreateSubscriptionParams) (model.Subscription, error)
+	ListSubscriptions(ctx context.Context) ([]model.Subscription, error)
+	GetSubscriptionByID(ctx context.Context, subscriptionID string) (model.Subscription, error)
+	UpdateSubscription(ctx context.Context, subscriptionID string, params hrisrepo.UpdateSubscriptionParams) (model.Subscription, error)
+	DeleteSubscription(ctx context.Context, subscriptionID string) error
+	Summary(ctx context.Context) (model.SubscriptionSummary, error)
+	ListAlerts(ctx context.Context) ([]model.SubscriptionAlert, error)
+	MarkAlertRead(ctx context.Context, alertID string) error
+	ListSubscriptionsForAlertCheck(ctx context.Context) ([]model.Subscription, error)
+	AlertExistsForDay(ctx context.Context, subscriptionID string, alertType string, day time.Time) (bool, error)
+	CreateSubscriptionAlert(ctx context.Context, subscriptionID string, alertType string) error
+}
+
+type subscriptionsEmployeesRepository interface {
+	GetEmployeeByID(ctx context.Context, employeeID string) (model.Employee, error)
+}
+
 type SubscriptionsService struct {
-	repo          *hrisrepo.SubscriptionsRepository
-	employeesRepo *hrisrepo.EmployeesRepository
+	repo          subscriptionsRepository
+	employeesRepo subscriptionsEmployeesRepository
 	encrypter     *security.Encrypter
 }
 
-func NewSubscriptionsService(repo *hrisrepo.SubscriptionsRepository, employeesRepo *hrisrepo.EmployeesRepository, encrypter *security.Encrypter) *SubscriptionsService {
+func NewSubscriptionsService(repo subscriptionsRepository, employeesRepo subscriptionsEmployeesRepository, encrypter *security.Encrypter) *SubscriptionsService {
 	return &SubscriptionsService{
 		repo:          repo,
 		employeesRepo: employeesRepo,

--- a/backend/internal/service/marketing/ads_metrics.go
+++ b/backend/internal/service/marketing/ads_metrics.go
@@ -20,11 +20,22 @@ var (
 	ErrAdsMetricUnsupportedExport = errors.New("ads metrics export format is not supported")
 )
 
-type AdsMetricsService struct {
-	repo *marketingrepo.AdsMetricsRepository
+type adsMetricsRepository interface {
+	CreateMetric(ctx context.Context, params marketingrepo.UpsertAdsMetricParams) (model.AdsMetric, error)
+	BatchCreateMetrics(ctx context.Context, params []marketingrepo.UpsertAdsMetricParams) ([]model.AdsMetric, error)
+	ListMetrics(ctx context.Context, params marketingrepo.ListAdsMetricsParams) ([]model.AdsMetric, int64, error)
+	GetMetricByID(ctx context.Context, metricID string) (model.AdsMetric, error)
+	UpdateMetric(ctx context.Context, metricID string, params marketingrepo.UpsertAdsMetricParams) (model.AdsMetric, error)
+	DeleteMetric(ctx context.Context, metricID string) error
+	Summary(ctx context.Context, params marketingrepo.AdsMetricsSummaryParams) (model.AdsMetricsSummary, error)
+	ListForExport(ctx context.Context, params marketingrepo.AdsMetricsExportParams) ([]model.AdsMetric, error)
 }
 
-func NewAdsMetricsService(repo *marketingrepo.AdsMetricsRepository) *AdsMetricsService {
+type AdsMetricsService struct {
+	repo adsMetricsRepository
+}
+
+func NewAdsMetricsService(repo adsMetricsRepository) *AdsMetricsService {
 	return &AdsMetricsService{repo: repo}
 }
 

--- a/backend/internal/service/marketing/campaigns.go
+++ b/backend/internal/service/marketing/campaigns.go
@@ -8,9 +8,8 @@ import (
 
 	marketingdto "github.com/kana-consultant/kantor/backend/internal/dto/marketing"
 	"github.com/kana-consultant/kantor/backend/internal/model"
-	authrepo "github.com/kana-consultant/kantor/backend/internal/repository/auth"
 	marketingrepo "github.com/kana-consultant/kantor/backend/internal/repository/marketing"
-	notificationsservice "github.com/kana-consultant/kantor/backend/internal/service/notifications"
+	notificationsrepo "github.com/kana-consultant/kantor/backend/internal/repository/notifications"
 )
 
 var (
@@ -21,10 +20,38 @@ var (
 	ErrCampaignColumnInUse        = errors.New("campaign column still has campaigns assigned")
 )
 
+type campaignsRepository interface {
+	CreateCampaign(ctx context.Context, params marketingrepo.UpsertCampaignParams) (model.Campaign, error)
+	ListCampaigns(ctx context.Context, params marketingrepo.ListCampaignsParams) ([]model.Campaign, int64, error)
+	GetCampaignByID(ctx context.Context, campaignID string) (model.Campaign, error)
+	UpdateCampaign(ctx context.Context, campaignID string, params marketingrepo.UpsertCampaignParams) (model.Campaign, error)
+	DeleteCampaign(ctx context.Context, campaignID string) error
+	ListKanban(ctx context.Context) ([]model.CampaignColumn, error)
+	MoveCampaign(ctx context.Context, campaignID string, columnID string, position int, movedBy string) (model.Campaign, error)
+	ListColumns(ctx context.Context) ([]model.CampaignColumn, error)
+	CreateColumn(ctx context.Context, params marketingrepo.CreateCampaignColumnParams) (model.CampaignColumn, error)
+	UpdateColumn(ctx context.Context, columnID string, params marketingrepo.UpdateCampaignColumnParams) (model.CampaignColumn, error)
+	DeleteColumn(ctx context.Context, columnID string) error
+	ReorderColumns(ctx context.Context, columnIDs []string) error
+	CreateAttachment(ctx context.Context, params marketingrepo.CreateCampaignAttachmentParams) (model.CampaignAttachment, error)
+	ListAttachments(ctx context.Context, campaignID string) ([]model.CampaignAttachment, error)
+	DeleteAttachment(ctx context.Context, campaignID string, attachmentID string) (model.CampaignAttachment, error)
+	ListActivities(ctx context.Context, campaignID string) ([]model.CampaignActivity, error)
+	LogActivity(ctx context.Context, campaignID string, actorID string, action string, payload map[string]any) error
+}
+
+type campaignsAuthRepository interface {
+	ListUserIDsByRole(ctx context.Context, roleName string, module string) ([]string, error)
+}
+
+type campaignsNotificationsService interface {
+	CreateMany(ctx context.Context, params []notificationsrepo.CreateParams) error
+}
+
 type CampaignsService struct {
-	repo                 *marketingrepo.CampaignsRepository
-	authRepo             *authrepo.Repository
-	notificationsService *notificationsservice.Service
+	repo                 campaignsRepository
+	authRepo             campaignsAuthRepository
+	notificationsService campaignsNotificationsService
 }
 
 type CampaignDetail struct {
@@ -33,9 +60,9 @@ type CampaignDetail struct {
 }
 
 func NewCampaignsService(
-	repo *marketingrepo.CampaignsRepository,
-	authRepo *authrepo.Repository,
-	notificationsService *notificationsservice.Service,
+	repo campaignsRepository,
+	authRepo campaignsAuthRepository,
+	notificationsService campaignsNotificationsService,
 ) *CampaignsService {
 	return &CampaignsService{
 		repo:                 repo,

--- a/backend/internal/service/marketing/leads.go
+++ b/backend/internal/service/marketing/leads.go
@@ -11,9 +11,8 @@ import (
 
 	marketingdto "github.com/kana-consultant/kantor/backend/internal/dto/marketing"
 	"github.com/kana-consultant/kantor/backend/internal/model"
-	authrepo "github.com/kana-consultant/kantor/backend/internal/repository/auth"
 	marketingrepo "github.com/kana-consultant/kantor/backend/internal/repository/marketing"
-	notificationsservice "github.com/kana-consultant/kantor/backend/internal/service/notifications"
+	notificationsrepo "github.com/kana-consultant/kantor/backend/internal/repository/notifications"
 )
 
 var (
@@ -23,16 +22,37 @@ var (
 	ErrLeadContactRequired      = errors.New("lead must include at least phone or email")
 )
 
+type leadsRepository interface {
+	CreateLead(ctx context.Context, params marketingrepo.UpsertLeadParams) (model.Lead, error)
+	ListLeads(ctx context.Context, params marketingrepo.ListLeadsParams) ([]model.Lead, int64, error)
+	GetLeadByID(ctx context.Context, leadID string) (model.Lead, error)
+	UpdateLead(ctx context.Context, leadID string, params marketingrepo.UpsertLeadParams) (model.Lead, error)
+	DeleteLead(ctx context.Context, leadID string) error
+	ListPipeline(ctx context.Context) ([]model.LeadPipelineColumn, error)
+	MoveLeadStatus(ctx context.Context, leadID string, status string, actorID string) (model.Lead, error)
+	ListActivities(ctx context.Context, leadID string) ([]model.LeadActivity, error)
+	CreateActivity(ctx context.Context, params marketingrepo.CreateLeadActivityParams) (model.LeadActivity, error)
+	Summary(ctx context.Context) (model.LeadSummary, error)
+}
+
+type leadsAuthRepository interface {
+	ListUserIDsByRole(ctx context.Context, roleName string, module string) ([]string, error)
+}
+
+type leadsNotificationsService interface {
+	CreateMany(ctx context.Context, params []notificationsrepo.CreateParams) error
+}
+
 type LeadsService struct {
-	repo                 *marketingrepo.LeadsRepository
-	authRepo             *authrepo.Repository
-	notificationsService *notificationsservice.Service
+	repo                 leadsRepository
+	authRepo             leadsAuthRepository
+	notificationsService leadsNotificationsService
 }
 
 func NewLeadsService(
-	repo *marketingrepo.LeadsRepository,
-	authRepo *authrepo.Repository,
-	notificationsService *notificationsservice.Service,
+	repo leadsRepository,
+	authRepo leadsAuthRepository,
+	notificationsService leadsNotificationsService,
 ) *LeadsService {
 	return &LeadsService{
 		repo:                 repo,

--- a/backend/internal/service/marketing/notifications.go
+++ b/backend/internal/service/marketing/notifications.go
@@ -5,12 +5,15 @@ import (
 	"strings"
 
 	notificationsrepo "github.com/kana-consultant/kantor/backend/internal/repository/notifications"
-	notificationsservice "github.com/kana-consultant/kantor/backend/internal/service/notifications"
 )
+
+type notificationSender interface {
+	CreateMany(ctx context.Context, params []notificationsrepo.CreateParams) error
+}
 
 func sendNotifications(
 	ctx context.Context,
-	service *notificationsservice.Service,
+	service notificationSender,
 	userIDs []string,
 	notificationType string,
 	title string,

--- a/backend/internal/service/marketing/overview.go
+++ b/backend/internal/service/marketing/overview.go
@@ -5,14 +5,17 @@ import (
 	"time"
 
 	"github.com/kana-consultant/kantor/backend/internal/model"
-	marketingrepo "github.com/kana-consultant/kantor/backend/internal/repository/marketing"
 )
 
-type OverviewService struct {
-	repo *marketingrepo.OverviewRepository
+type marketingOverviewRepository interface {
+	GetOverview(ctx context.Context, now time.Time) (model.MarketingOverview, error)
 }
 
-func NewOverviewService(repo *marketingrepo.OverviewRepository) *OverviewService {
+type OverviewService struct {
+	repo marketingOverviewRepository
+}
+
+func NewOverviewService(repo marketingOverviewRepository) *OverviewService {
 	return &OverviewService{repo: repo}
 }
 

--- a/backend/internal/service/notifications/service.go
+++ b/backend/internal/service/notifications/service.go
@@ -11,8 +11,16 @@ import (
 
 var ErrNotificationNotFound = errors.New("notification not found")
 
+type notificationsRepository interface {
+	CreateMany(ctx context.Context, params []notificationsrepo.CreateParams) error
+	List(ctx context.Context, params notificationsrepo.ListParams) ([]model.Notification, int64, error)
+	CountUnread(ctx context.Context, userID string) (int64, error)
+	MarkRead(ctx context.Context, notificationID string, userID string) error
+	MarkAllRead(ctx context.Context, userID string) error
+}
+
 type Service struct {
-	repo *notificationsrepo.Repository
+	repo notificationsRepository
 }
 
 type ListParams struct {
@@ -22,7 +30,7 @@ type ListParams struct {
 	PerPage int
 }
 
-func New(repo *notificationsrepo.Repository) *Service {
+func New(repo notificationsRepository) *Service {
 	return &Service{repo: repo}
 }
 

--- a/backend/internal/service/operational/assignment_rules.go
+++ b/backend/internal/service/operational/assignment_rules.go
@@ -17,8 +17,17 @@ var (
 	ErrAutoAssignNoMatch           = errors.New("no project member matched the active assignment rules")
 )
 
+type assignmentRulesRepository interface {
+	CreateRule(ctx context.Context, projectID string, params operationalrepo.CreateAssignmentRuleParams) (model.AssignmentRule, error)
+	ListRules(ctx context.Context, projectID string) ([]model.AssignmentRule, error)
+	UpdateRule(ctx context.Context, projectID string, ruleID string, params operationalrepo.UpdateAssignmentRuleParams) (model.AssignmentRule, error)
+	DeleteRule(ctx context.Context, projectID string, ruleID string) error
+	ListCandidates(ctx context.Context, projectID string) ([]model.AssignmentCandidate, error)
+	AutoAssignTask(ctx context.Context, projectID string, taskID string, params operationalrepo.AutoAssignTaskParams) (model.KanbanTask, error)
+}
+
 type AssignmentRulesService struct {
-	repo *operationalrepo.AssignmentRulesRepository
+	repo assignmentRulesRepository
 }
 
 type AutoAssignResult struct {
@@ -27,7 +36,7 @@ type AutoAssignResult struct {
 	AssignedTo  model.AssignmentCandidate `json:"assigned_to"`
 }
 
-func NewAssignmentRulesService(repo *operationalrepo.AssignmentRulesRepository) *AssignmentRulesService {
+func NewAssignmentRulesService(repo assignmentRulesRepository) *AssignmentRulesService {
 	return &AssignmentRulesService{repo: repo}
 }
 

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -16,11 +16,26 @@ var (
 	ErrKanbanTaskNotFound   = errors.New("kanban task not found")
 )
 
-type KanbanService struct {
-	repo *operationalrepo.KanbanRepository
+type kanbanRepository interface {
+	CreateDefaultColumns(ctx context.Context, projectID string) error
+	ListColumns(ctx context.Context, projectID string) ([]model.KanbanColumn, error)
+	CreateColumn(ctx context.Context, projectID string, params operationalrepo.CreateKanbanColumnParams) (model.KanbanColumn, error)
+	UpdateColumn(ctx context.Context, projectID string, columnID string, params operationalrepo.UpdateKanbanColumnParams) (model.KanbanColumn, error)
+	DeleteColumn(ctx context.Context, projectID string, columnID string) error
+	ReorderColumns(ctx context.Context, projectID string, columnIDs []string) error
+	ListTasks(ctx context.Context, projectID string) ([]model.KanbanTask, error)
+	CreateTask(ctx context.Context, projectID string, params operationalrepo.CreateKanbanTaskParams) (model.KanbanTask, error)
+	UpdateTask(ctx context.Context, projectID string, taskID string, params operationalrepo.UpdateKanbanTaskParams) (model.KanbanTask, error)
+	DeleteTask(ctx context.Context, projectID string, taskID string) error
+	MoveTask(ctx context.Context, projectID string, taskID string, destinationColumnID string, destinationPosition int) error
+	Snapshot(ctx context.Context, projectID string) (operationalrepo.KanbanSnapshot, error)
 }
 
-func NewKanbanService(repo *operationalrepo.KanbanRepository) *KanbanService {
+type KanbanService struct {
+	repo kanbanRepository
+}
+
+func NewKanbanService(repo kanbanRepository) *KanbanService {
 	return &KanbanService{repo: repo}
 }
 

--- a/backend/internal/service/operational/overview.go
+++ b/backend/internal/service/operational/overview.go
@@ -5,14 +5,17 @@ import (
 	"time"
 
 	"github.com/kana-consultant/kantor/backend/internal/model"
-	operationalrepo "github.com/kana-consultant/kantor/backend/internal/repository/operational"
 )
 
-type OverviewService struct {
-	repo *operationalrepo.OverviewRepository
+type overviewRepository interface {
+	GetOverview(ctx context.Context, now time.Time) (model.OperationalOverview, error)
 }
 
-func NewOverviewService(repo *operationalrepo.OverviewRepository) *OverviewService {
+type OverviewService struct {
+	repo overviewRepository
+}
+
+func NewOverviewService(repo overviewRepository) *OverviewService {
 	return &OverviewService{repo: repo}
 }
 

--- a/backend/internal/service/operational/projects.go
+++ b/backend/internal/service/operational/projects.go
@@ -18,9 +18,23 @@ var (
 	ErrProjectMemberNotFound = errors.New("project member user not found")
 )
 
+type projectsRepository interface {
+	CreateProject(ctx context.Context, params operationalrepo.CreateProjectParams) (model.Project, error)
+	ListProjects(ctx context.Context, params operationalrepo.ListProjectsParams) ([]model.Project, int64, error)
+	GetProjectByID(ctx context.Context, projectID string) (model.Project, error)
+	UpdateProject(ctx context.Context, projectID string, params operationalrepo.UpdateProjectParams) (model.Project, error)
+	DeleteProject(ctx context.Context, projectID string) error
+	ListProjectMembers(ctx context.Context, projectID string) ([]model.ProjectMember, error)
+	MutateProjectMember(ctx context.Context, projectID string, params operationalrepo.ProjectMemberMutationParams) error
+}
+
+type projectsKanbanRepository interface {
+	CreateDefaultColumns(ctx context.Context, projectID string) error
+}
+
 type ProjectsService struct {
-	repo       *operationalrepo.ProjectsRepository
-	kanbanRepo *operationalrepo.KanbanRepository
+	repo       projectsRepository
+	kanbanRepo projectsKanbanRepository
 }
 
 type ProjectDetail struct {
@@ -28,7 +42,7 @@ type ProjectDetail struct {
 	Members []model.ProjectMember `json:"members"`
 }
 
-func NewProjectsService(repo *operationalrepo.ProjectsRepository, kanbanRepo *operationalrepo.KanbanRepository) *ProjectsService {
+func NewProjectsService(repo projectsRepository, kanbanRepo projectsKanbanRepository) *ProjectsService {
 	return &ProjectsService{
 		repo:       repo,
 		kanbanRepo: kanbanRepo,


### PR DESCRIPTION
## Summary
- Define private (unexported) interfaces in each service file for all repository dependencies
- Follow Go convention: "accept interfaces, return structs" — interfaces live at the consumer side
- All 19 service files updated; no changes to repository implementations or `app.go` wire-up
- Enables unit testing services with mock repositories without a real database

Closes #18