### PR TITLE
fix(db): add CHECK constraints for WA broadcast enum columns

### DIFF
--- a/backend/migrations/20260420020000_wa_enum_checks.down.sql
+++ b/backend/migrations/20260420020000_wa_enum_checks.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE wa_broadcast_logs DROP CONSTRAINT IF EXISTS wa_broadcast_logs_trigger_type_check;
+ALTER TABLE wa_broadcast_logs DROP CONSTRAINT IF EXISTS wa_broadcast_logs_status_check;
+ALTER TABLE wa_broadcast_schedules DROP CONSTRAINT IF EXISTS wa_broadcast_schedules_target_type_check;
+ALTER TABLE wa_broadcast_schedules DROP CONSTRAINT IF EXISTS wa_broadcast_schedules_schedule_type_check;
+ALTER TABLE wa_message_templates DROP CONSTRAINT IF EXISTS wa_message_templates_trigger_type_check;
+ALTER TABLE wa_message_templates DROP CONSTRAINT IF EXISTS wa_message_templates_category_check;

--- a/backend/migrations/20260420020000_wa_enum_checks.up.sql
+++ b/backend/migrations/20260420020000_wa_enum_checks.up.sql
@@ -1,0 +1,31 @@
+-- Tighten enum-like VARCHAR columns on the WA broadcast tables with DB-level
+-- CHECK constraints. Until now the allowed values were enforced only by Go DTO
+-- validation; direct INSERTs or future code paths could bypass it.
+--
+-- The allowed values mirror the Go `oneof` tags in
+-- backend/internal/dto/whatsapp/dto.go and the statuses actually written by
+-- backend/internal/service/whatsapp/*.
+
+ALTER TABLE wa_message_templates
+    ADD CONSTRAINT wa_message_templates_category_check
+        CHECK (category IN ('operational', 'hris', 'marketing', 'general'));
+
+ALTER TABLE wa_message_templates
+    ADD CONSTRAINT wa_message_templates_trigger_type_check
+        CHECK (trigger_type IN ('auto_scheduled', 'event_triggered', 'manual'));
+
+ALTER TABLE wa_broadcast_schedules
+    ADD CONSTRAINT wa_broadcast_schedules_schedule_type_check
+        CHECK (schedule_type IN ('daily', 'weekly', 'monthly', 'once'));
+
+ALTER TABLE wa_broadcast_schedules
+    ADD CONSTRAINT wa_broadcast_schedules_target_type_check
+        CHECK (target_type IN ('all_employees', 'department', 'specific_users', 'project_members'));
+
+ALTER TABLE wa_broadcast_logs
+    ADD CONSTRAINT wa_broadcast_logs_status_check
+        CHECK (status IN ('queued', 'sent', 'failed', 'skipped_disabled', 'skipped_no_phone'));
+
+ALTER TABLE wa_broadcast_logs
+    ADD CONSTRAINT wa_broadcast_logs_trigger_type_check
+        CHECK (trigger_type IN ('auto_scheduled', 'event_triggered', 'manual', 'manual_quick_send'));


### PR DESCRIPTION
## Summary

Closes #66.

Adds DB-level CHECK constraints to the enum-like VARCHAR columns on the WhatsApp broadcast tables so invalid values can't be inserted even if a future caller bypasses the Go DTO layer.

New constraints (migration \`20260420020000_wa_enum_checks\`):

| Table | Column | Allowed values |
|---|---|---|
| \`wa_message_templates\` | \`category\` | \`operational\`, \`hris\`, \`marketing\`, \`general\` |
| \`wa_message_templates\` | \`trigger_type\` | \`auto_scheduled\`, \`event_triggered\`, \`manual\` |
| \`wa_broadcast_schedules\` | \`schedule_type\` | \`daily\`, \`weekly\`, \`monthly\`, \`once\` |
| \`wa_broadcast_schedules\` | \`target_type\` | \`all_employees\`, \`department\`, \`specific_users\`, \`project_members\` |
| \`wa_broadcast_logs\` | \`status\` | \`queued\`, \`sent\`, \`failed\`, \`skipped_disabled\`, \`skipped_no_phone\` |
| \`wa_broadcast_logs\` | \`trigger_type\` | \`auto_scheduled\`, \`event_triggered\`, \`manual\`, \`manual_quick_send\` |

## Why these exact values

- Template/schedule lists mirror the \`oneof\` tags in \`backend/internal/dto/whatsapp/dto.go\`.
- Log statuses and trigger types are the exact literals written by \`backend/internal/service/whatsapp/{service,scheduler}.go\`, including the skip reasons (\`skipped_disabled\`, \`skipped_no_phone\`) and the \`manual_quick_send\` trigger used by the quick-send endpoint.

## Risk / compatibility

The migration is additive only. Existing rows written by the current code all fall inside the allowlists above, so the \`ALTER TABLE ... ADD CONSTRAINT\` will validate cleanly. A \`.down.sql\` is included to drop the constraints in reverse order.

## Test plan

- [ ] \`docker compose up --build -d\` applies the migration without errors
- [ ] Manual: try inserting a row with an invalid \`status\` via \`psql\`; confirm the INSERT is rejected
- [ ] Smoke: create a template / schedule via the UI and trigger a quick-send; log row persists as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)