### PR TITLE
[codex] fix hris overview payroll type

### DIFF
--- a/frontend/src/types/overview.ts
+++ b/frontend/src/types/overview.ts
@@ -62,6 +62,7 @@ export interface HrisRecentReimbursement {
 
 export interface HrisOverview {
   total_employees: number;
+  total_monthly_payroll: number;
   active_subscriptions: number;
   active_subscription_monthly_cost: number;
   monthly_net: number;


### PR DESCRIPTION
## Summary
This PR fixes issue #76 by updating the frontend HRIS overview type to include `total_monthly_payroll`.

The backend model and the HRIS overview page were already using this field, but the TypeScript interface in `frontend/src/types/overview.ts` did not declare it. That mismatch meant the frontend type definition was out of sync with the actual API contract.

## Root Cause
The backend `HrisOverview` response had evolved to include `total_monthly_payroll`, while the frontend overview type was not updated alongside it. The UI page already referenced `overview.total_monthly_payroll`, so the issue was not missing UI wiring; it was a stale frontend contract.

## Fix
- Add `total_monthly_payroll: number` to the frontend `HrisOverview` interface.
- Keep the scope intentionally narrow because the page already renders the value correctly once the type matches the API.

## Validation
- `cd frontend && npm run build`

Closes #76.
