### PR TITLE
security(auth): raise bcrypt cost to 12 and rehash on login

### DIFF
--- a/backend/internal/auth/password.go
+++ b/backend/internal/auth/password.go
@@ -2,8 +2,14 @@ package auth
 
 import "golang.org/x/crypto/bcrypt"
 
+// PasswordHashCost is the bcrypt cost factor used when hashing new passwords.
+// OWASP currently recommends a cost of 12 or higher for bcrypt; the library
+// default is only 10. Existing hashes at lower costs continue to verify, and
+// callers may use NeedsRehash to opportunistically upgrade them on next login.
+const PasswordHashCost = 12
+
 func HashPassword(password string) (string, error) {
-	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	bytes, err := bcrypt.GenerateFromPassword([]byte(password), PasswordHashCost)
 	if err != nil {
 		return "", err
 	}
@@ -13,4 +19,16 @@ func HashPassword(password string) (string, error) {
 
 func ComparePassword(hash string, password string) error {
 	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+}
+
+// NeedsRehash reports whether an existing bcrypt hash was produced with a cost
+// lower than the current PasswordHashCost. Callers that have just verified a
+// password successfully can use this signal to re-hash and persist the new
+// digest, transparently upgrading legacy hashes over time.
+func NeedsRehash(hash string) bool {
+	cost, err := bcrypt.Cost([]byte(hash))
+	if err != nil {
+		return false
+	}
+	return cost < PasswordHashCost
 }

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -61,6 +61,7 @@ type authRepository interface {
 	IncrementFailedLoginAttempts(ctx context.Context, userID string, maxAttempts int, lockDuration time.Duration) error
 	ResetFailedLoginAttempts(ctx context.Context, userID string) error
 	ChangePasswordAndRevokeTokens(ctx context.Context, userID string, passwordHash string) error
+	UpdatePasswordHash(ctx context.Context, userID string, passwordHash string) error
 	ListUsers(ctx context.Context, params authrepo.ListUsersParams) ([]authrepo.UserWithRoles, int64, error)
 	ReplaceUserRoles(ctx context.Context, userID string, roles []rbac.RoleKey) error
 	SetUserActive(ctx context.Context, userID string, active bool) error
@@ -242,6 +243,14 @@ func (s *Service) Login(ctx context.Context, input dto.LoginRequest, userAgent s
 
 	if user.FailedLoginAttempts > 0 {
 		_ = s.repo.ResetFailedLoginAttempts(ctx, user.ID)
+	}
+
+	if backendauth.NeedsRehash(user.PasswordHash) {
+		if newHash, err := backendauth.HashPassword(input.Password); err == nil {
+			if err := s.repo.UpdatePasswordHash(ctx, user.ID, newHash); err != nil {
+				slog.Error("failed to upgrade password hash", "error", err, "user_id", user.ID)
+			}
+		}
 	}
 
 	return s.issueAuthResult(ctx, user, "", userAgent, ipAddress)


### PR DESCRIPTION
## Summary

Closes #62.

- Raise `HashPassword` cost from `bcrypt.DefaultCost` (10) to a new `PasswordHashCost = 12` constant, matching OWASP's current recommendation for bcrypt.
- Add `NeedsRehash(hash)` so callers can detect hashes produced at a lower cost.
- On a successful `Login`, opportunistically re-hash the plaintext and persist the new digest. Existing users are upgraded transparently on next sign-in; failures are logged but never block authentication.

## Why

Existing hashes at cost 10 still verify (bcrypt encodes the cost in the digest), so we don't have to force a password reset for everyone. Argon2id would be a stronger choice long term, but it's a much larger lift and out of scope here — this PR closes the immediate gap.

## Notes

- The auth service's repository interface gained `UpdatePasswordHash`. The method already exists on the concrete `Repository`, so this is purely an interface widening.
- No DB migration is needed.

## Test plan

- [ ] `go build ./...` passes
- [ ] Manually log in as an existing user (cost-10 hash); confirm the row's `password_hash` is rewritten with a `\$2a\$12\$...` prefix and the next login still works
- [ ] Wrong password still fails with `ErrInvalidCredentials` and no rehash is attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)