### PR TITLE
feat: audit log viewer with JSON diff and export

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-chi/chi/v5"
 
 	"github.com/kana-consultant/kantor/backend/internal/config"
+	adminhandler "github.com/kana-consultant/kantor/backend/internal/handler/admin"
 	authhandler "github.com/kana-consultant/kantor/backend/internal/handler/auth"
 	fileshandler "github.com/kana-consultant/kantor/backend/internal/handler/files"
 	hrishandler "github.com/kana-consultant/kantor/backend/internal/handler/hris"
@@ -205,6 +206,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	application.router = application.buildRouter(
 		auditService,
 		authService,
+		adminhandler.NewAuditLogsHandler(auditService),
 		operationalhandler.NewOverviewHandler(operationalOverviewService),
 		operationalhandler.NewProjectsHandler(projectsService, projectsRepository),
 		operationalhandler.NewKanbanHandler(kanbanService),
@@ -249,6 +251,7 @@ func (a *App) Close() {
 func (a *App) buildRouter(
 	auditService *auditservice.Service,
 	authService *authservice.Service,
+	auditLogsHandler *adminhandler.AuditLogsHandler,
 	operationalOverviewHandler *operationalhandler.OverviewHandler,
 	projectsHandler *operationalhandler.ProjectsHandler,
 	kanbanHandler *operationalhandler.KanbanHandler,
@@ -326,6 +329,7 @@ func (a *App) buildRouter(
 
 			protected.Route("/admin", func(admin chi.Router) {
 				admin.Use(platformmiddleware.RequireModuleAccess(rbac.ModuleAdmin))
+				admin.Route("/audit-logs", auditLogsHandler.RegisterRoutes)
 				admin.With(platformmiddleware.RequireAnyPermission(
 					"admin:roles:view",
 					"admin:users:view",

--- a/backend/internal/handler/admin/audit_logs.go
+++ b/backend/internal/handler/admin/audit_logs.go
@@ -1,0 +1,160 @@
+package admin
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
+	auditrepo "github.com/kana-consultant/kantor/backend/internal/repository/audit"
+	"github.com/kana-consultant/kantor/backend/internal/response"
+	auditservice "github.com/kana-consultant/kantor/backend/internal/service/audit"
+)
+
+type AuditLogsHandler struct {
+	service *auditservice.Service
+}
+
+func NewAuditLogsHandler(service *auditservice.Service) *AuditLogsHandler {
+	return &AuditLogsHandler{service: service}
+}
+
+func (h *AuditLogsHandler) RegisterRoutes(router chi.Router) {
+	router.With(platformmiddleware.RequirePermission("admin:audit_log:view")).Get("/", h.list)
+	router.With(platformmiddleware.RequirePermission("admin:audit_log:view")).Get("/summary", h.summary)
+	router.With(platformmiddleware.RequirePermission("admin:audit_log:view")).Get("/users", h.listUsers)
+	router.With(platformmiddleware.RequirePermission("admin:audit_log:export")).Get("/export", h.exportCSV)
+}
+
+func (h *AuditLogsHandler) list(w http.ResponseWriter, r *http.Request) {
+	params, ok := parseListParams(w, r, true)
+	if !ok {
+		return
+	}
+
+	items, total, err := h.service.ListLogs(r.Context(), params)
+	if err != nil {
+		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list audit logs", nil)
+		return
+	}
+
+	page := params.Page
+	if page <= 0 {
+		page = 1
+	}
+	perPage := params.PerPage
+	if perPage <= 0 {
+		perPage = 20
+	}
+
+	response.WriteJSON(w, http.StatusOK, items, map[string]any{
+		"page":     page,
+		"per_page": perPage,
+		"total":    total,
+	})
+}
+
+func (h *AuditLogsHandler) summary(w http.ResponseWriter, r *http.Request) {
+	item, err := h.service.GetSummary(r.Context())
+	if err != nil {
+		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load audit log summary", nil)
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, item, nil)
+}
+
+func (h *AuditLogsHandler) listUsers(w http.ResponseWriter, r *http.Request) {
+	items, err := h.service.ListActors(r.Context(), strings.TrimSpace(r.URL.Query().Get("search")))
+	if err != nil {
+		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load audit log users", nil)
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, items, nil)
+}
+
+func (h *AuditLogsHandler) exportCSV(w http.ResponseWriter, r *http.Request) {
+	params, ok := parseListParams(w, r, false)
+	if !ok {
+		return
+	}
+
+	payload, err := h.service.ExportCSV(r.Context(), params)
+	if err != nil {
+		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to export audit logs", nil)
+		return
+	}
+
+	filename := "audit-logs-" + time.Now().Format("20060102-150405") + ".csv"
+	w.Header().Set("Content-Type", "text/csv")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(payload)
+}
+
+func parseListParams(w http.ResponseWriter, r *http.Request, includePagination bool) (auditrepo.ListParams, bool) {
+	params := auditrepo.ListParams{
+		Module:     strings.TrimSpace(r.URL.Query().Get("module")),
+		Action:     strings.TrimSpace(r.URL.Query().Get("action")),
+		UserID:     strings.TrimSpace(r.URL.Query().Get("user_id")),
+		Resource:   strings.TrimSpace(r.URL.Query().Get("resource")),
+		ResourceID: strings.TrimSpace(r.URL.Query().Get("resource_id")),
+		Search:     strings.TrimSpace(r.URL.Query().Get("search")),
+	}
+
+	dateFrom, ok := parseDate(w, "date_from", strings.TrimSpace(r.URL.Query().Get("date_from")))
+	if !ok {
+		return auditrepo.ListParams{}, false
+	}
+	if dateFrom != nil {
+		params.DateFrom = dateFrom
+	}
+
+	dateTo, ok := parseDate(w, "date_to", strings.TrimSpace(r.URL.Query().Get("date_to")))
+	if !ok {
+		return auditrepo.ListParams{}, false
+	}
+	if dateTo != nil {
+		nextDay := dateTo.Add(24 * time.Hour)
+		params.DateTo = &nextDay
+	}
+
+	if includePagination {
+		if value := strings.TrimSpace(r.URL.Query().Get("page")); value != "" {
+			page, err := strconv.Atoi(value)
+			if err != nil {
+				response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "page must be a number", map[string]string{"page": "invalid_number"})
+				return auditrepo.ListParams{}, false
+			}
+			params.Page = page
+		}
+		if value := strings.TrimSpace(r.URL.Query().Get("per_page")); value != "" {
+			perPage, err := strconv.Atoi(value)
+			if err != nil {
+				response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "per_page must be a number", map[string]string{"per_page": "invalid_number"})
+				return auditrepo.ListParams{}, false
+			}
+			params.PerPage = perPage
+		}
+	}
+
+	return params, true
+}
+
+func parseDate(w http.ResponseWriter, field string, raw string) (*time.Time, bool) {
+	if raw == "" {
+		return nil, true
+	}
+
+	value, err := time.Parse("2006-01-02", raw)
+	if err != nil {
+		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", field+" must use YYYY-MM-DD format", map[string]string{field: "invalid_date"})
+		return nil, false
+	}
+
+	return &value, true
+}

--- a/backend/internal/handler/auth/admin_rbac.go
+++ b/backend/internal/handler/auth/admin_rbac.go
@@ -76,10 +76,18 @@ func (h *Handler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	platformmiddleware.AuditLog(r.Context(), "create", "admin", "role", item.ID, nil, item)
 	response.WriteJSON(w, http.StatusCreated, item, nil)
 }
 
 func (h *Handler) UpdateRole(w http.ResponseWriter, r *http.Request) {
+	roleID := chi.URLParam(r, "roleID")
+	previous, previousErr := h.service.GetRoleDetail(r.Context(), roleID)
+	if previousErr != nil {
+		h.writeRoleError(w, previousErr)
+		return
+	}
+
 	var input dto.UpsertRoleRequest
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		response.WriteError(w, http.StatusBadRequest, "INVALID_JSON", "Request body must be valid JSON", nil)
@@ -90,7 +98,7 @@ func (h *Handler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	item, err := h.service.UpdateRole(r.Context(), chi.URLParam(r, "roleID"), authrepo.UpsertRoleParams{
+	item, err := h.service.UpdateRole(r.Context(), roleID, authrepo.UpsertRoleParams{
 		Name:           strings.TrimSpace(input.Name),
 		Slug:           strings.ToLower(strings.TrimSpace(input.Slug)),
 		Description:    strings.TrimSpace(input.Description),
@@ -102,25 +110,42 @@ func (h *Handler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	platformmiddleware.AuditLog(r.Context(), "update", "admin", "role", roleID, previous, item)
 	response.WriteJSON(w, http.StatusOK, item, nil)
 }
 
 func (h *Handler) DeleteRole(w http.ResponseWriter, r *http.Request) {
-	if err := h.service.DeleteRole(r.Context(), chi.URLParam(r, "roleID")); err != nil {
+	roleID := chi.URLParam(r, "roleID")
+	previous, previousErr := h.service.GetRoleDetail(r.Context(), roleID)
+	if previousErr != nil {
+		h.writeRoleError(w, previousErr)
+		return
+	}
+
+	if err := h.service.DeleteRole(r.Context(), roleID); err != nil {
 		h.writeRoleError(w, err)
 		return
 	}
 
+	platformmiddleware.AuditLog(r.Context(), "delete", "admin", "role", roleID, previous, nil)
 	response.WriteJSON(w, http.StatusOK, map[string]bool{"success": true}, nil)
 }
 
 func (h *Handler) ToggleRole(w http.ResponseWriter, r *http.Request) {
-	item, err := h.service.ToggleRole(r.Context(), chi.URLParam(r, "roleID"))
+	roleID := chi.URLParam(r, "roleID")
+	previous, previousErr := h.service.GetRoleDetail(r.Context(), roleID)
+	if previousErr != nil {
+		h.writeRoleError(w, previousErr)
+		return
+	}
+
+	item, err := h.service.ToggleRole(r.Context(), roleID)
 	if err != nil {
 		h.writeRoleError(w, err)
 		return
 	}
 
+	platformmiddleware.AuditLog(r.Context(), "update", "admin", "role", roleID, previous, item)
 	response.WriteJSON(w, http.StatusOK, item, nil)
 }
 
@@ -137,6 +162,10 @@ func (h *Handler) DuplicateRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	platformmiddleware.AuditLog(r.Context(), "create", "admin", "role", item.ID, nil, map[string]any{
+		"duplicated_from": chi.URLParam(r, "roleID"),
+		"role":            item,
+	})
 	response.WriteJSON(w, http.StatusCreated, item, nil)
 }
 
@@ -177,6 +206,12 @@ func (h *Handler) UpdateDefaultRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	previous, err := h.service.GetSettings(r.Context())
+	if err != nil {
+		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load current settings", nil)
+		return
+	}
+
 	var input dto.UpdateDefaultRolesRequest
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
 		response.WriteError(w, http.StatusBadRequest, "INVALID_JSON", "Request body must be valid JSON", nil)
@@ -201,6 +236,8 @@ func (h *Handler) UpdateDefaultRoles(w http.ResponseWriter, r *http.Request) {
 		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Default roles updated but failed to fetch settings", nil)
 		return
 	}
+
+	platformmiddleware.AuditLog(r.Context(), "update", "admin", "system_setting", "default_roles", previous.DefaultRoles, settings.DefaultRoles)
 	response.WriteJSON(w, http.StatusOK, settings, nil)
 }
 
@@ -208,6 +245,12 @@ func (h *Handler) UpdateAutoCreateEmployee(w http.ResponseWriter, r *http.Reques
 	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
 	if !ok {
 		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+		return
+	}
+
+	previous, err := h.service.GetSettings(r.Context())
+	if err != nil {
+		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load current settings", nil)
 		return
 	}
 
@@ -230,6 +273,8 @@ func (h *Handler) UpdateAutoCreateEmployee(w http.ResponseWriter, r *http.Reques
 		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Setting updated but failed to fetch settings", nil)
 		return
 	}
+
+	platformmiddleware.AuditLog(r.Context(), "update", "admin", "system_setting", "auto_create_employee", previous.AutoCreateEmployee, settings.AutoCreateEmployee)
 	response.WriteJSON(w, http.StatusOK, settings, nil)
 }
 

--- a/backend/internal/handler/auth/handler.go
+++ b/backend/internal/handler/auth/handler.go
@@ -20,11 +20,11 @@ import (
 const refreshTokenCookie = "refresh_token"
 
 type Handler struct {
-	service        *authservice.Service
-	validator      *validator.Validate
-	cookieSecure   bool
-	cookiePath     string
-	refreshExpiry  time.Duration
+	service       *authservice.Service
+	validator     *validator.Validate
+	cookieSecure  bool
+	cookiePath    string
+	refreshExpiry time.Duration
 }
 
 func New(service *authservice.Service, cfg config.Config) *Handler {
@@ -106,6 +106,11 @@ func (h *Handler) register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.setRefreshTokenCookie(w, result.Tokens.RefreshToken)
+	platformmiddleware.AuditLogWithUser(r.Context(), result.User.ID, "register", "admin", "auth", result.User.ID, nil, map[string]any{
+		"email":          result.User.Email,
+		"is_super_admin": result.IsSuperAdmin,
+		"module_roles":   result.ModuleRoles,
+	})
 	response.WriteJSON(w, http.StatusCreated, dto.AuthResponse{
 		User:         result.User,
 		ModuleRoles:  result.ModuleRoles,
@@ -128,6 +133,10 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.setRefreshTokenCookie(w, result.Tokens.RefreshToken)
+	platformmiddleware.AuditLogWithUser(r.Context(), result.User.ID, "login", "admin", "auth", result.User.ID, nil, map[string]any{
+		"email":          result.User.Email,
+		"is_super_admin": result.IsSuperAdmin,
+	})
 	response.WriteJSON(w, http.StatusOK, dto.AuthResponse{
 		User:         result.User,
 		ModuleRoles:  result.ModuleRoles,
@@ -163,7 +172,11 @@ func (h *Handler) refresh(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) logout(w http.ResponseWriter, r *http.Request) {
 	refreshToken, err := h.readRefreshTokenCookie(r)
 	if err == nil {
-		_ = h.service.Logout(r.Context(), refreshToken)
+		if userID, logoutErr := h.service.Logout(r.Context(), refreshToken); logoutErr == nil {
+			platformmiddleware.AuditLogWithUser(r.Context(), userID, "logout", "admin", "auth", userID, nil, map[string]any{
+				"revoked": true,
+			})
+		}
 	}
 
 	h.clearRefreshTokenCookie(w)

--- a/backend/internal/handler/auth/users.go
+++ b/backend/internal/handler/auth/users.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/kana-consultant/kantor/backend/internal/dto"
 	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
-	"github.com/kana-consultant/kantor/backend/internal/response"
 	authrepo "github.com/kana-consultant/kantor/backend/internal/repository/auth"
+	"github.com/kana-consultant/kantor/backend/internal/response"
 )
 
 func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
@@ -67,6 +67,11 @@ func (h *Handler) GetUser(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) UpdateUserRoles(w http.ResponseWriter, r *http.Request) {
 	userID := chi.URLParam(r, "userID")
+	previous, previousErr := h.service.GetAdminUserDetail(r.Context(), userID)
+	if previousErr != nil {
+		response.WriteError(w, http.StatusNotFound, "USER_NOT_FOUND", "User not found", nil)
+		return
+	}
 
 	var input dto.UpdateUserModuleRolesRequest
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
@@ -95,11 +100,17 @@ func (h *Handler) UpdateUserRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	platformmiddleware.AuditLog(r.Context(), "update", "admin", "user_module_roles", userID, previous, result)
 	response.WriteJSON(w, http.StatusOK, result, nil)
 }
 
 func (h *Handler) ToggleUserActive(w http.ResponseWriter, r *http.Request) {
 	userID := chi.URLParam(r, "userID")
+	previous, previousErr := h.service.GetAdminUserDetail(r.Context(), userID)
+	if previousErr != nil {
+		response.WriteError(w, http.StatusNotFound, "USER_NOT_FOUND", "User not found", nil)
+		return
+	}
 
 	var input dto.ToggleActiveRequest
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
@@ -112,6 +123,11 @@ func (h *Handler) ToggleUserActive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	platformmiddleware.AuditLog(r.Context(), "update", "admin", "user", userID, map[string]any{
+		"is_active": previous.User.IsActive,
+	}, map[string]any{
+		"is_active": input.Active,
+	})
 	response.WriteJSON(w, http.StatusOK, map[string]bool{"success": true}, nil)
 }
 
@@ -127,6 +143,11 @@ func (h *Handler) ToggleUserSuperAdmin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := chi.URLParam(r, "userID")
+	previous, previousErr := h.service.GetAdminUserDetail(r.Context(), userID)
+	if previousErr != nil {
+		response.WriteError(w, http.StatusNotFound, "USER_NOT_FOUND", "User not found", nil)
+		return
+	}
 
 	var input dto.ToggleSuperAdminRequest
 	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
@@ -150,6 +171,11 @@ func (h *Handler) ToggleUserSuperAdmin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	platformmiddleware.AuditLog(r.Context(), "update", "admin", "user", userID, map[string]any{
+		"is_super_admin": previous.IsSuperAdmin,
+	}, map[string]any{
+		"is_super_admin": result.IsSuperAdmin,
+	})
 	response.WriteJSON(w, http.StatusOK, result, nil)
 }
 

--- a/backend/internal/handler/hris/compensation.go
+++ b/backend/internal/handler/hris/compensation.go
@@ -69,6 +69,11 @@ func (h *CompensationHandler) listSalaries(w http.ResponseWriter, r *http.Reques
 		h.writeError(w, err)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "view", "hris", "salary", chi.URLParam(r, "employeeID"), nil, map[string]any{
+		"scope":         "history",
+		"employee_id":   chi.URLParam(r, "employeeID"),
+		"records_count": len(result),
+	})
 	response.WriteJSON(w, http.StatusOK, result, nil)
 }
 
@@ -84,6 +89,11 @@ func (h *CompensationHandler) getCurrentSalary(w http.ResponseWriter, r *http.Re
 		h.writeError(w, err)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "view", "hris", "salary", chi.URLParam(r, "employeeID"), nil, map[string]any{
+		"scope":       "current",
+		"employee_id": chi.URLParam(r, "employeeID"),
+		"salary_id":   result.ID,
+	})
 	response.WriteJSON(w, http.StatusOK, result, nil)
 }
 

--- a/backend/internal/handler/whatsapp/handler.go
+++ b/backend/internal/handler/whatsapp/handler.go
@@ -87,18 +87,32 @@ func (h *Handler) getQR(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) startSession(w http.ResponseWriter, r *http.Request) {
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+		return
+	}
+
 	if err := h.service.StartSession(); err != nil {
 		response.WriteError(w, http.StatusBadGateway, "WAHA_ERROR", err.Error(), nil)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "update", "operational", "wa_session", principal.UserID, nil, map[string]any{"status": "started"})
 	response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Session started"}, nil)
 }
 
 func (h *Handler) stopSession(w http.ResponseWriter, r *http.Request) {
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+		return
+	}
+
 	if err := h.service.StopSession(); err != nil {
 		response.WriteError(w, http.StatusBadGateway, "WAHA_ERROR", err.Error(), nil)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "update", "operational", "wa_session", principal.UserID, nil, map[string]any{"status": "stopped"})
 	response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Session stopped"}, nil)
 }
 
@@ -153,11 +167,22 @@ func (h *Handler) createTemplate(w http.ResponseWriter, r *http.Request) {
 		h.writeInternalError(w, err)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "create", "operational", "wa_template", result.ID, nil, result)
 	response.WriteJSON(w, http.StatusCreated, result, nil)
 }
 
 func (h *Handler) updateTemplate(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "templateID")
+	previous, previousErr := h.service.GetTemplate(r.Context(), id)
+	if previousErr != nil {
+		if errors.Is(previousErr, waservice.ErrTemplateNotFound) {
+			response.WriteError(w, http.StatusNotFound, "TEMPLATE_NOT_FOUND", "Template not found", nil)
+			return
+		}
+		h.writeInternalError(w, previousErr)
+		return
+	}
+
 	var input wadto.UpdateTemplateRequest
 	if !h.decodeAndValidate(w, r, &input) {
 		return
@@ -180,11 +205,17 @@ func (h *Handler) updateTemplate(w http.ResponseWriter, r *http.Request) {
 		h.writeInternalError(w, err)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "update", "operational", "wa_template", id, previous, result)
 	response.WriteJSON(w, http.StatusOK, result, nil)
 }
 
 func (h *Handler) deleteTemplate(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "templateID")
+	previous, previousErr := h.service.GetTemplate(r.Context(), id)
+	if previousErr != nil && !errors.Is(previousErr, waservice.ErrTemplateNotFound) {
+		h.writeInternalError(w, previousErr)
+		return
+	}
 	err := h.service.DeleteTemplate(r.Context(), id)
 	switch {
 	case errors.Is(err, waservice.ErrTemplateNotFound):
@@ -194,6 +225,7 @@ func (h *Handler) deleteTemplate(w http.ResponseWriter, r *http.Request) {
 	case err != nil:
 		h.writeInternalError(w, err)
 	default:
+		platformmiddleware.AuditLog(r.Context(), "delete", "operational", "wa_template", id, previous, nil)
 		response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Template deleted"}, nil)
 	}
 }
@@ -249,11 +281,22 @@ func (h *Handler) createSchedule(w http.ResponseWriter, r *http.Request) {
 		h.writeInternalError(w, err)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "create", "operational", "wa_schedule", result.ID, nil, result)
 	response.WriteJSON(w, http.StatusCreated, result, nil)
 }
 
 func (h *Handler) updateSchedule(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "scheduleID")
+	previous, previousErr := h.service.GetSchedule(r.Context(), id)
+	if previousErr != nil {
+		if errors.Is(previousErr, waservice.ErrScheduleNotFound) {
+			response.WriteError(w, http.StatusNotFound, "SCHEDULE_NOT_FOUND", "Schedule not found", nil)
+			return
+		}
+		h.writeInternalError(w, previousErr)
+		return
+	}
+
 	var input wadto.UpdateScheduleRequest
 	if !h.decodeAndValidate(w, r, &input) {
 		return
@@ -276,11 +319,17 @@ func (h *Handler) updateSchedule(w http.ResponseWriter, r *http.Request) {
 		h.writeInternalError(w, err)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "update", "operational", "wa_schedule", id, previous, result)
 	response.WriteJSON(w, http.StatusOK, result, nil)
 }
 
 func (h *Handler) deleteSchedule(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "scheduleID")
+	previous, previousErr := h.service.GetSchedule(r.Context(), id)
+	if previousErr != nil && !errors.Is(previousErr, waservice.ErrScheduleNotFound) {
+		h.writeInternalError(w, previousErr)
+		return
+	}
 	err := h.service.DeleteSchedule(r.Context(), id)
 	if errors.Is(err, waservice.ErrScheduleNotFound) {
 		response.WriteError(w, http.StatusNotFound, "SCHEDULE_NOT_FOUND", "Schedule not found", nil)
@@ -290,12 +339,14 @@ func (h *Handler) deleteSchedule(w http.ResponseWriter, r *http.Request) {
 		h.writeInternalError(w, err)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "delete", "operational", "wa_schedule", id, previous, nil)
 	response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Schedule deleted"}, nil)
 }
 
 func (h *Handler) triggerSchedule(w http.ResponseWriter, r *http.Request) {
 	// For now, manual trigger runs the daily reminders
 	go h.service.RunDailyReminders(r.Context())
+	platformmiddleware.AuditLog(r.Context(), "trigger", "operational", "wa_schedule", chi.URLParam(r, "scheduleID"), nil, map[string]any{"trigger": "manual"})
 	response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Schedule triggered"}, nil)
 }
 
@@ -315,6 +366,7 @@ func (h *Handler) toggleSchedule(w http.ResponseWriter, r *http.Request) {
 		h.writeInternalError(w, err)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "update", "operational", "wa_schedule", id, nil, result)
 	response.WriteJSON(w, http.StatusOK, result, nil)
 }
 
@@ -368,6 +420,12 @@ func (h *Handler) getLogSummary(w http.ResponseWriter, r *http.Request) {
 // --------------- Quick Send ---------------
 
 func (h *Handler) quickSend(w http.ResponseWriter, r *http.Request) {
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+		return
+	}
+
 	var input wadto.QuickSendRequest
 	if !h.decodeAndValidate(w, r, &input) {
 		return
@@ -377,6 +435,10 @@ func (h *Handler) quickSend(w http.ResponseWriter, r *http.Request) {
 		response.WriteError(w, http.StatusBadGateway, "SEND_FAILED", err.Error(), nil)
 		return
 	}
+	platformmiddleware.AuditLog(r.Context(), "send", "operational", "wa_broadcast", principal.UserID, nil, map[string]any{
+		"phone":          input.Phone,
+		"message_length": len([]rune(input.Message)),
+	})
 	response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Message sent"}, nil)
 }
 

--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -56,6 +56,24 @@ func AuditLog(ctx context.Context, action, module, resource, resourceID string, 
 	})
 }
 
+func AuditLogWithUser(ctx context.Context, userID, action, module, resource, resourceID string, oldValue, newValue interface{}) {
+	svc := AuditServiceFromContext(ctx)
+	if svc == nil {
+		return
+	}
+
+	svc.Log(ctx, auditservice.Entry{
+		UserID:     userID,
+		Action:     action,
+		Module:     module,
+		Resource:   resource,
+		ResourceID: resourceID,
+		OldValue:   oldValue,
+		NewValue:   newValue,
+		IPAddress:  ClientIPFromContext(ctx),
+	})
+}
+
 func extractIP(r *http.Request) string {
 	// chi's RealIP middleware sets RemoteAddr from X-Forwarded-For / X-Real-IP,
 	// so r.RemoteAddr already reflects the real client IP in most setups.

--- a/backend/internal/repository/audit/repository.go
+++ b/backend/internal/repository/audit/repository.go
@@ -2,11 +2,16 @@ package audit
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	repository "github.com/kana-consultant/kantor/backend/internal/repository"
 )
 
 type Entry struct {
@@ -20,6 +25,62 @@ type Entry struct {
 	IPAddress  string
 }
 
+type ListParams struct {
+	Module     string
+	Action     string
+	UserID     string
+	Resource   string
+	ResourceID string
+	DateFrom   *time.Time
+	DateTo     *time.Time
+	Search     string
+	Page       int
+	PerPage    int
+}
+
+type LogRecord struct {
+	ID            string          `json:"id"`
+	UserID        *string         `json:"user_id,omitempty"`
+	UserName      string          `json:"user_name"`
+	UserEmail     string          `json:"user_email"`
+	UserAvatarURL *string         `json:"user_avatar_url,omitempty"`
+	Action        string          `json:"action"`
+	Module        string          `json:"module"`
+	Resource      string          `json:"resource"`
+	ResourceID    string          `json:"resource_id"`
+	OldValue      json.RawMessage `json:"old_value,omitempty"`
+	NewValue      json.RawMessage `json:"new_value,omitempty"`
+	IPAddress     string          `json:"ip_address,omitempty"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+type SummaryBucket struct {
+	Key   string `json:"key"`
+	Count int64  `json:"count"`
+}
+
+type UserActivityCount struct {
+	UserID    *string `json:"user_id,omitempty"`
+	UserName  string  `json:"user_name"`
+	UserEmail string  `json:"user_email"`
+	Count     int64   `json:"count"`
+}
+
+type Summary struct {
+	TotalToday int64               `json:"total_today"`
+	TotalWeek  int64               `json:"total_week"`
+	ByModule   []SummaryBucket     `json:"by_module"`
+	ByAction   []SummaryBucket     `json:"by_action"`
+	TopUsers   []UserActivityCount `json:"top_users"`
+}
+
+type ActorOption struct {
+	UserID        string  `json:"user_id"`
+	UserName      string  `json:"user_name"`
+	UserEmail     string  `json:"user_email"`
+	UserAvatarURL *string `json:"user_avatar_url,omitempty"`
+}
+
 type Repository struct {
 	db *pgxpool.Pool
 }
@@ -29,6 +90,9 @@ func NewRepository(db *pgxpool.Pool) *Repository {
 }
 
 func (r *Repository) Insert(ctx context.Context, entry Entry) error {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
 	oldJSON, err := marshalNullableJSON(entry.OldValue)
 	if err != nil {
 		return fmt.Errorf("marshal old_value: %w", err)
@@ -56,6 +120,350 @@ func (r *Repository) Insert(ctx context.Context, entry Entry) error {
 	}
 
 	return nil
+}
+
+func (r *Repository) List(ctx context.Context, params ListParams) ([]LogRecord, int64, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	whereClause, args, nextArgIndex := buildWhereClause(params)
+
+	var total int64
+	if err := r.db.QueryRow(ctx, fmt.Sprintf(`
+		SELECT COUNT(*)
+		FROM audit_logs
+		LEFT JOIN users ON users.id = audit_logs.user_id
+		WHERE %s
+	`, whereClause), args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count audit logs: %w", err)
+	}
+
+	page := params.Page
+	if page <= 0 {
+		page = 1
+	}
+	perPage := params.PerPage
+	if perPage <= 0 {
+		perPage = 20
+	}
+
+	listArgs := append([]any{}, args...)
+	listArgs = append(listArgs, perPage, (page-1)*perPage)
+
+	rows, err := r.db.Query(ctx, fmt.Sprintf(`
+		SELECT
+			audit_logs.id::text,
+			audit_logs.user_id::text,
+			COALESCE(users.full_name, 'System'),
+			COALESCE(users.email, ''),
+			users.avatar_url,
+			audit_logs.action,
+			audit_logs.module,
+			audit_logs.resource,
+			audit_logs.resource_id,
+			audit_logs.old_value,
+			audit_logs.new_value,
+			COALESCE(audit_logs.ip_address::text, ''),
+			audit_logs.created_at
+		FROM audit_logs
+		LEFT JOIN users ON users.id = audit_logs.user_id
+		WHERE %s
+		ORDER BY audit_logs.created_at DESC
+		LIMIT $%d OFFSET $%d
+	`, whereClause, nextArgIndex, nextArgIndex+1), listArgs...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list audit logs: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]LogRecord, 0)
+	for rows.Next() {
+		item, err := scanLogRecord(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		items = append(items, item)
+	}
+
+	return items, total, rows.Err()
+}
+
+func (r *Repository) ListForExport(ctx context.Context, params ListParams) ([]LogRecord, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	whereClause, args, _ := buildWhereClause(params)
+	rows, err := r.db.Query(ctx, fmt.Sprintf(`
+		SELECT
+			audit_logs.id::text,
+			audit_logs.user_id::text,
+			COALESCE(users.full_name, 'System'),
+			COALESCE(users.email, ''),
+			users.avatar_url,
+			audit_logs.action,
+			audit_logs.module,
+			audit_logs.resource,
+			audit_logs.resource_id,
+			audit_logs.old_value,
+			audit_logs.new_value,
+			COALESCE(audit_logs.ip_address::text, ''),
+			audit_logs.created_at
+		FROM audit_logs
+		LEFT JOIN users ON users.id = audit_logs.user_id
+		WHERE %s
+		ORDER BY audit_logs.created_at DESC
+	`, whereClause), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list audit logs for export: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]LogRecord, 0)
+	for rows.Next() {
+		item, err := scanLogRecord(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+
+	return items, rows.Err()
+}
+
+func (r *Repository) Summary(ctx context.Context) (Summary, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var summary Summary
+	if err := r.db.QueryRow(ctx, `
+		SELECT
+			COUNT(*) FILTER (WHERE created_at >= date_trunc('day', NOW()))::bigint AS total_today,
+			COUNT(*) FILTER (WHERE created_at >= date_trunc('week', NOW()))::bigint AS total_week
+		FROM audit_logs
+	`).Scan(&summary.TotalToday, &summary.TotalWeek); err != nil {
+		return Summary{}, fmt.Errorf("load audit log totals: %w", err)
+	}
+
+	byModuleRows, err := r.db.Query(ctx, `
+		SELECT module, COUNT(*)::bigint
+		FROM audit_logs
+		GROUP BY module
+		ORDER BY COUNT(*) DESC, module ASC
+	`)
+	if err != nil {
+		return Summary{}, fmt.Errorf("load audit log module summary: %w", err)
+	}
+	defer byModuleRows.Close()
+
+	summary.ByModule = make([]SummaryBucket, 0)
+	for byModuleRows.Next() {
+		var bucket SummaryBucket
+		if err := byModuleRows.Scan(&bucket.Key, &bucket.Count); err != nil {
+			return Summary{}, fmt.Errorf("scan audit log module summary: %w", err)
+		}
+		summary.ByModule = append(summary.ByModule, bucket)
+	}
+	if err := byModuleRows.Err(); err != nil {
+		return Summary{}, fmt.Errorf("iterate audit log module summary: %w", err)
+	}
+
+	byActionRows, err := r.db.Query(ctx, `
+		SELECT action, COUNT(*)::bigint
+		FROM audit_logs
+		GROUP BY action
+		ORDER BY COUNT(*) DESC, action ASC
+	`)
+	if err != nil {
+		return Summary{}, fmt.Errorf("load audit log action summary: %w", err)
+	}
+	defer byActionRows.Close()
+
+	summary.ByAction = make([]SummaryBucket, 0)
+	for byActionRows.Next() {
+		var bucket SummaryBucket
+		if err := byActionRows.Scan(&bucket.Key, &bucket.Count); err != nil {
+			return Summary{}, fmt.Errorf("scan audit log action summary: %w", err)
+		}
+		summary.ByAction = append(summary.ByAction, bucket)
+	}
+	if err := byActionRows.Err(); err != nil {
+		return Summary{}, fmt.Errorf("iterate audit log action summary: %w", err)
+	}
+
+	topUserRows, err := r.db.Query(ctx, `
+		SELECT
+			audit_logs.user_id::text,
+			COALESCE(users.full_name, 'System'),
+			COALESCE(users.email, ''),
+			COUNT(*)::bigint AS total_logs
+		FROM audit_logs
+		LEFT JOIN users ON users.id = audit_logs.user_id
+		GROUP BY audit_logs.user_id, users.full_name, users.email
+		ORDER BY total_logs DESC, COALESCE(users.full_name, 'System') ASC
+		LIMIT 5
+	`)
+	if err != nil {
+		return Summary{}, fmt.Errorf("load audit log top users: %w", err)
+	}
+	defer topUserRows.Close()
+
+	summary.TopUsers = make([]UserActivityCount, 0)
+	for topUserRows.Next() {
+		var userID sql.NullString
+		var item UserActivityCount
+		if err := topUserRows.Scan(&userID, &item.UserName, &item.UserEmail, &item.Count); err != nil {
+			return Summary{}, fmt.Errorf("scan audit log top user: %w", err)
+		}
+		if userID.Valid {
+			value := userID.String
+			item.UserID = &value
+		}
+		summary.TopUsers = append(summary.TopUsers, item)
+	}
+	if err := topUserRows.Err(); err != nil {
+		return Summary{}, fmt.Errorf("iterate audit log top users: %w", err)
+	}
+
+	return summary, nil
+}
+
+func (r *Repository) ListActors(ctx context.Context, search string) ([]ActorOption, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	args := make([]any, 0)
+	where := ""
+	if trimmed := strings.TrimSpace(search); trimmed != "" {
+		args = append(args, "%"+trimmed+"%")
+		where = "AND (users.full_name ILIKE $1 OR users.email ILIKE $1)"
+	}
+
+	rows, err := r.db.Query(ctx, fmt.Sprintf(`
+		SELECT DISTINCT users.id::text, users.full_name, users.email, users.avatar_url
+		FROM audit_logs
+		INNER JOIN users ON users.id = audit_logs.user_id
+		WHERE audit_logs.user_id IS NOT NULL %s
+		ORDER BY users.full_name ASC, users.email ASC
+	`, where), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list audit log actors: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]ActorOption, 0)
+	for rows.Next() {
+		var item ActorOption
+		if err := rows.Scan(&item.UserID, &item.UserName, &item.UserEmail, &item.UserAvatarURL); err != nil {
+			return nil, fmt.Errorf("scan audit log actor: %w", err)
+		}
+		items = append(items, item)
+	}
+
+	return items, rows.Err()
+}
+
+func buildWhereClause(params ListParams) (string, []any, int) {
+	filters := []string{"1=1"}
+	args := make([]any, 0)
+	argIndex := 1
+
+	if module := strings.TrimSpace(params.Module); module != "" {
+		filters = append(filters, fmt.Sprintf("audit_logs.module = $%d", argIndex))
+		args = append(args, module)
+		argIndex++
+	}
+	if action := strings.TrimSpace(params.Action); action != "" {
+		filters = append(filters, fmt.Sprintf("audit_logs.action = $%d", argIndex))
+		args = append(args, action)
+		argIndex++
+	}
+	if userID := strings.TrimSpace(params.UserID); userID != "" {
+		filters = append(filters, fmt.Sprintf("audit_logs.user_id = $%d::uuid", argIndex))
+		args = append(args, userID)
+		argIndex++
+	}
+	if resource := strings.TrimSpace(params.Resource); resource != "" {
+		filters = append(filters, fmt.Sprintf("audit_logs.resource = $%d", argIndex))
+		args = append(args, resource)
+		argIndex++
+	}
+	if resourceID := strings.TrimSpace(params.ResourceID); resourceID != "" {
+		filters = append(filters, fmt.Sprintf("audit_logs.resource_id = $%d", argIndex))
+		args = append(args, resourceID)
+		argIndex++
+	}
+	if params.DateFrom != nil {
+		filters = append(filters, fmt.Sprintf("audit_logs.created_at >= $%d", argIndex))
+		args = append(args, params.DateFrom.UTC())
+		argIndex++
+	}
+	if params.DateTo != nil {
+		filters = append(filters, fmt.Sprintf("audit_logs.created_at < $%d", argIndex))
+		args = append(args, params.DateTo.UTC())
+		argIndex++
+	}
+	if search := strings.TrimSpace(params.Search); search != "" {
+		filters = append(filters, fmt.Sprintf(`(
+			audit_logs.action ILIKE $%d OR
+			audit_logs.resource ILIKE $%d OR
+			audit_logs.resource_id ILIKE $%d OR
+			audit_logs.old_value::text ILIKE $%d OR
+			audit_logs.new_value::text ILIKE $%d OR
+			COALESCE(users.full_name, '') ILIKE $%d OR
+			COALESCE(users.email, '') ILIKE $%d
+		)`, argIndex, argIndex, argIndex, argIndex, argIndex, argIndex, argIndex))
+		args = append(args, "%"+search+"%")
+		argIndex++
+	}
+
+	return strings.Join(filters, " AND "), args, argIndex
+}
+
+type logScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanLogRecord(scanner logScanner) (LogRecord, error) {
+	var item LogRecord
+	var userID sql.NullString
+	var avatarURL sql.NullString
+	var oldValue []byte
+	var newValue []byte
+
+	if err := scanner.Scan(
+		&item.ID,
+		&userID,
+		&item.UserName,
+		&item.UserEmail,
+		&avatarURL,
+		&item.Action,
+		&item.Module,
+		&item.Resource,
+		&item.ResourceID,
+		&oldValue,
+		&newValue,
+		&item.IPAddress,
+		&item.CreatedAt,
+	); err != nil {
+		return LogRecord{}, fmt.Errorf("scan audit log: %w", err)
+	}
+
+	if userID.Valid {
+		value := userID.String
+		item.UserID = &value
+	}
+	if avatarURL.Valid {
+		value := avatarURL.String
+		item.UserAvatarURL = &value
+	}
+	if len(oldValue) > 0 {
+		item.OldValue = json.RawMessage(oldValue)
+	}
+	if len(newValue) > 0 {
+		item.NewValue = json.RawMessage(newValue)
+	}
+
+	return item, nil
 }
 
 func marshalNullableJSON(v interface{}) ([]byte, error) {

--- a/backend/internal/service/audit/service.go
+++ b/backend/internal/service/audit/service.go
@@ -2,7 +2,9 @@ package audit
 
 import (
 	"context"
+	"encoding/csv"
 	"log/slog"
+	"strings"
 
 	auditrepo "github.com/kana-consultant/kantor/backend/internal/repository/audit"
 )
@@ -30,4 +32,64 @@ func (s *Service) Log(ctx context.Context, entry Entry) {
 			"user_id", entry.UserID,
 		)
 	}
+}
+
+func (s *Service) ListLogs(ctx context.Context, params auditrepo.ListParams) ([]auditrepo.LogRecord, int64, error) {
+	return s.repo.List(ctx, params)
+}
+
+func (s *Service) GetSummary(ctx context.Context) (auditrepo.Summary, error) {
+	return s.repo.Summary(ctx)
+}
+
+func (s *Service) ListActors(ctx context.Context, search string) ([]auditrepo.ActorOption, error) {
+	return s.repo.ListActors(ctx, search)
+}
+
+func (s *Service) ExportCSV(ctx context.Context, params auditrepo.ListParams) ([]byte, error) {
+	items, err := s.repo.ListForExport(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	builder := &strings.Builder{}
+	writer := csv.NewWriter(builder)
+	if err := writer.Write([]string{
+		"timestamp",
+		"user_name",
+		"user_email",
+		"module",
+		"action",
+		"resource",
+		"resource_id",
+		"ip_address",
+		"old_value",
+		"new_value",
+	}); err != nil {
+		return nil, err
+	}
+
+	for _, item := range items {
+		if err := writer.Write([]string{
+			item.CreatedAt.Format("2006-01-02 15:04:05 MST"),
+			item.UserName,
+			item.UserEmail,
+			item.Module,
+			item.Action,
+			item.Resource,
+			item.ResourceID,
+			item.IPAddress,
+			string(item.OldValue),
+			string(item.NewValue),
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+
+	return []byte(builder.String()), nil
 }

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -247,20 +247,28 @@ func (s *Service) ChangePassword(ctx context.Context, userID string, currentPass
 	return s.repo.ChangePasswordAndRevokeTokens(ctx, userID, newHash)
 }
 
-func (s *Service) Logout(ctx context.Context, refreshToken string) error {
+func (s *Service) Logout(ctx context.Context, refreshToken string) (string, error) {
 	tokenHash := backendauth.HashRefreshToken(strings.TrimSpace(refreshToken))
 	if tokenHash == "" {
-		return ErrInvalidRefreshToken
+		return "", ErrInvalidRefreshToken
+	}
+
+	storedToken, err := s.repo.GetRefreshTokenByHash(ctx, tokenHash)
+	if err != nil {
+		if errors.Is(err, authrepo.ErrNotFound) {
+			return "", ErrInvalidRefreshToken
+		}
+		return "", err
 	}
 
 	if err := s.repo.RevokeRefreshToken(ctx, tokenHash); err != nil {
 		if errors.Is(err, authrepo.ErrNotFound) {
-			return ErrInvalidRefreshToken
+			return "", ErrInvalidRefreshToken
 		}
-		return err
+		return "", err
 	}
 
-	return nil
+	return storedToken.UserID, nil
 }
 
 func (s *Service) ParseAccessToken(token string) (*backendauth.AccessClaims, error) {

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   BarChart3,
   UserPlus,
   Shield,
+  ScrollText,
   Settings2,
 } from "lucide-react";
 import { Link, useRouterState } from "@tanstack/react-router";
@@ -169,6 +170,12 @@ export function Sidebar({ collapsed = false, mobile = false, onNavigate, onToggl
 
   if (isSuperAdmin || hasModuleAccess("admin")) {
     const adminItems = [
+      {
+        to: "/admin/audit-logs",
+        label: "Audit Logs",
+        icon: ScrollText,
+        permission: permissions.adminAuditLogView,
+      },
       {
         to: "/admin/roles",
         label: "Roles",

--- a/frontend/src/components/shared/data-table.tsx
+++ b/frontend/src/components/shared/data-table.tsx
@@ -1,3 +1,4 @@
+import { Fragment } from "react";
 import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { ChevronDown, ChevronUp, Inbox } from "lucide-react";
@@ -27,6 +28,7 @@ interface DataTableProps<TData> {
   getRowClassName?: (row: TData) => string | undefined;
   selectedRowId?: string | null;
   onRowClick?: (row: TData) => void;
+  renderExpandedRow?: (row: TData) => ReactNode;
   emptyTitle: string;
   emptyDescription: string;
   emptyActionLabel?: string;
@@ -53,6 +55,7 @@ export function DataTable<TData>({
   getRowClassName,
   selectedRowId,
   onRowClick,
+  renderExpandedRow,
   emptyTitle,
   emptyDescription,
   emptyActionLabel,
@@ -153,30 +156,38 @@ export function DataTable<TData>({
               const selected = rowId === selectedRowId;
 
               return (
-                <tr
-                  className={cn(
-                    "border-b border-border transition last:border-b-0 hover:bg-surface-muted",
-                    selected && "bg-module-light shadow-[inset_3px_0_0_0_var(--module-primary)]",
-                    getRowClassName?.(row),
-                    onRowClick && "cursor-pointer",
-                  )}
-                  key={rowId}
-                  onClick={() => onRowClick?.(row)}
-                >
-                  {columns.map((column) => (
-                    <td
-                      className={cn(
-                        "px-4 py-4 align-top text-sm text-text-primary",
-                        column.numeric && "font-mono tabular-nums",
-                        column.align === "right" && "text-right",
-                        column.align === "center" && "text-center",
-                      )}
-                      key={column.id}
-                    >
-                      {column.cell ? column.cell(row) : formatValue(readValue(row, column))}
-                    </td>
-                  ))}
-                </tr>
+                <Fragment key={rowId}>
+                  <tr
+                    className={cn(
+                      "border-b border-border transition last:border-b-0 hover:bg-surface-muted",
+                      selected && "bg-module-light shadow-[inset_3px_0_0_0_var(--module-primary)]",
+                      getRowClassName?.(row),
+                      onRowClick && "cursor-pointer",
+                    )}
+                    onClick={() => onRowClick?.(row)}
+                  >
+                    {columns.map((column) => (
+                      <td
+                        className={cn(
+                          "px-4 py-4 align-top text-sm text-text-primary",
+                          column.numeric && "font-mono tabular-nums",
+                          column.align === "right" && "text-right",
+                          column.align === "center" && "text-center",
+                        )}
+                        key={column.id}
+                      >
+                        {column.cell ? column.cell(row) : formatValue(readValue(row, column))}
+                      </td>
+                    ))}
+                  </tr>
+                  {selected && renderExpandedRow ? (
+                    <tr className="border-b border-border bg-surface-muted/40 last:border-b-0">
+                      <td className="px-4 py-4" colSpan={columns.length}>
+                        {renderExpandedRow(row)}
+                      </td>
+                    </tr>
+                  ) : null}
+                </Fragment>
               );
             })}
           </tbody>

--- a/frontend/src/components/shared/json-diff-viewer.tsx
+++ b/frontend/src/components/shared/json-diff-viewer.tsx
@@ -1,0 +1,155 @@
+import { useMemo } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface JsonDiffViewerProps {
+  oldValue: unknown | null;
+  newValue: unknown | null;
+}
+
+type DiffStatus = "added" | "removed" | "changed" | "unchanged";
+
+interface DiffRow {
+  path: string;
+  oldValue: unknown;
+  newValue: unknown;
+  status: DiffStatus;
+}
+
+export function JsonDiffViewer({ oldValue, newValue }: JsonDiffViewerProps) {
+  const rows = useMemo(() => buildDiffRows(oldValue, newValue), [oldValue, newValue]);
+
+  return (
+    <div className="overflow-hidden rounded-md border border-border bg-surface">
+      <div className="grid grid-cols-[minmax(180px,220px)_1fr_1fr] border-b border-border bg-surface-muted text-[11px] font-semibold uppercase tracking-[0.08em] text-text-secondary">
+        <div className="px-4 py-3">Field</div>
+        <div className="border-l border-border px-4 py-3">Old Value</div>
+        <div className="border-l border-border px-4 py-3">New Value</div>
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="px-4 py-5 font-mono text-sm text-text-secondary">
+          Tidak ada perubahan JSON yang bisa ditampilkan.
+        </div>
+      ) : (
+        <div className="divide-y divide-border">
+          {rows.map((row) => (
+            <div
+              className={cn(
+                "grid grid-cols-[minmax(180px,220px)_1fr_1fr]",
+                row.status === "added" && "bg-success-light/50",
+                row.status === "removed" && "bg-error-light/50",
+                row.status === "changed" && "bg-warning-light/40",
+              )}
+              key={row.path}
+            >
+              <div className="px-4 py-3 font-mono text-[13px] text-text-primary">{row.path}</div>
+              <div className="border-l border-border px-4 py-3">
+                <pre className="whitespace-pre-wrap break-all font-mono text-[12px] leading-6 text-text-secondary">
+                  {formatJsonValue(row.oldValue)}
+                </pre>
+              </div>
+              <div className="border-l border-border px-4 py-3">
+                <pre className="whitespace-pre-wrap break-all font-mono text-[12px] leading-6 text-text-primary">
+                  {formatJsonValue(row.newValue)}
+                </pre>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function buildDiffRows(oldValue: unknown | null, newValue: unknown | null): DiffRow[] {
+  const oldFlat = flattenValue(oldValue);
+  const newFlat = flattenValue(newValue);
+  const paths = Array.from(new Set([...oldFlat.keys(), ...newFlat.keys()])).sort();
+
+  return paths.map((path) => {
+    const oldEntry = oldFlat.get(path);
+    const newEntry = newFlat.get(path);
+
+    if (oldEntry === undefined) {
+      return { path, oldValue: null, newValue: newEntry, status: "added" };
+    }
+    if (newEntry === undefined) {
+      return { path, oldValue: oldEntry, newValue: null, status: "removed" };
+    }
+
+    const status = isSameValue(oldEntry, newEntry) ? "unchanged" : "changed";
+    return { path, oldValue: oldEntry, newValue: newEntry, status };
+  });
+}
+
+function flattenValue(input: unknown, parentPath = ""): Map<string, unknown> {
+  const output = new Map<string, unknown>();
+
+  if (input === null || input === undefined) {
+    if (parentPath) {
+      output.set(parentPath, input);
+    }
+    return output;
+  }
+
+  if (Array.isArray(input)) {
+    if (input.length === 0) {
+      output.set(parentPath || "$", []);
+      return output;
+    }
+
+    input.forEach((item, index) => {
+      const nextPath = parentPath ? `${parentPath}[${index}]` : `$[${index}]`;
+      const nested = flattenValue(item, nextPath);
+      if (nested.size === 0) {
+        output.set(nextPath, item);
+        return;
+      }
+      nested.forEach((value, key) => output.set(key, value));
+    });
+    return output;
+  }
+
+  if (isPlainObject(input)) {
+    const entries = Object.entries(input);
+    if (entries.length === 0) {
+      output.set(parentPath || "$", {});
+      return output;
+    }
+
+    entries.forEach(([key, value]) => {
+      const nextPath = parentPath ? `${parentPath}.${key}` : key;
+      const nested = flattenValue(value, nextPath);
+      if (nested.size === 0) {
+        output.set(nextPath, value);
+        return;
+      }
+      nested.forEach((nestedValue, nestedKey) => output.set(nestedKey, nestedValue));
+    });
+    return output;
+  }
+
+  output.set(parentPath || "$", input);
+  return output;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSameValue(left: unknown, right: unknown) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function formatJsonValue(value: unknown) {
+  if (value === undefined || value === null) {
+    return "-";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return JSON.stringify(value, null, 2);
+}

--- a/frontend/src/components/shared/status-badge.tsx
+++ b/frontend/src/components/shared/status-badge.tsx
@@ -11,7 +11,9 @@ type StatusVariant =
   | "renewal-alert"
   | "campaign-status"
   | "lead-status"
-  | "assignment";
+  | "assignment"
+  | "audit-action"
+  | "module";
 
 interface StatusBadgeProps {
   status: string | null | undefined;
@@ -212,6 +214,49 @@ function resolveTone(status: string, variant: StatusVariant): Tone {
         return tones.info;
       case "manual":
         return tones.neutral;
+      default:
+        return tones.neutral;
+    }
+  }
+
+  if (variant === "audit-action") {
+    switch (normalized) {
+      case "create":
+      case "register":
+      case "login":
+      case "submit":
+      case "send":
+        return tones.success;
+      case "update":
+      case "edit":
+      case "review":
+      case "move":
+      case "toggle":
+      case "trigger":
+        return tones.info;
+      case "view":
+        return tones.neutral;
+      case "approve":
+        return tones.success;
+      case "reject":
+      case "delete":
+      case "logout":
+        return tones.error;
+      default:
+        return tones.neutral;
+    }
+  }
+
+  if (variant === "module") {
+    switch (normalized) {
+      case "operational":
+        return tones.ops;
+      case "hris":
+        return tones.qualified;
+      case "marketing":
+        return tones.proposal;
+      case "admin":
+        return tones.error;
       default:
         return tones.neutral;
     }

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as AuthenticatedHrisDepartmentsRouteImport } from './routes/_auth
 import { Route as AuthenticatedAdminUsersRouteImport } from './routes/_authenticated/admin/users'
 import { Route as AuthenticatedAdminSettingsRouteImport } from './routes/_authenticated/admin/settings'
 import { Route as AuthenticatedAdminRolesRouteImport } from './routes/_authenticated/admin/roles'
+import { Route as AuthenticatedAdminAuditLogsRouteImport } from './routes/_authenticated/admin/audit-logs'
 import { Route as AuthenticatedOperationalProjectsIndexRouteImport } from './routes/_authenticated/operational/projects/index'
 import { Route as AuthenticatedHrisReimbursementsIndexRouteImport } from './routes/_authenticated/hris/reimbursements/index'
 import { Route as AuthenticatedHrisEmployeesIndexRouteImport } from './routes/_authenticated/hris/employees/index'
@@ -174,6 +175,12 @@ const AuthenticatedAdminRolesRoute = AuthenticatedAdminRolesRouteImport.update({
   path: '/admin/roles',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedAdminAuditLogsRoute =
+  AuthenticatedAdminAuditLogsRouteImport.update({
+    id: '/admin/audit-logs',
+    path: '/admin/audit-logs',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedOperationalProjectsIndexRoute =
   AuthenticatedOperationalProjectsIndexRouteImport.update({
     id: '/operational/projects/',
@@ -217,6 +224,7 @@ export interface FileRoutesByFullPath {
   '/register': typeof RegisterRoute
   '/forbidden': typeof AuthenticatedForbiddenRoute
   '/profile': typeof AuthenticatedProfileRoute
+  '/admin/audit-logs': typeof AuthenticatedAdminAuditLogsRoute
   '/admin/roles': typeof AuthenticatedAdminRolesRoute
   '/admin/settings': typeof AuthenticatedAdminSettingsRoute
   '/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -248,6 +256,7 @@ export interface FileRoutesByTo {
   '/register': typeof RegisterRoute
   '/forbidden': typeof AuthenticatedForbiddenRoute
   '/profile': typeof AuthenticatedProfileRoute
+  '/admin/audit-logs': typeof AuthenticatedAdminAuditLogsRoute
   '/admin/roles': typeof AuthenticatedAdminRolesRoute
   '/admin/settings': typeof AuthenticatedAdminSettingsRoute
   '/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -281,6 +290,7 @@ export interface FileRoutesById {
   '/register': typeof RegisterRoute
   '/_authenticated/forbidden': typeof AuthenticatedForbiddenRoute
   '/_authenticated/profile': typeof AuthenticatedProfileRoute
+  '/_authenticated/admin/audit-logs': typeof AuthenticatedAdminAuditLogsRoute
   '/_authenticated/admin/roles': typeof AuthenticatedAdminRolesRoute
   '/_authenticated/admin/settings': typeof AuthenticatedAdminSettingsRoute
   '/_authenticated/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -314,6 +324,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/forbidden'
     | '/profile'
+    | '/admin/audit-logs'
     | '/admin/roles'
     | '/admin/settings'
     | '/admin/users'
@@ -345,6 +356,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/forbidden'
     | '/profile'
+    | '/admin/audit-logs'
     | '/admin/roles'
     | '/admin/settings'
     | '/admin/users'
@@ -377,6 +389,7 @@ export interface FileRouteTypes {
     | '/register'
     | '/_authenticated/forbidden'
     | '/_authenticated/profile'
+    | '/_authenticated/admin/audit-logs'
     | '/_authenticated/admin/roles'
     | '/_authenticated/admin/settings'
     | '/_authenticated/admin/users'
@@ -580,6 +593,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminRolesRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/admin/audit-logs': {
+      id: '/_authenticated/admin/audit-logs'
+      path: '/admin/audit-logs'
+      fullPath: '/admin/audit-logs'
+      preLoaderRoute: typeof AuthenticatedAdminAuditLogsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/operational/projects/': {
       id: '/_authenticated/operational/projects/'
       path: '/operational/projects'
@@ -628,6 +648,7 @@ declare module '@tanstack/react-router' {
 interface AuthenticatedRouteChildren {
   AuthenticatedForbiddenRoute: typeof AuthenticatedForbiddenRoute
   AuthenticatedProfileRoute: typeof AuthenticatedProfileRoute
+  AuthenticatedAdminAuditLogsRoute: typeof AuthenticatedAdminAuditLogsRoute
   AuthenticatedAdminRolesRoute: typeof AuthenticatedAdminRolesRoute
   AuthenticatedAdminSettingsRoute: typeof AuthenticatedAdminSettingsRoute
   AuthenticatedAdminUsersRoute: typeof AuthenticatedAdminUsersRoute
@@ -657,6 +678,7 @@ interface AuthenticatedRouteChildren {
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedForbiddenRoute: AuthenticatedForbiddenRoute,
   AuthenticatedProfileRoute: AuthenticatedProfileRoute,
+  AuthenticatedAdminAuditLogsRoute: AuthenticatedAdminAuditLogsRoute,
   AuthenticatedAdminRolesRoute: AuthenticatedAdminRolesRoute,
   AuthenticatedAdminSettingsRoute: AuthenticatedAdminSettingsRoute,
   AuthenticatedAdminUsersRoute: AuthenticatedAdminUsersRoute,

--- a/frontend/src/routes/_authenticated/admin/audit-logs.tsx
+++ b/frontend/src/routes/_authenticated/admin/audit-logs.tsx
@@ -1,0 +1,494 @@
+import { useEffect, useMemo, useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import {
+  CalendarClock,
+  Download,
+  ScrollText,
+  Shield,
+  UserRound,
+} from "lucide-react";
+
+import { DataTable, type DataTableColumn } from "@/components/shared/data-table";
+import { EmptyState } from "@/components/shared/empty-state";
+import { JsonDiffViewer } from "@/components/shared/json-diff-viewer";
+import { OverviewSkeleton } from "@/components/shared/skeletons";
+import { StatCard } from "@/components/shared/stat-card";
+import { StatusBadge } from "@/components/shared/status-badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Tooltip } from "@/components/ui/tooltip";
+import { useRBAC } from "@/hooks/use-rbac";
+import { permissions } from "@/lib/permissions";
+import { ensureModuleAccess, ensurePermission } from "@/lib/rbac";
+import {
+  adminAuditKeys,
+  exportAuditLogs,
+  getAuditLogSummary,
+  listAuditLogUsers,
+  listAuditLogs,
+} from "@/services/admin-audit";
+import { toast } from "@/stores/toast-store";
+import type {
+  AuditLogFilters,
+  AuditLogItem,
+  AuditLogSummaryBucket,
+} from "@/types/audit-log";
+
+const defaultFilters: AuditLogFilters = {
+  module: "",
+  action: "",
+  userId: "",
+  resource: "",
+  resourceId: "",
+  dateFrom: "",
+  dateTo: "",
+  search: "",
+  page: 1,
+  perPage: 20,
+};
+
+const moduleOptions = [
+  { value: "", label: "Semua Modul" },
+  { value: "operational", label: "Operasional" },
+  { value: "hris", label: "HRIS" },
+  { value: "marketing", label: "Marketing" },
+  { value: "admin", label: "Admin" },
+];
+
+const actionOptions = [
+  { value: "", label: "Semua Aksi" },
+  { value: "create", label: "Create" },
+  { value: "update", label: "Update" },
+  { value: "delete", label: "Delete" },
+  { value: "view", label: "View" },
+  { value: "approve", label: "Approve" },
+  { value: "reject", label: "Reject" },
+  { value: "login", label: "Login" },
+  { value: "logout", label: "Logout" },
+];
+
+export const Route = createFileRoute("/_authenticated/admin/audit-logs")({
+  beforeLoad: async () => {
+    await ensureModuleAccess("admin");
+    await ensurePermission(permissions.adminAuditLogView);
+  },
+  component: AuditLogsPage,
+});
+
+function AuditLogsPage() {
+  const { hasPermission } = useRBAC();
+  const canExport = hasPermission(permissions.adminAuditLogExport);
+  const [filters, setFilters] = useState<AuditLogFilters>(defaultFilters);
+  const [searchInput, setSearchInput] = useState("");
+  const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setFilters((current) =>
+        current.search === searchInput.trim()
+          ? current
+          : { ...current, search: searchInput.trim(), page: 1 },
+      );
+    }, 250);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [searchInput]);
+
+  const summaryQuery = useQuery({
+    queryKey: adminAuditKeys.summary(),
+    queryFn: getAuditLogSummary,
+  });
+
+  const usersQuery = useQuery({
+    queryKey: adminAuditKeys.users(),
+    queryFn: () => listAuditLogUsers(),
+  });
+
+  const logsQuery = useQuery({
+    queryKey: adminAuditKeys.logList(filters),
+    queryFn: () => listAuditLogs(filters),
+  });
+
+  const summary = summaryQuery.data;
+  const mostActiveModule = summary?.by_module?.[0] ?? null;
+  const mostActiveUser = summary?.top_users?.[0] ?? null;
+
+  const columns: Array<DataTableColumn<AuditLogItem>> = [
+    {
+      id: "timestamp",
+      header: "Timestamp",
+      accessor: "created_at",
+      sortable: true,
+      widthClassName: "min-w-[180px]",
+      cell: (row) => (
+        <Tooltip content={formatFullDate(row.created_at)} side="left">
+          <span className="text-sm text-text-primary">{formatRelativeTime(row.created_at)}</span>
+        </Tooltip>
+      ),
+    },
+    {
+      id: "user",
+      header: "User",
+      sortable: true,
+      accessor: "user_name",
+      widthClassName: "min-w-[200px]",
+      cell: (row) => (
+        <div className="flex items-center gap-3">
+          <AvatarChip name={row.user_name} avatarUrl={row.user_avatar_url} />
+          <div className="space-y-0.5">
+            <p className="font-medium text-text-primary">{row.user_name}</p>
+            <p className="text-xs text-text-secondary">{row.user_email || "-"}</p>
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: "module",
+      header: "Module",
+      accessor: "module",
+      sortable: true,
+      cell: (row) => <StatusBadge status={row.module} variant="module" />,
+    },
+    {
+      id: "action",
+      header: "Action",
+      accessor: "action",
+      sortable: true,
+      cell: (row) => <StatusBadge status={row.action} variant="audit-action" />,
+    },
+    {
+      id: "resource",
+      header: "Resource",
+      accessor: "resource",
+      sortable: true,
+      cell: (row) => (
+        <div>
+          <p className="font-medium text-text-primary">{humanizeResource(row.resource)}</p>
+          <p className="text-xs text-text-secondary">{row.resource}</p>
+        </div>
+      ),
+    },
+    {
+      id: "resource_id",
+      header: "Resource ID",
+      accessor: "resource_id",
+      sortable: true,
+      widthClassName: "min-w-[170px]",
+      cell: (row) => {
+        const resourceLink = resolveResourceLink(row);
+        if (!resourceLink) {
+          return <code className="font-mono text-[12px] text-text-secondary">{row.resource_id}</code>;
+        }
+
+        return (
+          <a
+            className="font-mono text-[12px] text-module underline-offset-4 hover:underline"
+            href={resourceLink}
+          >
+            {row.resource_id}
+          </a>
+        );
+      },
+    },
+    {
+      id: "ip_address",
+      header: "IP Address",
+      accessor: "ip_address",
+      sortable: true,
+      widthClassName: "min-w-[140px]",
+      cell: (row) => <span className="font-mono text-[12px] text-text-secondary">{row.ip_address || "-"}</span>,
+    },
+  ];
+
+  const downloadExport = async () => {
+    try {
+      const result = await exportAuditLogs(filters);
+      const url = window.URL.createObjectURL(result.blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = result.filename || "audit-logs.csv";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (error) {
+      toast.error(
+        "Gagal export audit log",
+        error instanceof Error ? error.message : undefined,
+      );
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.08em] text-error">Admin</p>
+          <h1 className="mt-2 font-display text-[28px] font-[700] tracking-[-0.02em] text-text-primary">
+            Audit Logs
+          </h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-text-secondary">
+            Telusuri perubahan penting lintas modul, lihat diff JSON, dan export jejak audit untuk investigasi atau compliance review.
+          </p>
+        </div>
+        {canExport ? (
+          <Button onClick={() => void downloadExport()} type="button" variant="outline">
+            <Download className="h-4 w-4" />
+            Export CSV
+          </Button>
+        ) : null}
+      </div>
+
+      {summaryQuery.isLoading ? (
+        <OverviewSkeleton />
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-4">
+          <StatCard
+            icon={ScrollText}
+            label="Total Logs Today"
+            tone="error"
+            value={String(summary?.total_today ?? 0)}
+          />
+          <StatCard
+            icon={CalendarClock}
+            label="Total Logs This Week"
+            tone="info"
+            value={String(summary?.total_week ?? 0)}
+          />
+          <StatCard
+            icon={Shield}
+            label="Most Active Module"
+            tone={moduleTone(mostActiveModule?.key)}
+            value={moduleLabel(mostActiveModule)}
+            helper={mostActiveModule ? `${mostActiveModule.count} log tercatat` : "Belum ada data"}
+          />
+          <StatCard
+            icon={UserRound}
+            label="Most Active User"
+            tone="warning"
+            value={mostActiveUser?.user_name ?? "-"}
+            helper={mostActiveUser ? `${mostActiveUser.count} aksi | ${mostActiveUser.user_email || "tanpa email"}` : "Belum ada data"}
+          />
+        </div>
+      )}
+
+      <Card className="p-6">
+        <div className="grid gap-4 xl:grid-cols-[180px_180px_180px_180px_220px_minmax(0,1fr)]">
+          <select
+            className="field-select"
+            onChange={(event) =>
+              setFilters((current) => ({ ...current, module: event.target.value, page: 1 }))
+            }
+            value={filters.module}
+          >
+            {moduleOptions.map((option) => (
+              <option key={option.value || "all"} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <select
+            className="field-select"
+            onChange={(event) =>
+              setFilters((current) => ({ ...current, action: event.target.value, page: 1 }))
+            }
+            value={filters.action}
+          >
+            {actionOptions.map((option) => (
+              <option key={option.value || "all"} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <Input
+            onChange={(event) =>
+              setFilters((current) => ({ ...current, dateFrom: event.target.value, page: 1 }))
+            }
+            type="date"
+            value={filters.dateFrom}
+          />
+          <Input
+            onChange={(event) =>
+              setFilters((current) => ({ ...current, dateTo: event.target.value, page: 1 }))
+            }
+            type="date"
+            value={filters.dateTo}
+          />
+          <select
+            className="field-select"
+            onChange={(event) =>
+              setFilters((current) => ({ ...current, userId: event.target.value, page: 1 }))
+            }
+            value={filters.userId}
+          >
+            <option value="">Semua User</option>
+            {(usersQuery.data ?? []).map((user) => (
+              <option key={user.user_id} value={user.user_id}>
+                {user.user_name} {user.user_email ? `(${user.user_email})` : ""}
+              </option>
+            ))}
+          </select>
+          <Input
+            onChange={(event) => setSearchInput(event.target.value)}
+            placeholder="Cari action, resource, nilai JSON, atau user"
+            value={searchInput}
+          />
+        </div>
+      </Card>
+
+      {logsQuery.isLoading && !logsQuery.data ? (
+        <OverviewSkeleton />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={logsQuery.data?.items ?? []}
+          emptyDescription="Belum ada audit log yang cocok dengan filter aktif."
+          emptyTitle="Audit log tidak ditemukan"
+          getRowId={(row) => row.id}
+          loading={logsQuery.isFetching && !logsQuery.data}
+          onRowClick={(row) => setExpandedLogId((current) => (current === row.id ? null : row.id))}
+          pagination={
+            logsQuery.data?.meta
+              ? {
+                  page: logsQuery.data.meta.page,
+                  perPage: logsQuery.data.meta.per_page,
+                  total: logsQuery.data.meta.total,
+                  onPageChange: (page) =>
+                    setFilters((current) => ({
+                      ...current,
+                      page,
+                    })),
+                }
+              : undefined
+          }
+          renderExpandedRow={(row) => (
+            <div className="space-y-4">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                <div>
+                  <p className="text-sm font-semibold text-text-primary">
+                    Detail perubahan untuk {humanizeResource(row.resource)}
+                  </p>
+                  <p className="text-xs text-text-secondary">
+                    {row.user_name} | {formatFullDate(row.created_at)} | {row.module}/{row.action}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <StatusBadge status={row.module} variant="module" />
+                  <StatusBadge status={row.action} variant="audit-action" />
+                </div>
+              </div>
+              <JsonDiffViewer oldValue={row.old_value ?? null} newValue={row.new_value ?? null} />
+            </div>
+          )}
+          selectedRowId={expandedLogId}
+        />
+      )}
+    </div>
+  );
+}
+
+function AvatarChip({
+  name,
+  avatarUrl,
+}: {
+  name: string;
+  avatarUrl?: string | null;
+}) {
+  if (avatarUrl) {
+    return (
+      <img
+        alt={name}
+        className="h-6 w-6 rounded-full border border-border object-cover"
+        src={avatarUrl}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-6 w-6 items-center justify-center rounded-full bg-surface-muted text-[11px] font-semibold text-text-primary">
+      {name.slice(0, 1).toUpperCase()}
+    </div>
+  );
+}
+
+function humanizeResource(resource: string) {
+  return resource
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function resolveResourceLink(item: AuditLogItem) {
+  if (item.module === "operational" && item.resource === "project") {
+    return `/operational/projects/${item.resource_id}`;
+  }
+  if (item.module === "hris" && item.resource === "employee") {
+    return `/hris/employees/${item.resource_id}`;
+  }
+  if (item.module === "hris" && item.resource === "reimbursement") {
+    return `/hris/reimbursements/${item.resource_id}`;
+  }
+
+  return null;
+}
+
+function formatFullDate(value: string) {
+  return new Date(value).toLocaleString("id-ID", {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  });
+}
+
+function formatRelativeTime(value: string) {
+  const target = new Date(value).getTime();
+  const now = Date.now();
+  const diffSeconds = Math.round((target - now) / 1000);
+  const formatter = new Intl.RelativeTimeFormat("id-ID", { numeric: "auto" });
+
+  const ranges: Array<[Intl.RelativeTimeFormatUnit, number]> = [
+    ["day", 60 * 60 * 24],
+    ["hour", 60 * 60],
+    ["minute", 60],
+    ["second", 1],
+  ];
+
+  for (const [unit, seconds] of ranges) {
+    if (Math.abs(diffSeconds) >= seconds || unit === "second") {
+      return formatter.format(Math.round(diffSeconds / seconds), unit);
+    }
+  }
+
+  return formatFullDate(value);
+}
+
+function moduleTone(moduleID?: string) {
+  switch (moduleID) {
+    case "operational":
+      return "ops" as const;
+    case "hris":
+      return "hr" as const;
+    case "marketing":
+      return "mkt" as const;
+    case "admin":
+      return "error" as const;
+    default:
+      return "info" as const;
+  }
+}
+
+function moduleLabel(bucket: AuditLogSummaryBucket | null) {
+  if (!bucket) {
+    return "-";
+  }
+
+  return bucket.key === "operational"
+    ? "Operasional"
+    : bucket.key === "hris"
+      ? "HRIS"
+      : bucket.key === "marketing"
+        ? "Marketing"
+        : bucket.key === "admin"
+          ? "Admin"
+          : bucket.key;
+}

--- a/frontend/src/services/admin-audit.ts
+++ b/frontend/src/services/admin-audit.ts
@@ -1,0 +1,103 @@
+import { authDownload, authGetJSON, authRequestEnvelope } from "@/lib/api-client";
+import type {
+  AuditLogFilters,
+  AuditLogListResponse,
+  AuditLogSummary,
+  AuditLogUserOption,
+} from "@/types/audit-log";
+import type { PaginationMeta } from "@/types/hris";
+
+export const adminAuditKeys = {
+  all: ["admin-audit"] as const,
+  logs: () => [...adminAuditKeys.all, "logs"] as const,
+  logList: (filters: AuditLogFilters) =>
+    [...adminAuditKeys.logs(), "list", { ...filters }] as const,
+  summary: () => [...adminAuditKeys.all, "summary"] as const,
+  users: (search = "") => [...adminAuditKeys.all, "users", search] as const,
+};
+
+export async function listAuditLogs(filters: AuditLogFilters): Promise<AuditLogListResponse> {
+  const params = new URLSearchParams();
+  params.set("page", String(filters.page));
+  params.set("per_page", String(filters.perPage));
+
+  if (filters.module) {
+    params.set("module", filters.module);
+  }
+  if (filters.action) {
+    params.set("action", filters.action);
+  }
+  if (filters.userId) {
+    params.set("user_id", filters.userId);
+  }
+  if (filters.resource) {
+    params.set("resource", filters.resource);
+  }
+  if (filters.resourceId) {
+    params.set("resource_id", filters.resourceId);
+  }
+  if (filters.dateFrom) {
+    params.set("date_from", filters.dateFrom);
+  }
+  if (filters.dateTo) {
+    params.set("date_to", filters.dateTo);
+  }
+  if (filters.search.trim()) {
+    params.set("search", filters.search.trim());
+  }
+
+  const response = await authRequestEnvelope<AuditLogListResponse["items"]>(
+    `/admin/audit-logs?${params.toString()}`,
+    { method: "GET" },
+  );
+
+  return {
+    items: response.data ?? [],
+    meta:
+      (response.meta as PaginationMeta | undefined) ?? {
+        page: filters.page,
+        per_page: filters.perPage,
+        total: 0,
+      },
+  };
+}
+
+export function getAuditLogSummary() {
+  return authGetJSON<AuditLogSummary>("/admin/audit-logs/summary");
+}
+
+export function listAuditLogUsers(search = "") {
+  const suffix = search.trim() ? `?search=${encodeURIComponent(search.trim())}` : "";
+  return authGetJSON<AuditLogUserOption[]>(`/admin/audit-logs/users${suffix}`);
+}
+
+export function exportAuditLogs(filters: AuditLogFilters) {
+  const params = new URLSearchParams();
+
+  if (filters.module) {
+    params.set("module", filters.module);
+  }
+  if (filters.action) {
+    params.set("action", filters.action);
+  }
+  if (filters.userId) {
+    params.set("user_id", filters.userId);
+  }
+  if (filters.resource) {
+    params.set("resource", filters.resource);
+  }
+  if (filters.resourceId) {
+    params.set("resource_id", filters.resourceId);
+  }
+  if (filters.dateFrom) {
+    params.set("date_from", filters.dateFrom);
+  }
+  if (filters.dateTo) {
+    params.set("date_to", filters.dateTo);
+  }
+  if (filters.search.trim()) {
+    params.set("search", filters.search.trim());
+  }
+
+  return authDownload(`/admin/audit-logs/export?${params.toString()}`);
+}

--- a/frontend/src/types/audit-log.ts
+++ b/frontend/src/types/audit-log.ts
@@ -1,0 +1,62 @@
+import type { PaginationMeta } from "@/types/hris";
+
+export interface AuditLogItem {
+  id: string;
+  user_id?: string | null;
+  user_name: string;
+  user_email: string;
+  user_avatar_url?: string | null;
+  action: string;
+  module: "operational" | "hris" | "marketing" | "admin" | string;
+  resource: string;
+  resource_id: string;
+  old_value?: unknown | null;
+  new_value?: unknown | null;
+  ip_address?: string;
+  created_at: string;
+}
+
+export interface AuditLogFilters {
+  module: string;
+  action: string;
+  userId: string;
+  resource: string;
+  resourceId: string;
+  dateFrom: string;
+  dateTo: string;
+  search: string;
+  page: number;
+  perPage: number;
+}
+
+export interface AuditLogListResponse {
+  items: AuditLogItem[];
+  meta: PaginationMeta;
+}
+
+export interface AuditLogSummaryBucket {
+  key: string;
+  count: number;
+}
+
+export interface AuditLogTopUser {
+  user_id?: string | null;
+  user_name: string;
+  user_email: string;
+  count: number;
+}
+
+export interface AuditLogSummary {
+  total_today: number;
+  total_week: number;
+  by_module: AuditLogSummaryBucket[];
+  by_action: AuditLogSummaryBucket[];
+  top_users: AuditLogTopUser[];
+}
+
+export interface AuditLogUserOption {
+  user_id: string;
+  user_name: string;
+  user_email: string;
+  user_avatar_url?: string | null;
+}


### PR DESCRIPTION
## Summary

- add admin audit log list, summary, actor lookup, and CSV export endpoints protected by the new RBAC permissions
- extend audit logging coverage for auth, admin RBAC changes, salary views, and WA broadcast actions
- add an admin audit log viewer page with summary cards, filters, expandable JSON diff rows, and export controls

## Why This Change

The platform already stored audit logs, but there was no usable viewer for privileged users and no export flow for investigation or compliance work. This meant operational visibility depended on direct database access and several important actions still were not being recorded consistently.

## Root Cause

The existing code had an audit repository and middleware helper, but it stopped short of exposing filtered admin endpoints and a dedicated frontend page. Several high-value actions also never wrote to audit_logs, which made the dataset incomplete once the viewer was introduced.

## What Changed

- added `/api/v1/admin/audit-logs`, `/summary`, `/users`, and `/export` with RBAC checks for `admin:audit_log:view` and `admin:audit_log:export`
- added filtering, pagination, actor joins, summary aggregation, and CSV export in the audit repository/service layer
- added missing audit entries for register/login/logout, role changes, user access changes, system settings updates, salary view access, and WA broadcast management actions
- added `/admin/audit-logs` in the admin frontend with shared DataTable integration, module/action badges, and a JSON diff viewer for old/new values

## Validation

- `go build ./cmd/server`
- `npm.cmd run build`
- `docker compose up --build -d backend frontend db`
- smoke tested audit log list, summary, users, export as super admin
- verified a viewer without `admin:audit_log:view` receives HTTP 403 on the audit log endpoint
