### PR TITLE
[codex] fix kanban column status type

### DIFF
--- a/backend/internal/model/kanban.go
+++ b/backend/internal/model/kanban.go
@@ -2,13 +2,21 @@ package model
 
 import "time"
 
+const (
+	KanbanColumnTypeTodo       = "todo"
+	KanbanColumnTypeInProgress = "in_progress"
+	KanbanColumnTypeDone       = "done"
+	KanbanColumnTypeCustom     = "custom"
+)
+
 type KanbanColumn struct {
-	ID        string    `json:"id"`
-	ProjectID string    `json:"project_id"`
-	Name      string    `json:"name"`
-	Position  int       `json:"position"`
-	Color     *string   `json:"color,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	ID         string    `json:"id"`
+	ProjectID  string    `json:"project_id"`
+	Name       string    `json:"name"`
+	ColumnType string    `json:"column_type"`
+	Position   int       `json:"position"`
+	Color      *string   `json:"color,omitempty"`
+	CreatedAt  time.Time `json:"created_at"`
 }
 
 type KanbanTask struct {

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -61,6 +61,12 @@ type KanbanSnapshot struct {
 	Tasks   []model.KanbanTask   `json:"tasks"`
 }
 
+type kanbanColumnSeed struct {
+	Name       string
+	Color      string
+	ColumnType string
+}
+
 func NewKanbanRepository(db repository.DBTX) *KanbanRepository {
 	return &KanbanRepository{db: db}
 }
@@ -68,16 +74,7 @@ func NewKanbanRepository(db repository.DBTX) *KanbanRepository {
 func (r *KanbanRepository) CreateDefaultColumns(ctx context.Context, projectID string) error {
 	ctx, cancel := repository.QueryContext(ctx)
 	defer cancel()
-	defaults := []struct {
-		Name  string
-		Color string
-	}{
-		{Name: "Backlog", Color: "#94A3B8"},
-		{Name: "To Do", Color: "#38BDF8"},
-		{Name: "In Progress", Color: "#F59E0B"},
-		{Name: "Review", Color: "#8B5CF6"},
-		{Name: "Done", Color: "#22C55E"},
-	}
+	defaults := defaultKanbanColumns()
 
 	db := repository.DB(ctx, r.db)
 	if tx, ok := db.(pgx.Tx); ok {
@@ -105,7 +102,7 @@ func (r *KanbanRepository) ListColumns(ctx context.Context, projectID string) ([
 	ctx, cancel := repository.QueryContext(ctx)
 	defer cancel()
 	rows, err := repository.DB(ctx, r.db).Query(ctx, `
-		SELECT id::text, project_id::text, name, position, color, created_at
+		SELECT id::text, project_id::text, name, column_type, position, color, created_at
 		FROM kanban_columns
 		WHERE project_id = $1::uuid
 		ORDER BY position ASC, created_at ASC
@@ -122,6 +119,7 @@ func (r *KanbanRepository) ListColumns(ctx context.Context, projectID string) ([
 			&column.ID,
 			&column.ProjectID,
 			&column.Name,
+			&column.ColumnType,
 			&column.Position,
 			&column.Color,
 			&column.CreatedAt,
@@ -165,18 +163,20 @@ func (r *KanbanRepository) CreateColumn(ctx context.Context, projectID string, p
 	err = tx.QueryRow(
 		ctx,
 		`
-			INSERT INTO kanban_columns (project_id, name, position, color)
-			VALUES ($1::uuid, $2, $3, NULLIF($4, ''))
-			RETURNING id::text, project_id::text, name, position, color, created_at
+			INSERT INTO kanban_columns (project_id, name, column_type, position, color)
+			VALUES ($1::uuid, $2, $3, $4, NULLIF($5, ''))
+			RETURNING id::text, project_id::text, name, column_type, position, color, created_at
 		`,
 		projectID,
 		params.Name,
+		model.KanbanColumnTypeCustom,
 		position,
 		nullableText(params.Color),
 	).Scan(
 		&column.ID,
 		&column.ProjectID,
 		&column.Name,
+		&column.ColumnType,
 		&column.Position,
 		&column.Color,
 		&column.CreatedAt,
@@ -202,7 +202,7 @@ func (r *KanbanRepository) UpdateColumn(ctx context.Context, projectID string, c
 			UPDATE kanban_columns
 			SET name = $3, color = NULLIF($4, '')
 			WHERE project_id = $1::uuid AND id = $2::uuid
-			RETURNING id::text, project_id::text, name, position, color, created_at
+			RETURNING id::text, project_id::text, name, column_type, position, color, created_at
 		`,
 		projectID,
 		columnID,
@@ -212,6 +212,7 @@ func (r *KanbanRepository) UpdateColumn(ctx context.Context, projectID string, c
 		&column.ID,
 		&column.ProjectID,
 		&column.Name,
+		&column.ColumnType,
 		&column.Position,
 		&column.Color,
 		&column.CreatedAt,
@@ -808,16 +809,14 @@ func (r *KanbanRepository) resolveColumnInsertPosition(ctx context.Context, tx p
 	return *requested, nil
 }
 
-func (r *KanbanRepository) insertDefaultColumns(ctx context.Context, tx pgx.Tx, projectID string, defaults []struct {
-	Name  string
-	Color string
-}) error {
+func (r *KanbanRepository) insertDefaultColumns(ctx context.Context, tx pgx.Tx, projectID string, defaults []kanbanColumnSeed) error {
 	for index, column := range defaults {
 		if _, err := tx.Exec(
 			ctx,
-			`INSERT INTO kanban_columns (project_id, name, position, color) VALUES ($1::uuid, $2, $3, $4)`,
+			`INSERT INTO kanban_columns (project_id, name, column_type, position, color) VALUES ($1::uuid, $2, $3, $4, $5)`,
 			projectID,
 			column.Name,
+			column.ColumnType,
 			index+1,
 			column.Color,
 		); err != nil {
@@ -826,6 +825,16 @@ func (r *KanbanRepository) insertDefaultColumns(ctx context.Context, tx pgx.Tx, 
 	}
 
 	return nil
+}
+
+func defaultKanbanColumns() []kanbanColumnSeed {
+	return []kanbanColumnSeed{
+		{Name: "Backlog", Color: "#94A3B8", ColumnType: model.KanbanColumnTypeTodo},
+		{Name: "To Do", Color: "#38BDF8", ColumnType: model.KanbanColumnTypeTodo},
+		{Name: "In Progress", Color: "#F59E0B", ColumnType: model.KanbanColumnTypeInProgress},
+		{Name: "Review", Color: "#8B5CF6", ColumnType: model.KanbanColumnTypeCustom},
+		{Name: "Done", Color: "#22C55E", ColumnType: model.KanbanColumnTypeDone},
+	}
 }
 
 func (r *KanbanRepository) ensureColumnBelongsToProject(ctx context.Context, tx queryRowExecutor, projectID string, columnID string) error {

--- a/backend/internal/repository/operational/kanban_test.go
+++ b/backend/internal/repository/operational/kanban_test.go
@@ -1,0 +1,25 @@
+package operational
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/kana-consultant/kantor/backend/internal/model"
+)
+
+func TestDefaultKanbanColumns(t *testing.T) {
+	t.Parallel()
+
+	got := defaultKanbanColumns()
+	want := []kanbanColumnSeed{
+		{Name: "Backlog", Color: "#94A3B8", ColumnType: model.KanbanColumnTypeTodo},
+		{Name: "To Do", Color: "#38BDF8", ColumnType: model.KanbanColumnTypeTodo},
+		{Name: "In Progress", Color: "#F59E0B", ColumnType: model.KanbanColumnTypeInProgress},
+		{Name: "Review", Color: "#8B5CF6", ColumnType: model.KanbanColumnTypeCustom},
+		{Name: "Done", Color: "#22C55E", ColumnType: model.KanbanColumnTypeDone},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("defaultKanbanColumns() = %#v, want %#v", got, want)
+	}
+}

--- a/backend/internal/repository/operational/overview.go
+++ b/backend/internal/repository/operational/overview.go
@@ -29,7 +29,7 @@ func (r *OverviewRepository) GetOverview(ctx context.Context, now time.Time) (mo
 		SELECT COUNT(*)
 		FROM kanban_tasks
 		INNER JOIN kanban_columns ON kanban_columns.id = kanban_tasks.column_id
-		WHERE LOWER(REPLACE(kanban_columns.name, ' ', '_')) = 'in_progress'
+		WHERE kanban_columns.column_type = 'in_progress'
 	`).Scan(&overview.ActiveTasks); err != nil {
 		return model.OperationalOverview{}, err
 	}
@@ -40,7 +40,7 @@ func (r *OverviewRepository) GetOverview(ctx context.Context, now time.Time) (mo
 		INNER JOIN kanban_columns ON kanban_columns.id = kanban_tasks.column_id
 		WHERE kanban_tasks.due_date IS NOT NULL
 		  AND kanban_tasks.due_date < $1
-		  AND LOWER(REPLACE(kanban_columns.name, ' ', '_')) <> 'done'
+		  AND kanban_columns.column_type <> 'done'
 	`, now).Scan(&overview.OverdueTasks); err != nil {
 		return model.OperationalOverview{}, err
 	}
@@ -72,7 +72,7 @@ func (r *OverviewRepository) listCompletedByWeek(ctx context.Context, now time.T
 		SELECT DATE_TRUNC('week', kanban_tasks.updated_at)::date AS week_start, COUNT(*)::bigint
 		FROM kanban_tasks
 		INNER JOIN kanban_columns ON kanban_columns.id = kanban_tasks.column_id
-		WHERE LOWER(REPLACE(kanban_columns.name, ' ', '_')) = 'done'
+		WHERE kanban_columns.column_type = 'done'
 		  AND kanban_tasks.updated_at >= $1
 		GROUP BY week_start
 		ORDER BY week_start ASC

--- a/backend/migrations/20260413093000_operational_kanban_column_type.down.sql
+++ b/backend/migrations/20260413093000_operational_kanban_column_type.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_kanban_columns_project_type;
+
+ALTER TABLE kanban_columns
+DROP CONSTRAINT IF EXISTS chk_kanban_columns_column_type;
+
+ALTER TABLE kanban_columns
+DROP COLUMN IF EXISTS column_type;

--- a/backend/migrations/20260413093000_operational_kanban_column_type.up.sql
+++ b/backend/migrations/20260413093000_operational_kanban_column_type.up.sql
@@ -1,0 +1,28 @@
+ALTER TABLE kanban_columns
+ADD COLUMN column_type TEXT;
+
+UPDATE kanban_columns
+SET column_type = CASE
+    WHEN LOWER(REPLACE(name, ' ', '_')) IN ('backlog', 'todo', 'to_do') THEN 'todo'
+    WHEN LOWER(REPLACE(name, ' ', '_')) IN ('in_progress', 'inprogress', 'working', 'doing') THEN 'in_progress'
+    WHEN LOWER(REPLACE(name, ' ', '_')) IN ('done', 'completed', 'complete', 'closed') THEN 'done'
+    ELSE 'custom'
+END
+WHERE column_type IS NULL;
+
+ALTER TABLE kanban_columns
+ALTER COLUMN column_type SET DEFAULT 'custom';
+
+UPDATE kanban_columns
+SET column_type = 'custom'
+WHERE column_type IS NULL;
+
+ALTER TABLE kanban_columns
+ALTER COLUMN column_type SET NOT NULL;
+
+ALTER TABLE kanban_columns
+ADD CONSTRAINT chk_kanban_columns_column_type
+CHECK (column_type IN ('todo', 'in_progress', 'done', 'custom'));
+
+CREATE INDEX idx_kanban_columns_project_type
+ON kanban_columns (project_id, column_type);

--- a/frontend/src/types/kanban.ts
+++ b/frontend/src/types/kanban.ts
@@ -4,6 +4,7 @@ export interface KanbanColumn {
   id: string;
   project_id: string;
   name: string;
+  column_type: "todo" | "in_progress" | "done" | "custom";
   position: number;
   color?: string | null;
   created_at: string;


### PR DESCRIPTION
## Summary
This PR fixes issue #74 by stopping operational overview metrics from deriving task status from kanban column display names.

Previously, the overview repository treated a task as active or done by string-matching `kanban_columns.name` values such as `In Progress` and `Done`. That meant a tenant could rename a column for UX reasons and silently break dashboard counts.

## Root Cause
The overview aggregation logic used `LOWER(REPLACE(kanban_columns.name, ' ', '_'))` in SQL to infer status semantics from presentation labels. Column names are user-editable, so the aggregation depended on mutable display text instead of stable workflow metadata.

## Fix
- Add `column_type` to `kanban_columns` with allowed values `todo`, `in_progress`, `done`, and `custom`.
- Backfill existing rows in a migration and add a database CHECK constraint.
- Seed default project columns with stable `column_type` values.
- Make manually created columns default to `custom`.
- Update operational overview queries to aggregate by `column_type` instead of column names.
- Expose `column_type` in the kanban column model/type so the API contract stays explicit.
- Add a regression test for the default column mapping.

## Validation
- `cd backend && go test ./internal/repository/operational`
- `cd backend && go build ./cmd/server`
- `cd frontend && npm run build`

Closes #74.
