### PR TITLE
feat(observability): mount HTTP access logging middleware

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -315,6 +315,7 @@ func (a *App) buildRouter(
 
 	router.Use(chimiddleware.RequestID)
 	router.Use(chimiddleware.RealIP)
+	router.Use(platformmiddleware.AccessLogger)
 	router.Use(chimiddleware.Recoverer)
 	router.Use(platformmiddleware.AuditMiddleware(auditService))
 	router.Use(platformmiddleware.MaxBodySize(1 << 20)) // 1 MB default for JSON endpoints

--- a/backend/internal/middleware/logging.go
+++ b/backend/internal/middleware/logging.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"time"
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 )
@@ -18,6 +19,80 @@ func LoggingMiddleware(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), requestIDKey{}, reqID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// accessLogSkipPaths lists endpoints that are excluded from access logging
+// to keep the log volume manageable. Health probes are hit every few seconds
+// by container orchestrators and would otherwise dominate the log output.
+var accessLogSkipPaths = map[string]struct{}{
+	"/healthz":       {},
+	"/readyz":        {},
+	"/api/v1/health": {},
+}
+
+// AccessLogger emits a structured log line for every HTTP request after the
+// response is written. It captures method, path, status, latency, bytes,
+// remote IP, request_id, and (when authenticated) user_id and tenant_id.
+//
+// Mount this OUTSIDE Recoverer (i.e. before Recoverer in the .Use chain) so
+// that panics surfaced as 500s by Recoverer are still recorded.
+func AccessLogger(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, skip := accessLogSkipPaths[r.URL.Path]; skip {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+		start := time.Now()
+
+		defer func() {
+			status := ww.Status()
+			if status == 0 {
+				status = http.StatusOK
+			}
+			latency := time.Since(start)
+
+			attrs := []any{
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+				slog.Int("status", status),
+				slog.Int("bytes", ww.BytesWritten()),
+				slog.Int64("latency_ms", latency.Milliseconds()),
+				slog.String("remote_ip", r.RemoteAddr),
+			}
+			if reqID := chimiddleware.GetReqID(r.Context()); reqID != "" {
+				attrs = append(attrs, slog.String("request_id", reqID))
+			}
+			if principal, ok := PrincipalFromContext(r.Context()); ok {
+				attrs = append(attrs, slog.String("user_id", principal.UserID))
+				if principal.TenantID != "" {
+					attrs = append(attrs, slog.String("tenant_id", principal.TenantID))
+				}
+			}
+
+			level := slog.LevelInfo
+			switch {
+			case status >= 500:
+				level = slog.LevelError
+			case status >= 400:
+				level = slog.LevelWarn
+			}
+			slog.Default().LogAttrs(r.Context(), level, "http_request", toSlogAttrs(attrs)...)
+		}()
+
+		next.ServeHTTP(ww, r)
+	})
+}
+
+func toSlogAttrs(values []any) []slog.Attr {
+	out := make([]slog.Attr, 0, len(values))
+	for _, v := range values {
+		if attr, ok := v.(slog.Attr); ok {
+			out = append(out, attr)
+		}
+	}
+	return out
 }
 
 // LoggerFromContext returns a logger enriched with the request_id


### PR DESCRIPTION
## Summary

Closes #68.

Adds a structured `AccessLogger` middleware that emits one log line per HTTP request after the response is written. Each line includes:

- `method`, `path`, `status`, `bytes`, `latency_ms`
- `remote_ip`, `request_id`
- `user_id`, `tenant_id` (when the principal has been resolved by `AuthMiddleware`)

## Why

Per the audit report, `chi`'s `Logger` middleware was never mounted, so we had no visibility into request traffic — no method/path/status/latency was recorded anywhere. That blocks debugging, incident response, and basic performance analysis.

We did not simply mount `chimiddleware.Logger` because:

1. It hard-codes its output format and does not include `user_id`/`tenant_id` from our `Principal` context.
2. It logs at a single level — we want 5xx → Error, 4xx → Warn, 2xx/3xx → Info so log-based alerts are trivial to wire up later.

## Implementation

- New `AccessLogger` in `backend/internal/middleware/logging.go` wraps the `ResponseWriter` (via `chimiddleware.NewWrapResponseWriter`) to capture status and bytes.
- Mounted in `app.buildRouter` between `RealIP` and `Recoverer`, so panics caught by `Recoverer` (and turned into 500s) are still observed by the logger.
- Health probes (`/healthz`, `/readyz`, `/api/v1/health`) are skipped via an allowlist to avoid drowning the log with container probe traffic.
- Log level is derived from response status (5xx Error / 4xx Warn / else Info).

## Test plan

- [ ] `go build ./...` and `go vet ./...` — pass locally
- [ ] Manual: hit `GET /api/v1/auth/me` while authenticated; observe `http_request` log with `user_id` + `tenant_id`
- [ ] Manual: hit `GET /healthz` repeatedly; confirm no log spam
- [ ] Manual: trigger a 4xx (e.g. missing Authorization header) and a forced 5xx; confirm correct log levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)