### PR TITLE
fix(migrations): enforce employees.department FK to departments

### DIFF
--- a/backend/migrations/20260420030000_employees_department_fk.down.sql
+++ b/backend/migrations/20260420030000_employees_department_fk.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE employees DROP CONSTRAINT IF EXISTS fk_employees_department;

--- a/backend/migrations/20260420030000_employees_department_fk.up.sql
+++ b/backend/migrations/20260420030000_employees_department_fk.up.sql
@@ -1,0 +1,31 @@
+-- Enforce referential integrity between employees.department and departments(name).
+-- Until now the column was a free-form TEXT, so typos created ghost departments and
+-- renaming a department in the departments table left employees rows pointing at a
+-- stale string. The FK below catches both: rejects unknown names, and cascades on
+-- rename. Deletes set the employee's department to NULL so we never lose an employee
+-- record when a department is removed.
+
+-- Backfill: every (tenant_id, department) pair that an employee currently references
+-- must exist in departments before the FK can be added.
+INSERT INTO departments (tenant_id, name, created_at)
+SELECT DISTINCT e.tenant_id, e.department, NOW()
+FROM employees e
+WHERE e.department IS NOT NULL
+  AND TRIM(e.department) <> ''
+  AND NOT EXISTS (
+    SELECT 1
+    FROM departments d
+    WHERE d.tenant_id = e.tenant_id
+      AND d.name = e.department
+  );
+
+-- Normalize blank strings to NULL so the FK doesn't try to validate '' against a row
+-- that will never exist.
+UPDATE employees SET department = NULL WHERE department IS NOT NULL AND TRIM(department) = '';
+
+ALTER TABLE employees
+    ADD CONSTRAINT fk_employees_department
+    FOREIGN KEY (tenant_id, department)
+    REFERENCES departments (tenant_id, name)
+    ON UPDATE CASCADE
+    ON DELETE SET NULL;


### PR DESCRIPTION
## Summary
- Adds a new migration `20260420030000_employees_department_fk` that introduces a foreign key from `employees(tenant_id, department)` to `departments(tenant_id, name)` with `ON UPDATE CASCADE` and `ON DELETE SET NULL`.
- Backfills `departments` with any `(tenant_id, department)` pair that an employee currently references but the table doesn't yet contain — so the constraint can attach without losing or rejecting data.
- Normalizes blank strings to `NULL` to avoid creating spurious empty department rows.

## Why
`employees.department` was a free-form `TEXT` column. There was no integrity link to the `departments` table, so:
- Typos created ghost departments that never appeared in the directory
- Renaming a department in `departments` left employees pointing at the old string
- Department analytics were always one cleanup pass behind reality

The `(tenant_id, name)` composite matches the existing `uq_departments_tenant_name` unique constraint introduced by the multi-tenancy migration. `ON UPDATE CASCADE` makes renames safe; `ON DELETE SET NULL` keeps employee records intact when a department is removed.

## Test plan
- [x] `go build ./...`
- [ ] Apply the migration on a database with mismatched employee department names — confirm the backfill creates the missing rows and the FK attaches without error
- [ ] Try inserting an employee with a department name that does not exist — should fail with FK violation
- [ ] Rename a department row's `name` — confirm employee rows pick up the new value
- [ ] Delete a department row — confirm employee rows have their `department` set to `NULL`
- [ ] Run the down migration — confirm the FK is dropped cleanly

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)