### PR TITLE
feat(config): add typed WAHA defaults and apply on tenant seeding

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -88,7 +88,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 
 	// Seed all tenants from env (TENANTS=name|slug|domains;...).
 	// Runs as superuser — no RLS needed for global tables.
-	if err := seedTenants(ctx, pool, cfg.Tenants); err != nil {
+	if err := seedTenants(ctx, pool, cfg.Tenants, cfg.WAHADefaults); err != nil {
 		pool.Close()
 		return nil, fmt.Errorf("seed tenants: %w", err)
 	}
@@ -672,7 +672,7 @@ const defaultTenantID = "00000000-0000-0000-0000-000000000001"
 // The first tenant reuses the well-known UUID created by the migration
 // (existing data is backfilled to it). Additional tenants are upserted by slug.
 // Runs as superuser — no RLS.
-func seedTenants(ctx context.Context, pool *pgxpool.Pool, tenants []config.TenantConfig) error {
+func seedTenants(ctx context.Context, pool *pgxpool.Pool, tenants []config.TenantConfig, waDefaults config.WAHADefaultsConfig) error {
 	for i, tc := range tenants {
 		var tenantID string
 
@@ -729,10 +729,18 @@ func seedTenants(ctx context.Context, pool *pgxpool.Pool, tenants []config.Tenan
 			return fmt.Errorf("set tenant guc for wa config seed: %w", err)
 		}
 		_, err = waConn.Exec(ctx,
-			`INSERT INTO tenant_wa_configs (tenant_id)
-			 VALUES ($1::uuid)
+			`INSERT INTO tenant_wa_configs (
+				tenant_id, api_url, api_key, session_name, enabled,
+				max_daily_messages, min_delay_ms, max_delay_ms,
+				reminder_cron, weekly_digest_cron
+			 )
+			 VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 			 ON CONFLICT (tenant_id) DO NOTHING`,
-			tenantID)
+			tenantID,
+			waDefaults.APIURL, waDefaults.APIKey, waDefaults.SessionName, waDefaults.Enabled,
+			waDefaults.MaxDailyMessages, waDefaults.MinDelayMS, waDefaults.MaxDelayMS,
+			waDefaults.ReminderCron, waDefaults.WeeklyDigestCron,
+		)
 		_, _ = waConn.Exec(ctx, "RESET ALL")
 		waConn.Release()
 		if err != nil {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -28,6 +28,22 @@ type Config struct {
 	SeedDemoUsers             SeedDemoUsersConfig
 	AppURL                    string
 	Tenants                   []TenantConfig
+	WAHADefaults              WAHADefaultsConfig
+}
+
+// WAHADefaultsConfig holds the WAHA (WhatsApp HTTP API) values used to seed a
+// tenant_wa_configs row when a tenant is first created. Existing rows are
+// untouched — operators tune live values via the in-app WhatsApp settings page.
+type WAHADefaultsConfig struct {
+	APIURL           string
+	APIKey           string
+	SessionName      string
+	Enabled          bool
+	MaxDailyMessages int
+	MinDelayMS       int
+	MaxDelayMS       int
+	ReminderCron     string
+	WeeklyDigestCron string
 }
 
 type SeedSuperAdminConfig struct {
@@ -88,6 +104,11 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
+	wahaDefaults, err := loadWAHADefaults()
+	if err != nil {
+		return Config{}, err
+	}
+
 	cfg := Config{
 		AppEnv:                    appEnv,
 		Port:                      getEnv("PORT", "8080"),
@@ -102,6 +123,7 @@ func Load() (Config, error) {
 		TrackerRetentionDays:      parseIntEnv("TRACKER_RETENTION_DAYS", 90),
 		AppURL:                    getEnv("APP_URL", "http://localhost:3000"),
 		Tenants:                   parseTenants(getEnv("TENANTS", "Default|default|localhost")),
+		WAHADefaults:              wahaDefaults,
 		SeedSuperAdmin: SeedSuperAdminConfig{
 			Enabled:  seedEnabled,
 			Email:    getEnv("SEED_SUPERADMIN_EMAIL", "superadmin@kantor.local"),
@@ -248,6 +270,60 @@ func splitCSV(value string) []string {
 	}
 
 	return result
+}
+
+func loadWAHADefaults() (WAHADefaultsConfig, error) {
+	enabled, err := parseBool("WAHA_ENABLED", false)
+	if err != nil {
+		return WAHADefaultsConfig{}, err
+	}
+
+	maxDaily, err := parseIntEnvStrict("WAHA_MAX_DAILY_MESSAGES", 50)
+	if err != nil {
+		return WAHADefaultsConfig{}, err
+	}
+	minDelay, err := parseIntEnvStrict("WAHA_MIN_DELAY_MS", 2000)
+	if err != nil {
+		return WAHADefaultsConfig{}, err
+	}
+	maxDelay, err := parseIntEnvStrict("WAHA_MAX_DELAY_MS", 5000)
+	if err != nil {
+		return WAHADefaultsConfig{}, err
+	}
+
+	if maxDaily <= 0 {
+		return WAHADefaultsConfig{}, errors.New("WAHA_MAX_DAILY_MESSAGES must be greater than zero")
+	}
+	if minDelay < 0 || maxDelay < 0 {
+		return WAHADefaultsConfig{}, errors.New("WAHA_MIN_DELAY_MS and WAHA_MAX_DELAY_MS must be non-negative")
+	}
+	if minDelay > maxDelay {
+		return WAHADefaultsConfig{}, errors.New("WAHA_MIN_DELAY_MS must be less than or equal to WAHA_MAX_DELAY_MS")
+	}
+
+	return WAHADefaultsConfig{
+		APIURL:           getEnv("WAHA_API_URL", "http://localhost:3000"),
+		APIKey:           os.Getenv("WAHA_API_KEY"),
+		SessionName:      getEnv("WAHA_SESSION", "default"),
+		Enabled:          enabled,
+		MaxDailyMessages: maxDaily,
+		MinDelayMS:       minDelay,
+		MaxDelayMS:       maxDelay,
+		ReminderCron:     getEnv("WAHA_REMINDER_CRON", "0 8 * * 1-5"),
+		WeeklyDigestCron: getEnv("WAHA_WEEKLY_DIGEST_CRON", "0 8 * * 1"),
+	}, nil
+}
+
+func parseIntEnvStrict(key string, fallback int) (int, error) {
+	value, ok := os.LookupEnv(key)
+	if !ok || strings.TrimSpace(value) == "" {
+		return fallback, nil
+	}
+	parsed, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer for %s: %w", key, err)
+	}
+	return parsed, nil
 }
 
 func parseIntEnv(key string, fallback int) int {


### PR DESCRIPTION
## Summary
- Adds a typed `WAHADefaultsConfig` to `internal/config` covering `WAHA_API_URL`, `WAHA_API_KEY`, `WAHA_SESSION`, `WAHA_ENABLED`, `WAHA_MAX_DAILY_MESSAGES`, `WAHA_MIN_DELAY_MS`, `WAHA_MAX_DELAY_MS`, `WAHA_REMINDER_CRON`, and `WAHA_WEEKLY_DIGEST_CRON`.
- Validates ranges at startup: positive daily cap, non-negative delays, `min <= max`. Invalid values fail fast with a clear error instead of failing silently at runtime.
- Threads the parsed defaults through `seedTenants` so new tenants get a `tenant_wa_configs` row populated with operator-provided values. Existing rows are kept intact via `ON CONFLICT (tenant_id) DO NOTHING`, so the in-app WhatsApp settings page remains the source of truth for live tweaks.

## Why
The `WAHA_*` env vars defined in `module.nix` were never read by any Go code — `os.Getenv(\"WAHA_*\")` had zero hits, so any operator who set them at deploy time saw no effect. The audit report flagged this as \"raw os.Getenv calls bypassing typed Config,\" but the actual state was worse: a documented deployment surface with no consumer at all. This wires the surface up properly while respecting the per-tenant DB-backed architecture.

## Test plan
- [x] `go build ./...`
- [ ] Start backend with no `WAHA_*` env vars — defaults match prior DB column defaults (`api_url=http://localhost:3000`, `enabled=false`, `max_daily=50`, `min_delay=2000`, `max_delay=5000`, `reminder_cron=0 8 * * 1-5`, `weekly_digest_cron=0 8 * * 1`).
- [ ] Start backend with `WAHA_MIN_DELAY_MS=10000 WAHA_MAX_DELAY_MS=5000` — verify it refuses to start with the validation error.
- [ ] Drop `tenant_wa_configs` row for a tenant, restart with `WAHA_ENABLED=true WAHA_API_URL=https://waha.example.com` — confirm the seeded row reflects the env values.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)