### PR TITLE
fix(handler): log every 500 server-side via centralized helper

### DIFF
--- a/backend/internal/handler/admin/audit_logs.go
+++ b/backend/internal/handler/admin/audit_logs.go
@@ -37,7 +37,7 @@ func (h *AuditLogsHandler) list(w http.ResponseWriter, r *http.Request) {
 
 	items, total, err := h.service.ListLogs(r.Context(), params)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list audit logs", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to list audit logs")
 		return
 	}
 
@@ -60,7 +60,7 @@ func (h *AuditLogsHandler) list(w http.ResponseWriter, r *http.Request) {
 func (h *AuditLogsHandler) summary(w http.ResponseWriter, r *http.Request) {
 	item, err := h.service.GetSummary(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load audit log summary", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load audit log summary")
 		return
 	}
 
@@ -70,7 +70,7 @@ func (h *AuditLogsHandler) summary(w http.ResponseWriter, r *http.Request) {
 func (h *AuditLogsHandler) listUsers(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListActors(r.Context(), strings.TrimSpace(r.URL.Query().Get("search")))
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load audit log users", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load audit log users")
 		return
 	}
 
@@ -85,7 +85,7 @@ func (h *AuditLogsHandler) exportCSV(w http.ResponseWriter, r *http.Request) {
 
 	payload, err := h.service.ExportCSV(r.Context(), params)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to export audit logs", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to export audit logs")
 		return
 	}
 

--- a/backend/internal/handler/auth/admin_rbac.go
+++ b/backend/internal/handler/auth/admin_rbac.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -31,7 +32,7 @@ func (h *Handler) ListRoles(w http.ResponseWriter, r *http.Request) {
 		IsActive: isActive,
 	})
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list roles", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to list roles")
 		return
 	}
 
@@ -72,7 +73,7 @@ func (h *Handler) CreateRole(w http.ResponseWriter, r *http.Request) {
 		PermissionIDs:  input.PermissionIDs,
 	}, principal.UserID)
 	if err != nil {
-		h.writeRoleError(w, err)
+		h.writeRoleError(r.Context(), w, err)
 		return
 	}
 
@@ -84,7 +85,7 @@ func (h *Handler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 	roleID := chi.URLParam(r, "roleID")
 	previous, previousErr := h.service.GetRoleDetail(r.Context(), roleID)
 	if previousErr != nil {
-		h.writeRoleError(w, previousErr)
+		h.writeRoleError(r.Context(), w, previousErr)
 		return
 	}
 
@@ -106,7 +107,7 @@ func (h *Handler) UpdateRole(w http.ResponseWriter, r *http.Request) {
 		PermissionIDs:  input.PermissionIDs,
 	})
 	if err != nil {
-		h.writeRoleError(w, err)
+		h.writeRoleError(r.Context(), w, err)
 		return
 	}
 
@@ -118,12 +119,12 @@ func (h *Handler) DeleteRole(w http.ResponseWriter, r *http.Request) {
 	roleID := chi.URLParam(r, "roleID")
 	previous, previousErr := h.service.GetRoleDetail(r.Context(), roleID)
 	if previousErr != nil {
-		h.writeRoleError(w, previousErr)
+		h.writeRoleError(r.Context(), w, previousErr)
 		return
 	}
 
 	if err := h.service.DeleteRole(r.Context(), roleID); err != nil {
-		h.writeRoleError(w, err)
+		h.writeRoleError(r.Context(), w, err)
 		return
 	}
 
@@ -135,13 +136,13 @@ func (h *Handler) ToggleRole(w http.ResponseWriter, r *http.Request) {
 	roleID := chi.URLParam(r, "roleID")
 	previous, previousErr := h.service.GetRoleDetail(r.Context(), roleID)
 	if previousErr != nil {
-		h.writeRoleError(w, previousErr)
+		h.writeRoleError(r.Context(), w, previousErr)
 		return
 	}
 
 	item, err := h.service.ToggleRole(r.Context(), roleID)
 	if err != nil {
-		h.writeRoleError(w, err)
+		h.writeRoleError(r.Context(), w, err)
 		return
 	}
 
@@ -158,7 +159,7 @@ func (h *Handler) DuplicateRole(w http.ResponseWriter, r *http.Request) {
 
 	item, err := h.service.DuplicateRole(r.Context(), chi.URLParam(r, "roleID"), principal.UserID)
 	if err != nil {
-		h.writeRoleError(w, err)
+		h.writeRoleError(r.Context(), w, err)
 		return
 	}
 
@@ -172,7 +173,7 @@ func (h *Handler) DuplicateRole(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) ListPermissions(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListPermissionGroups(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list permissions", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to list permissions")
 		return
 	}
 
@@ -182,7 +183,7 @@ func (h *Handler) ListPermissions(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) GetSettings(w http.ResponseWriter, r *http.Request) {
 	settings, err := h.service.GetSettings(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load settings", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load settings")
 		return
 	}
 
@@ -192,7 +193,7 @@ func (h *Handler) GetSettings(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) ListSettingsDepartments(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListSettingsDepartments(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load departments", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load departments")
 		return
 	}
 
@@ -208,7 +209,7 @@ func (h *Handler) UpdateDefaultRoles(w http.ResponseWriter, r *http.Request) {
 
 	previous, err := h.service.GetSettings(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load current settings", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load current settings")
 		return
 	}
 
@@ -227,13 +228,13 @@ func (h *Handler) UpdateDefaultRoles(w http.ResponseWriter, r *http.Request) {
 			response.WriteError(w, http.StatusBadRequest, "INVALID_MODULE_ROLE", "Default role mapping contains an invalid role", nil)
 			return
 		}
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update default roles", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to update default roles")
 		return
 	}
 
 	settings, err := h.service.GetSettings(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Default roles updated but failed to fetch settings", nil)
+		response.WriteInternalError(r.Context(), w, err, "Default roles updated but failed to fetch settings")
 		return
 	}
 
@@ -250,7 +251,7 @@ func (h *Handler) UpdateAutoCreateEmployee(w http.ResponseWriter, r *http.Reques
 
 	previous, err := h.service.GetSettings(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load current settings", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load current settings")
 		return
 	}
 
@@ -264,13 +265,13 @@ func (h *Handler) UpdateAutoCreateEmployee(w http.ResponseWriter, r *http.Reques
 		Enabled:             input.Enabled,
 		DefaultDepartmentID: input.DefaultDepartmentID,
 	}); err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update auto-create employee setting", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to update auto-create employee setting")
 		return
 	}
 
 	settings, err := h.service.GetSettings(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Setting updated but failed to fetch settings", nil)
+		response.WriteInternalError(r.Context(), w, err, "Setting updated but failed to fetch settings")
 		return
 	}
 
@@ -287,7 +288,7 @@ func (h *Handler) UpdateMailDelivery(w http.ResponseWriter, r *http.Request) {
 
 	previous, err := h.service.GetSettings(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load current settings", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load current settings")
 		return
 	}
 
@@ -302,13 +303,13 @@ func (h *Handler) UpdateMailDelivery(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.UpdateMailDelivery(r.Context(), principal.UserID, input); err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update mail delivery setting", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to update mail delivery setting")
 		return
 	}
 
 	settings, err := h.service.GetSettings(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Setting updated but failed to fetch settings", nil)
+		response.WriteInternalError(r.Context(), w, err, "Setting updated but failed to fetch settings")
 		return
 	}
 
@@ -325,7 +326,7 @@ func (h *Handler) UpdateReimbursementReminder(w http.ResponseWriter, r *http.Req
 
 	previous, err := h.service.GetSettings(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load current settings", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load current settings")
 		return
 	}
 
@@ -340,13 +341,13 @@ func (h *Handler) UpdateReimbursementReminder(w http.ResponseWriter, r *http.Req
 	}
 
 	if err := h.service.UpdateReimbursementReminder(r.Context(), principal.UserID, input); err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update reimbursement reminder setting", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to update reimbursement reminder setting")
 		return
 	}
 
 	settings, err := h.service.GetSettings(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Setting updated but failed to fetch settings", nil)
+		response.WriteInternalError(r.Context(), w, err, "Setting updated but failed to fetch settings")
 		return
 	}
 
@@ -357,13 +358,13 @@ func (h *Handler) UpdateReimbursementReminder(w http.ResponseWriter, r *http.Req
 func (h *Handler) ListModules(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListModules(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list modules", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to list modules")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
 }
 
-func (h *Handler) writeRoleError(w http.ResponseWriter, err error) {
+func (h *Handler) writeRoleError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch err {
 	case authrepo.ErrRoleNotFound:
 		response.WriteError(w, http.StatusNotFound, "ROLE_NOT_FOUND", err.Error(), nil)
@@ -376,6 +377,6 @@ func (h *Handler) writeRoleError(w http.ResponseWriter, err error) {
 	case authrepo.ErrRoleHasAssignments:
 		response.WriteError(w, http.StatusConflict, "ROLE_HAS_ASSIGNMENTS", err.Error(), nil)
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }

--- a/backend/internal/handler/auth/handler.go
+++ b/backend/internal/handler/auth/handler.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -78,7 +79,7 @@ func (h *Handler) UpdateClientContext(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.service.UpdateClientContext(r.Context(), principal.UserID, input)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Gagal menyimpan konteks browser", nil)
+		response.WriteInternalError(r.Context(), w, err, "Gagal menyimpan konteks browser")
 		return
 	}
 
@@ -96,7 +97,7 @@ func (h *Handler) Me(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.GetSession(r.Context(), principal.UserID)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Terjadi kesalahan yang tidak terduga", nil)
+		response.WriteInternalError(r.Context(), w, err, "Terjadi kesalahan yang tidak terduga")
 		return
 	}
 
@@ -121,7 +122,7 @@ func (h *Handler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.ChangePassword(r.Context(), principal.UserID, input.CurrentPassword, input.NewPassword); err != nil {
-		h.writeAuthError(w, err)
+		h.writeAuthError(r.Context(), w, err)
 		return
 	}
 
@@ -142,7 +143,7 @@ func (h *Handler) register(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.Register(r.Context(), input, r.UserAgent(), clientIP(r))
 	if err != nil {
-		h.writeAuthError(w, err)
+		h.writeAuthError(r.Context(), w, err)
 		return
 	}
 
@@ -169,7 +170,7 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.Login(r.Context(), input, r.UserAgent(), clientIP(r))
 	if err != nil {
-		h.writeAuthError(w, err)
+		h.writeAuthError(r.Context(), w, err)
 		return
 	}
 
@@ -196,7 +197,7 @@ func (h *Handler) refresh(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.Refresh(r.Context(), refreshToken, r.UserAgent(), clientIP(r))
 	if err != nil {
-		h.writeAuthError(w, err)
+		h.writeAuthError(r.Context(), w, err)
 		return
 	}
 
@@ -227,7 +228,7 @@ func (h *Handler) logout(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) publicOptions(w http.ResponseWriter, r *http.Request) {
 	options, err := h.service.GetPublicAuthOptions(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Gagal memuat opsi auth tenant", nil)
+		response.WriteInternalError(r.Context(), w, err, "Gagal memuat opsi auth tenant")
 		return
 	}
 
@@ -257,7 +258,7 @@ func (h *Handler) forgotPassword(w http.ResponseWriter, r *http.Request) {
 		UserAgent:     r.UserAgent(),
 		IPAddress:     clientIP(r),
 	}); err != nil {
-		h.writeAuthError(w, err)
+		h.writeAuthError(r.Context(), w, err)
 		return
 	}
 
@@ -274,7 +275,7 @@ func (h *Handler) validateResetPassword(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.service.ValidatePasswordResetToken(r.Context(), token); err != nil {
-		h.writeAuthError(w, err)
+		h.writeAuthError(r.Context(), w, err)
 		return
 	}
 
@@ -289,7 +290,7 @@ func (h *Handler) resetPassword(w http.ResponseWriter, r *http.Request) {
 
 	userID, err := h.service.ResetPasswordWithToken(r.Context(), input.Token, input.NewPassword)
 	if err != nil {
-		h.writeAuthError(w, err)
+		h.writeAuthError(r.Context(), w, err)
 		return
 	}
 
@@ -336,7 +337,7 @@ func (h *Handler) decodeAndValidate(w http.ResponseWriter, r *http.Request, targ
 	return true
 }
 
-func (h *Handler) writeAuthError(w http.ResponseWriter, err error) {
+func (h *Handler) writeAuthError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, authservice.ErrEmailAlreadyExists):
 		response.WriteError(w, http.StatusConflict, "EMAIL_ALREADY_EXISTS", err.Error(), nil)
@@ -359,7 +360,7 @@ func (h *Handler) writeAuthError(w http.ResponseWriter, err error) {
 	case errors.Is(err, authservice.ErrPasswordUnchanged):
 		response.WriteError(w, http.StatusBadRequest, "PASSWORD_UNCHANGED", err.Error(), nil)
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Terjadi kesalahan yang tidak terduga", nil)
+		response.WriteInternalError(ctx, w, err, "Terjadi kesalahan yang tidak terduga")
 	}
 }
 

--- a/backend/internal/handler/auth/profile.go
+++ b/backend/internal/handler/auth/profile.go
@@ -49,7 +49,7 @@ func (h *Handler) UpdateProfile(w http.ResponseWriter, r *http.Request) {
 
 	employee, err := h.service.UpdateProfile(r.Context(), principal.UserID, input)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update profile", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to update profile")
 		return
 	}
 
@@ -78,7 +78,7 @@ func (h *Handler) ChangeEmail(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, authservice.ErrEmailUnchanged):
 			response.WriteError(w, http.StatusBadRequest, "EMAIL_UNCHANGED", err.Error(), nil)
 		default:
-			response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to change email", nil)
+			response.WriteInternalError(r.Context(), w, err, "Failed to change email")
 		}
 		return
 	}
@@ -120,7 +120,7 @@ func (h *Handler) UploadProfileAvatar(w http.ResponseWriter, r *http.Request) {
 
 	if err := h.service.UpdateProfileAvatar(r.Context(), principal.UserID, avatarPath); err != nil {
 		_ = os.Remove(filepath.Join(h.uploadsDir, filepath.FromSlash(avatarPath)))
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Gagal menyimpan avatar", nil)
+		response.WriteInternalError(r.Context(), w, err, "Gagal menyimpan avatar")
 		return
 	}
 

--- a/backend/internal/handler/auth/users.go
+++ b/backend/internal/handler/auth/users.go
@@ -36,7 +36,7 @@ func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		slog.Error("failed to list users", "error", err)
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list users", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to list users")
 		return
 	}
 
@@ -99,14 +99,14 @@ func (h *Handler) UpdateUserRoles(w http.ResponseWriter, r *http.Request) {
 		case authrepo.ErrInvalidModuleRole:
 			response.WriteError(w, http.StatusBadRequest, "INVALID_MODULE_ROLE", "Role assignment is invalid", nil)
 		default:
-			response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update module roles", nil)
+			response.WriteInternalError(r.Context(), w, err, "Failed to update module roles")
 		}
 		return
 	}
 
 	result, err := h.service.GetAdminUserDetail(r.Context(), userID)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Roles updated but failed to fetch user", nil)
+		response.WriteInternalError(r.Context(), w, err, "Roles updated but failed to fetch user")
 		return
 	}
 
@@ -133,7 +133,7 @@ func (h *Handler) ToggleUserActive(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.SetUserActive(r.Context(), userID, input.Active); err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update user status", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to update user status")
 		return
 	}
 
@@ -178,14 +178,14 @@ func (h *Handler) ToggleUserSuperAdmin(w http.ResponseWriter, r *http.Request) {
 		case authrepo.ErrCannotToggleSelf:
 			response.WriteError(w, http.StatusBadRequest, "CANNOT_TOGGLE_SELF", err.Error(), nil)
 		default:
-			response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update super admin status", nil)
+			response.WriteInternalError(r.Context(), w, err, "Failed to update super admin status")
 		}
 		return
 	}
 
 	result, err := h.service.GetAdminUserDetail(r.Context(), userID)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Super admin updated but failed to fetch user", nil)
+		response.WriteInternalError(r.Context(), w, err, "Super admin updated but failed to fetch user")
 		return
 	}
 
@@ -211,7 +211,7 @@ func (h *Handler) EnsureUserEmployeeProfile(w http.ResponseWriter, r *http.Reque
 
 	result, err := h.service.EnsureEmployeeProfileForUser(r.Context(), previous.User.ID)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create employee profile", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to create employee profile")
 		return
 	}
 

--- a/backend/internal/handler/files/handler.go
+++ b/backend/internal/handler/files/handler.go
@@ -39,7 +39,7 @@ func (h *Handler) Serve(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, filesservice.ErrFileNotFound):
 			response.WriteError(w, http.StatusNotFound, "FILE_NOT_FOUND", "Requested file was not found", nil)
 		default:
-			response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+			response.WriteInternalError(r.Context(), w, err, "An unexpected error occurred")
 		}
 		return
 	}

--- a/backend/internal/handler/hris/compensation.go
+++ b/backend/internal/handler/hris/compensation.go
@@ -1,6 +1,7 @@
 package hris
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -50,7 +51,7 @@ func (h *CompensationHandler) createSalary(w http.ResponseWriter, r *http.Reques
 
 	result, err := h.service.CreateSalary(r.Context(), chi.URLParam(r, "employeeID"), input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "hris", "salary", result.ID, nil, input)
@@ -66,7 +67,7 @@ func (h *CompensationHandler) listSalaries(w http.ResponseWriter, r *http.Reques
 
 	result, err := h.service.ListSalaries(r.Context(), chi.URLParam(r, "employeeID"), principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "view", "hris", "salary", chi.URLParam(r, "employeeID"), nil, map[string]any{
@@ -86,7 +87,7 @@ func (h *CompensationHandler) getCurrentSalary(w http.ResponseWriter, r *http.Re
 
 	result, err := h.service.GetCurrentSalary(r.Context(), chi.URLParam(r, "employeeID"), principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "view", "hris", "salary", chi.URLParam(r, "employeeID"), nil, map[string]any{
@@ -111,7 +112,7 @@ func (h *CompensationHandler) createBonus(w http.ResponseWriter, r *http.Request
 
 	result, err := h.service.CreateBonus(r.Context(), chi.URLParam(r, "employeeID"), input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "hris", "bonus", result.ID, nil, input)
@@ -126,7 +127,7 @@ func (h *CompensationHandler) listBonuses(w http.ResponseWriter, r *http.Request
 	}
 	result, err := h.service.ListBonuses(r.Context(), chi.URLParam(r, "employeeID"), principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, result, nil)
@@ -141,7 +142,7 @@ func (h *CompensationHandler) ApproveBonus(w http.ResponseWriter, r *http.Reques
 	bonusID := chi.URLParam(r, "bonusID")
 	result, err := h.service.ApproveBonus(r.Context(), bonusID, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "approve", "hris", "bonus", bonusID, nil, result)
@@ -162,7 +163,7 @@ func (h *CompensationHandler) UpdateBonus(w http.ResponseWriter, r *http.Request
 	bonusID := chi.URLParam(r, "bonusID")
 	result, err := h.service.UpdateBonus(r.Context(), bonusID, input, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "hris", "bonus", bonusID, nil, input)
@@ -178,7 +179,7 @@ func (h *CompensationHandler) RejectBonus(w http.ResponseWriter, r *http.Request
 	bonusID := chi.URLParam(r, "bonusID")
 	result, err := h.service.RejectBonus(r.Context(), bonusID, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "reject", "hris", "bonus", bonusID, nil, result)
@@ -193,14 +194,14 @@ func (h *CompensationHandler) DeleteBonus(w http.ResponseWriter, r *http.Request
 	}
 	bonusID := chi.URLParam(r, "bonusID")
 	if err := h.service.DeleteBonus(r.Context(), bonusID, principal.UserID, principal.Cached); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "delete", "hris", "bonus", bonusID, nil, nil)
 	response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Bonus deleted successfully"}, nil)
 }
 
-func (h *CompensationHandler) writeError(w http.ResponseWriter, err error) {
+func (h *CompensationHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, hrisservice.ErrEmployeeNotFound):
 		response.WriteError(w, http.StatusNotFound, "EMPLOYEE_NOT_FOUND", err.Error(), nil)
@@ -215,6 +216,6 @@ func (h *CompensationHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, hrisservice.ErrBonusForbidden):
 		response.WriteError(w, http.StatusForbidden, "BONUS_FORBIDDEN", err.Error(), nil)
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }

--- a/backend/internal/handler/hris/departments.go
+++ b/backend/internal/handler/hris/departments.go
@@ -1,6 +1,7 @@
 package hris
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -41,7 +42,7 @@ func (h *DepartmentsHandler) createDepartment(w http.ResponseWriter, r *http.Req
 
 	result, err := h.service.CreateDepartment(r.Context(), input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -52,7 +53,7 @@ func (h *DepartmentsHandler) createDepartment(w http.ResponseWriter, r *http.Req
 func (h *DepartmentsHandler) listDepartments(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.ListDepartments(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -62,7 +63,7 @@ func (h *DepartmentsHandler) listDepartments(w http.ResponseWriter, r *http.Requ
 func (h *DepartmentsHandler) getDepartment(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.GetDepartment(r.Context(), chi.URLParam(r, "departmentID"))
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -78,7 +79,7 @@ func (h *DepartmentsHandler) updateDepartment(w http.ResponseWriter, r *http.Req
 	departmentID := chi.URLParam(r, "departmentID")
 	result, err := h.service.UpdateDepartment(r.Context(), departmentID, input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -89,7 +90,7 @@ func (h *DepartmentsHandler) updateDepartment(w http.ResponseWriter, r *http.Req
 func (h *DepartmentsHandler) deleteDepartment(w http.ResponseWriter, r *http.Request) {
 	departmentID := chi.URLParam(r, "departmentID")
 	if err := h.service.DeleteDepartment(r.Context(), departmentID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -97,7 +98,7 @@ func (h *DepartmentsHandler) deleteDepartment(w http.ResponseWriter, r *http.Req
 	response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Department deleted successfully"}, nil)
 }
 
-func (h *DepartmentsHandler) writeError(w http.ResponseWriter, err error) {
+func (h *DepartmentsHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, hrisservice.ErrDepartmentNotFound):
 		response.WriteError(w, http.StatusNotFound, "DEPARTMENT_NOT_FOUND", err.Error(), nil)
@@ -106,6 +107,6 @@ func (h *DepartmentsHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, hrisservice.ErrDepartmentHeadMissing):
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"head_id": "employee not found"})
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }

--- a/backend/internal/handler/hris/employees.go
+++ b/backend/internal/handler/hris/employees.go
@@ -1,6 +1,7 @@
 package hris
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -65,7 +66,7 @@ func (h *EmployeesHandler) createEmployee(w http.ResponseWriter, r *http.Request
 
 	result, err := h.service.CreateEmployee(r.Context(), input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -81,7 +82,7 @@ func (h *EmployeesHandler) listEmployees(w http.ResponseWriter, r *http.Request)
 
 	result, total, page, perPage, err := h.service.ListEmployees(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -101,7 +102,7 @@ func (h *EmployeesHandler) getMyEmployee(w http.ResponseWriter, r *http.Request)
 
 	result, err := h.service.GetMyEmployee(r.Context(), principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -111,7 +112,7 @@ func (h *EmployeesHandler) getMyEmployee(w http.ResponseWriter, r *http.Request)
 func (h *EmployeesHandler) getEmployee(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.GetEmployee(r.Context(), chi.URLParam(r, "employeeID"))
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -127,7 +128,7 @@ func (h *EmployeesHandler) updateEmployee(w http.ResponseWriter, r *http.Request
 	employeeID := chi.URLParam(r, "employeeID")
 	result, err := h.service.UpdateEmployee(r.Context(), employeeID, input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -156,7 +157,7 @@ func (h *EmployeesHandler) uploadAvatar(w http.ResponseWriter, r *http.Request) 
 	employeeID := chi.URLParam(r, "employeeID")
 	current, err := h.service.GetEmployee(r.Context(), employeeID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -174,7 +175,7 @@ func (h *EmployeesHandler) uploadAvatar(w http.ResponseWriter, r *http.Request) 
 	result, err := h.service.UpdateEmployeeAvatar(r.Context(), employeeID, avatarPath)
 	if err != nil {
 		_ = os.Remove(filepath.Join(h.uploadsDir, filepath.FromSlash(avatarPath)))
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -196,7 +197,7 @@ func (h *EmployeesHandler) uploadAvatar(w http.ResponseWriter, r *http.Request) 
 func (h *EmployeesHandler) deleteEmployee(w http.ResponseWriter, r *http.Request) {
 	employeeID := chi.URLParam(r, "employeeID")
 	if err := h.service.DeleteEmployee(r.Context(), employeeID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -237,7 +238,7 @@ func (h *EmployeesHandler) parseListQuery(w http.ResponseWriter, r *http.Request
 	return query, true
 }
 
-func (h *EmployeesHandler) writeError(w http.ResponseWriter, err error) {
+func (h *EmployeesHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, hrisservice.ErrEmployeeNotFound):
 		response.WriteError(w, http.StatusNotFound, "EMPLOYEE_NOT_FOUND", err.Error(), nil)
@@ -246,7 +247,7 @@ func (h *EmployeesHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, hrisservice.ErrEmployeeUserLinkedTwice):
 		response.WriteError(w, http.StatusConflict, "EMPLOYEE_USER_ALREADY_LINKED", err.Error(), map[string]string{"user_id": "already linked"})
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }
 

--- a/backend/internal/handler/hris/employees_export.go
+++ b/backend/internal/handler/hris/employees_export.go
@@ -24,7 +24,7 @@ func (h *EmployeesHandler) exportList(w http.ResponseWriter, r *http.Request) {
 
 	items, _, _, _, err := h.service.ListEmployees(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -52,7 +52,7 @@ func (h *EmployeesHandler) exportList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -75,24 +75,24 @@ func (h *EmployeesHandler) exportDetail(w http.ResponseWriter, r *http.Request) 
 	employeeID := chi.URLParam(r, "employeeID")
 	item, err := h.service.GetEmployee(r.Context(), employeeID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
 	salaries, err := h.compensation.ListSalaries(r.Context(), employeeID, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	bonuses, err := h.compensation.ListBonuses(r.Context(), employeeID, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
 	payload, err := renderEmployeeDetailPDF(item, salaries, bonuses, exportutil.ResolveGeneratedBy(r.Context(), h.users))
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 

--- a/backend/internal/handler/hris/finance.go
+++ b/backend/internal/handler/hris/finance.go
@@ -1,6 +1,7 @@
 package hris
 
 import (
+	"context"
 	"bytes"
 	"encoding/csv"
 	"errors"
@@ -62,7 +63,7 @@ func (h *FinanceHandler) createCategory(w http.ResponseWriter, r *http.Request) 
 	}
 	result, err := h.service.CreateCategory(r.Context(), input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "hris", "finance_category", result.ID, nil, input)
@@ -72,7 +73,7 @@ func (h *FinanceHandler) createCategory(w http.ResponseWriter, r *http.Request) 
 func (h *FinanceHandler) listCategories(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListCategories(r.Context(), r.URL.Query().Get("type"))
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -89,7 +90,7 @@ func (h *FinanceHandler) updateCategory(w http.ResponseWriter, r *http.Request) 
 	categoryID := chi.URLParam(r, "categoryID")
 	result, err := h.service.UpdateCategory(r.Context(), categoryID, input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "hris", "finance_category", categoryID, nil, input)
@@ -102,7 +103,7 @@ func (h *FinanceHandler) deleteCategory(w http.ResponseWriter, r *http.Request) 
 	}
 	categoryID := chi.URLParam(r, "categoryID")
 	if err := h.service.DeleteCategory(r.Context(), categoryID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "delete", "hris", "finance_category", categoryID, nil, nil)
@@ -139,7 +140,7 @@ func (h *FinanceHandler) createRecord(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := h.service.CreateRecord(r.Context(), input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "hris", "finance_record", result.ID, nil, input)
@@ -158,7 +159,7 @@ func (h *FinanceHandler) listRecords(w http.ResponseWriter, r *http.Request) {
 	}
 	items, total, page, perPage, err := h.service.ListRecords(r.Context(), query, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, map[string]int64{
@@ -176,7 +177,7 @@ func (h *FinanceHandler) getRecord(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := h.service.GetRecord(r.Context(), chi.URLParam(r, "recordID"), principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, result, nil)
@@ -195,7 +196,7 @@ func (h *FinanceHandler) updateRecord(w http.ResponseWriter, r *http.Request) {
 	recordID := chi.URLParam(r, "recordID")
 	result, err := h.service.UpdateRecord(r.Context(), recordID, input, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "hris", "finance_record", recordID, nil, input)
@@ -210,7 +211,7 @@ func (h *FinanceHandler) deleteRecord(w http.ResponseWriter, r *http.Request) {
 	}
 	recordID := chi.URLParam(r, "recordID")
 	if err := h.service.DeleteRecord(r.Context(), recordID, principal.UserID, principal.Cached); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "delete", "hris", "finance_record", recordID, nil, nil)
@@ -226,7 +227,7 @@ func (h *FinanceHandler) submitRecord(w http.ResponseWriter, r *http.Request) {
 	recordID := chi.URLParam(r, "recordID")
 	result, err := h.service.SubmitRecord(r.Context(), recordID, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "submit", "hris", "finance_record", recordID, nil, result)
@@ -246,7 +247,7 @@ func (h *FinanceHandler) reviewRecord(w http.ResponseWriter, r *http.Request) {
 	recordID := chi.URLParam(r, "recordID")
 	result, err := h.service.ReviewRecord(r.Context(), recordID, input.Decision, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "review", "hris", "finance_record", recordID, nil, input)
@@ -260,7 +261,7 @@ func (h *FinanceHandler) summary(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := h.service.Summary(r.Context(), year)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, result, nil)
@@ -282,7 +283,7 @@ func (h *FinanceHandler) exportRecords(w http.ResponseWriter, r *http.Request) {
 
 	items, _, _, _, err := h.service.ListRecords(r.Context(), query, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -292,7 +293,7 @@ func (h *FinanceHandler) exportRecords(w http.ResponseWriter, r *http.Request) {
 	}
 	summary, err := h.service.Summary(r.Context(), selectedYear)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -325,7 +326,7 @@ func (h *FinanceHandler) exportRecords(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -389,7 +390,7 @@ func (h *FinanceHandler) parseListQuery(w http.ResponseWriter, r *http.Request) 
 	return query, true
 }
 
-func (h *FinanceHandler) writeError(w http.ResponseWriter, err error) {
+func (h *FinanceHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, hrisservice.ErrFinanceCategoryNotFound):
 		response.WriteError(w, http.StatusNotFound, "FINANCE_CATEGORY_NOT_FOUND", err.Error(), nil)
@@ -400,7 +401,7 @@ func (h *FinanceHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, hrisservice.ErrFinanceForbidden):
 		response.WriteError(w, http.StatusForbidden, "FINANCE_FORBIDDEN", err.Error(), nil)
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }
 

--- a/backend/internal/handler/hris/overview.go
+++ b/backend/internal/handler/hris/overview.go
@@ -25,7 +25,7 @@ func (h *OverviewHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.GetOverview(r.Context(), principal.UserID, principal.Cached)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(r.Context(), w, err, "An unexpected error occurred")
 		return
 	}
 

--- a/backend/internal/handler/hris/reimbursements.go
+++ b/backend/internal/handler/hris/reimbursements.go
@@ -1,6 +1,7 @@
 package hris
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -75,7 +76,7 @@ func (h *ReimbursementsHandler) create(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.Create(r.Context(), input, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "hris", "reimbursement", result.ID, nil, input)
@@ -96,7 +97,7 @@ func (h *ReimbursementsHandler) list(w http.ResponseWriter, r *http.Request) {
 
 	items, total, page, perPage, err := h.service.List(r.Context(), query, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, map[string]int64{
@@ -118,7 +119,7 @@ func (h *ReimbursementsHandler) get(w http.ResponseWriter, r *http.Request) {
 	}
 	item, err := h.service.Get(r.Context(), reimbursementID, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, item, nil)
@@ -142,7 +143,7 @@ func (h *ReimbursementsHandler) update(w http.ResponseWriter, r *http.Request) {
 	}
 	item, removedAttachments, err := h.service.Update(r.Context(), reimbursementID, input, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	removeSavedAttachments(h.uploadsDir, removedAttachments)
@@ -163,7 +164,7 @@ func (h *ReimbursementsHandler) deleteReimbursement(w http.ResponseWriter, r *ht
 	}
 	removedAttachments, err := h.service.Delete(r.Context(), reimbursementID, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	removeSavedAttachments(h.uploadsDir, removedAttachments)
@@ -212,7 +213,7 @@ func (h *ReimbursementsHandler) uploadAttachments(w http.ResponseWriter, r *http
 	item, err := h.service.AddAttachments(r.Context(), reimbursementID, paths, principal.UserID, principal.Cached)
 	if err != nil {
 		removeSavedAttachments(h.uploadsDir, paths)
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "upload_attachments", "hris", "reimbursement", reimbursementID, nil, nil)
@@ -237,7 +238,7 @@ func (h *ReimbursementsHandler) markPaid(w http.ResponseWriter, r *http.Request)
 	}
 	item, err := h.service.MarkPaid(r.Context(), reimbursementID, input.Notes, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "mark_paid", "hris", "reimbursement", reimbursementID, nil, input)
@@ -255,7 +256,7 @@ func (h *ReimbursementsHandler) summary(w http.ResponseWriter, r *http.Request) 
 	year, _ := strconv.Atoi(strings.TrimSpace(r.URL.Query().Get("year")))
 	item, err := h.service.Summary(r.Context(), month, year, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, item, nil)
@@ -275,7 +276,7 @@ func (h *ReimbursementsHandler) bulkReview(w http.ResponseWriter, r *http.Reques
 
 	count, err := h.service.BulkReview(r.Context(), input, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "bulk_review", "hris", "reimbursement", "", nil, input)
@@ -296,7 +297,7 @@ func (h *ReimbursementsHandler) bulkMarkPaid(w http.ResponseWriter, r *http.Requ
 
 	count, err := h.service.BulkMarkPaid(r.Context(), input, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "bulk_mark_paid", "hris", "reimbursement", "", nil, input)
@@ -321,7 +322,7 @@ func (h *ReimbursementsHandler) review(w http.ResponseWriter, r *http.Request) {
 	}
 	item, err := h.service.ManagerReview(r.Context(), reimbursementID, input, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "review", "hris", "reimbursement", reimbursementID, nil, input)
@@ -374,7 +375,7 @@ func (h *ReimbursementsHandler) parseListQuery(w http.ResponseWriter, r *http.Re
 	return query, true
 }
 
-func (h *ReimbursementsHandler) writeError(w http.ResponseWriter, err error) {
+func (h *ReimbursementsHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, hrisservice.ErrReimbursementNotFound):
 		response.WriteError(w, http.StatusNotFound, "REIMBURSEMENT_NOT_FOUND", err.Error(), nil)
@@ -390,7 +391,7 @@ func (h *ReimbursementsHandler) writeError(w http.ResponseWriter, err error) {
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"employee_id": "not found"})
 	default:
 		slog.Error("unexpected reimbursement error", "error", err)
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }
 

--- a/backend/internal/handler/hris/reimbursements_export.go
+++ b/backend/internal/handler/hris/reimbursements_export.go
@@ -28,13 +28,13 @@ func (h *ReimbursementsHandler) export(w http.ResponseWriter, r *http.Request) {
 
 	items, _, _, _, err := h.service.List(r.Context(), query, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
 	summary, err := h.service.Summary(r.Context(), query.Month, query.Year, principal.UserID, principal.Cached)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -63,7 +63,7 @@ func (h *ReimbursementsHandler) export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 

--- a/backend/internal/handler/hris/subscriptions.go
+++ b/backend/internal/handler/hris/subscriptions.go
@@ -1,6 +1,7 @@
 package hris
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -52,7 +53,7 @@ func (h *SubscriptionsHandler) createSubscription(w http.ResponseWriter, r *http
 	}
 	result, err := h.service.CreateSubscription(r.Context(), input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "hris", "subscription", result.ID, nil, input)
@@ -62,7 +63,7 @@ func (h *SubscriptionsHandler) createSubscription(w http.ResponseWriter, r *http
 func (h *SubscriptionsHandler) listSubscriptions(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.ListSubscriptions(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, result, nil)
@@ -71,7 +72,7 @@ func (h *SubscriptionsHandler) listSubscriptions(w http.ResponseWriter, r *http.
 func (h *SubscriptionsHandler) getSubscription(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.GetSubscription(r.Context(), chi.URLParam(r, "subscriptionID"))
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, result, nil)
@@ -90,7 +91,7 @@ func (h *SubscriptionsHandler) updateSubscription(w http.ResponseWriter, r *http
 	subscriptionID := chi.URLParam(r, "subscriptionID")
 	result, err := h.service.UpdateSubscription(r.Context(), subscriptionID, input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "hris", "subscription", subscriptionID, nil, input)
@@ -100,7 +101,7 @@ func (h *SubscriptionsHandler) updateSubscription(w http.ResponseWriter, r *http
 func (h *SubscriptionsHandler) deleteSubscription(w http.ResponseWriter, r *http.Request) {
 	subscriptionID := chi.URLParam(r, "subscriptionID")
 	if err := h.service.DeleteSubscription(r.Context(), subscriptionID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "delete", "hris", "subscription", subscriptionID, nil, nil)
@@ -110,7 +111,7 @@ func (h *SubscriptionsHandler) deleteSubscription(w http.ResponseWriter, r *http
 func (h *SubscriptionsHandler) summary(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.Summary(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, result, nil)
@@ -119,7 +120,7 @@ func (h *SubscriptionsHandler) summary(w http.ResponseWriter, r *http.Request) {
 func (h *SubscriptionsHandler) listAlerts(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.ListAlerts(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, result, nil)
@@ -127,13 +128,13 @@ func (h *SubscriptionsHandler) listAlerts(w http.ResponseWriter, r *http.Request
 
 func (h *SubscriptionsHandler) markAlertRead(w http.ResponseWriter, r *http.Request) {
 	if err := h.service.MarkAlertRead(r.Context(), chi.URLParam(r, "alertID")); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Alert marked as read"}, nil)
 }
 
-func (h *SubscriptionsHandler) writeError(w http.ResponseWriter, err error) {
+func (h *SubscriptionsHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, hrisservice.ErrSubscriptionNotFound):
 		response.WriteError(w, http.StatusNotFound, "SUBSCRIPTION_NOT_FOUND", err.Error(), nil)
@@ -142,6 +143,6 @@ func (h *SubscriptionsHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, hrisservice.ErrEmployeeNotFound):
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"pic_employee_id": "employee not found"})
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }

--- a/backend/internal/handler/hris/subscriptions_export.go
+++ b/backend/internal/handler/hris/subscriptions_export.go
@@ -15,12 +15,12 @@ import (
 func (h *SubscriptionsHandler) export(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListSubscriptions(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	summary, err := h.service.Summary(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -48,7 +48,7 @@ func (h *SubscriptionsHandler) export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 

--- a/backend/internal/handler/marketing/ads_metrics.go
+++ b/backend/internal/handler/marketing/ads_metrics.go
@@ -1,6 +1,7 @@
 package marketing
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -55,7 +56,7 @@ func (h *AdsMetricsHandler) createMetric(w http.ResponseWriter, r *http.Request)
 
 	item, err := h.service.CreateMetric(r.Context(), input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -77,7 +78,7 @@ func (h *AdsMetricsHandler) batchCreateMetrics(w http.ResponseWriter, r *http.Re
 
 	items, err := h.service.BatchCreateMetrics(r.Context(), input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -93,7 +94,7 @@ func (h *AdsMetricsHandler) listMetrics(w http.ResponseWriter, r *http.Request) 
 
 	items, total, page, perPage, err := h.service.ListMetrics(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -107,7 +108,7 @@ func (h *AdsMetricsHandler) listMetrics(w http.ResponseWriter, r *http.Request) 
 func (h *AdsMetricsHandler) getMetric(w http.ResponseWriter, r *http.Request) {
 	item, err := h.service.GetMetric(r.Context(), chi.URLParam(r, "metricID"))
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -123,7 +124,7 @@ func (h *AdsMetricsHandler) updateMetric(w http.ResponseWriter, r *http.Request)
 	metricID := chi.URLParam(r, "metricID")
 	item, err := h.service.UpdateMetric(r.Context(), metricID, input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -134,7 +135,7 @@ func (h *AdsMetricsHandler) updateMetric(w http.ResponseWriter, r *http.Request)
 func (h *AdsMetricsHandler) deleteMetric(w http.ResponseWriter, r *http.Request) {
 	metricID := chi.URLParam(r, "metricID")
 	if err := h.service.DeleteMetric(r.Context(), metricID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -155,7 +156,7 @@ func (h *AdsMetricsHandler) summary(w http.ResponseWriter, r *http.Request) {
 
 	item, err := h.service.Summary(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -175,7 +176,7 @@ func (h *AdsMetricsHandler) exportCSV(w http.ResponseWriter, r *http.Request) {
 		strings.TrimSpace(r.URL.Query().Get("date_to")),
 	)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -219,7 +220,7 @@ func (h *AdsMetricsHandler) parseListQuery(w http.ResponseWriter, r *http.Reques
 	return query, true
 }
 
-func (h *AdsMetricsHandler) writeError(w http.ResponseWriter, err error) {
+func (h *AdsMetricsHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, marketingservice.ErrAdsMetricNotFound):
 		response.WriteError(w, http.StatusNotFound, "ADS_METRIC_NOT_FOUND", err.Error(), nil)
@@ -230,7 +231,7 @@ func (h *AdsMetricsHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, marketingservice.ErrAdsMetricUnsupportedExport):
 		response.WriteError(w, http.StatusBadRequest, "UNSUPPORTED_EXPORT_FORMAT", err.Error(), map[string]string{"format": "must be csv"})
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }
 

--- a/backend/internal/handler/marketing/ads_metrics_export.go
+++ b/backend/internal/handler/marketing/ads_metrics_export.go
@@ -23,7 +23,7 @@ func (h *AdsMetricsHandler) export(w http.ResponseWriter, r *http.Request) {
 
 	items, _, _, _, err := h.service.ListMetrics(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -55,7 +55,7 @@ func (h *AdsMetricsHandler) export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 

--- a/backend/internal/handler/marketing/campaigns.go
+++ b/backend/internal/handler/marketing/campaigns.go
@@ -1,6 +1,7 @@
 package marketing
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -77,7 +78,7 @@ func (h *CampaignsHandler) createCampaign(w http.ResponseWriter, r *http.Request
 
 	item, err := h.service.CreateCampaign(r.Context(), input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -93,7 +94,7 @@ func (h *CampaignsHandler) listCampaigns(w http.ResponseWriter, r *http.Request)
 
 	items, total, page, perPage, err := h.service.ListCampaigns(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -107,7 +108,7 @@ func (h *CampaignsHandler) listCampaigns(w http.ResponseWriter, r *http.Request)
 func (h *CampaignsHandler) kanban(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListKanban(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -120,7 +121,7 @@ func (h *CampaignsHandler) getCampaign(w http.ResponseWriter, r *http.Request) {
 	}
 	item, err := h.service.GetCampaign(r.Context(), campaignID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, item, nil)
@@ -133,7 +134,7 @@ func (h *CampaignsHandler) listActivities(w http.ResponseWriter, r *http.Request
 	}
 	items, err := h.service.ListActivities(r.Context(), campaignID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -157,7 +158,7 @@ func (h *CampaignsHandler) updateCampaign(w http.ResponseWriter, r *http.Request
 	}
 	item, err := h.service.UpdateCampaign(r.Context(), campaignID, input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "marketing", "campaign", campaignID, nil, input)
@@ -170,7 +171,7 @@ func (h *CampaignsHandler) deleteCampaign(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if err := h.service.DeleteCampaign(r.Context(), campaignID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "delete", "marketing", "campaign", campaignID, nil, nil)
@@ -195,7 +196,7 @@ func (h *CampaignsHandler) moveCampaign(w http.ResponseWriter, r *http.Request) 
 	}
 	item, err := h.service.MoveCampaign(r.Context(), campaignID, input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "move", "marketing", "campaign", campaignID, nil, input)
@@ -258,7 +259,7 @@ func (h *CampaignsHandler) uploadAttachment(w http.ResponseWriter, r *http.Reque
 		for _, uploaded := range uploadedFiles {
 			_ = os.Remove(filepath.Join(h.uploadsDir, filepath.FromSlash(uploaded.FilePath)))
 		}
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -273,7 +274,7 @@ func (h *CampaignsHandler) listAttachments(w http.ResponseWriter, r *http.Reques
 	}
 	items, err := h.service.ListAttachments(r.Context(), campaignID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -290,7 +291,7 @@ func (h *CampaignsHandler) deleteAttachment(w http.ResponseWriter, r *http.Reque
 	}
 	item, err := h.service.DeleteAttachment(r.Context(), campaignID, attachmentID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	_ = os.Remove(filepath.Join(h.uploadsDir, filepath.FromSlash(item.FilePath)))
@@ -301,7 +302,7 @@ func (h *CampaignsHandler) deleteAttachment(w http.ResponseWriter, r *http.Reque
 func (h *CampaignsHandler) listColumns(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListColumns(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -319,7 +320,7 @@ func (h *CampaignsHandler) createColumn(w http.ResponseWriter, r *http.Request) 
 
 	item, err := h.service.CreateColumn(r.Context(), input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "marketing", "campaign_column", item.ID, nil, input)
@@ -339,7 +340,7 @@ func (h *CampaignsHandler) updateColumn(w http.ResponseWriter, r *http.Request) 
 	columnID := chi.URLParam(r, "columnID")
 	item, err := h.service.UpdateColumn(r.Context(), columnID, input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "marketing", "campaign_column", columnID, nil, input)
@@ -353,7 +354,7 @@ func (h *CampaignsHandler) deleteColumn(w http.ResponseWriter, r *http.Request) 
 
 	columnID := chi.URLParam(r, "columnID")
 	if err := h.service.DeleteColumn(r.Context(), columnID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "delete", "marketing", "campaign_column", columnID, nil, nil)
@@ -371,7 +372,7 @@ func (h *CampaignsHandler) reorderColumns(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := h.service.ReorderColumns(r.Context(), input); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "reorder", "marketing", "campaign_columns", "bulk", nil, input)
@@ -414,7 +415,7 @@ func (h *CampaignsHandler) parseListQuery(w http.ResponseWriter, r *http.Request
 	return query, true
 }
 
-func (h *CampaignsHandler) writeError(w http.ResponseWriter, err error) {
+func (h *CampaignsHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, marketingservice.ErrCampaignNotFound):
 		response.WriteError(w, http.StatusNotFound, "CAMPAIGN_NOT_FOUND", err.Error(), nil)
@@ -427,7 +428,7 @@ func (h *CampaignsHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, marketingservice.ErrCampaignColumnInUse):
 		response.WriteError(w, http.StatusConflict, "CAMPAIGN_COLUMN_IN_USE", err.Error(), nil)
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }
 

--- a/backend/internal/handler/marketing/campaigns_export.go
+++ b/backend/internal/handler/marketing/campaigns_export.go
@@ -22,7 +22,7 @@ func (h *CampaignsHandler) export(w http.ResponseWriter, r *http.Request) {
 
 	items, _, _, _, err := h.service.ListCampaigns(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -50,7 +50,7 @@ func (h *CampaignsHandler) export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 

--- a/backend/internal/handler/marketing/leads.go
+++ b/backend/internal/handler/marketing/leads.go
@@ -1,6 +1,7 @@
 package marketing
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -59,7 +60,7 @@ func (h *LeadsHandler) createLead(w http.ResponseWriter, r *http.Request) {
 
 	item, err := h.service.CreateLead(r.Context(), input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -75,7 +76,7 @@ func (h *LeadsHandler) listLeads(w http.ResponseWriter, r *http.Request) {
 
 	items, total, page, perPage, err := h.service.ListLeads(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -89,7 +90,7 @@ func (h *LeadsHandler) listLeads(w http.ResponseWriter, r *http.Request) {
 func (h *LeadsHandler) getLead(w http.ResponseWriter, r *http.Request) {
 	item, err := h.service.GetLead(r.Context(), chi.URLParam(r, "leadID"))
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, item, nil)
@@ -110,7 +111,7 @@ func (h *LeadsHandler) updateLead(w http.ResponseWriter, r *http.Request) {
 	leadID := chi.URLParam(r, "leadID")
 	item, err := h.service.UpdateLead(r.Context(), leadID, input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -121,7 +122,7 @@ func (h *LeadsHandler) updateLead(w http.ResponseWriter, r *http.Request) {
 func (h *LeadsHandler) deleteLead(w http.ResponseWriter, r *http.Request) {
 	leadID := chi.URLParam(r, "leadID")
 	if err := h.service.DeleteLead(r.Context(), leadID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "delete", "marketing", "lead", leadID, nil, nil)
@@ -131,7 +132,7 @@ func (h *LeadsHandler) deleteLead(w http.ResponseWriter, r *http.Request) {
 func (h *LeadsHandler) pipeline(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.Pipeline(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -152,7 +153,7 @@ func (h *LeadsHandler) moveStatus(w http.ResponseWriter, r *http.Request) {
 	leadID := chi.URLParam(r, "leadID")
 	item, err := h.service.MoveStatus(r.Context(), leadID, input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "move_status", "marketing", "lead", leadID, nil, input)
@@ -162,7 +163,7 @@ func (h *LeadsHandler) moveStatus(w http.ResponseWriter, r *http.Request) {
 func (h *LeadsHandler) listActivities(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListActivities(r.Context(), chi.URLParam(r, "leadID"))
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -183,7 +184,7 @@ func (h *LeadsHandler) createActivity(w http.ResponseWriter, r *http.Request) {
 	leadID := chi.URLParam(r, "leadID")
 	item, err := h.service.CreateActivity(r.Context(), leadID, input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "marketing", "lead_activity", item.ID, nil, input)
@@ -211,7 +212,7 @@ func (h *LeadsHandler) importCSV(w http.ResponseWriter, r *http.Request) {
 
 	summary, err := h.service.ImportCSV(r.Context(), file, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -222,7 +223,7 @@ func (h *LeadsHandler) importCSV(w http.ResponseWriter, r *http.Request) {
 func (h *LeadsHandler) summary(w http.ResponseWriter, r *http.Request) {
 	item, err := h.service.Summary(r.Context())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, item, nil)
@@ -264,7 +265,7 @@ func (h *LeadsHandler) parseListQuery(w http.ResponseWriter, r *http.Request) (m
 	return query, true
 }
 
-func (h *LeadsHandler) writeError(w http.ResponseWriter, err error) {
+func (h *LeadsHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, marketingservice.ErrLeadNotFound):
 		response.WriteError(w, http.StatusNotFound, "LEAD_NOT_FOUND", err.Error(), nil)
@@ -277,6 +278,6 @@ func (h *LeadsHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, marketingservice.ErrLeadImportLimitExceeded):
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"file": "maximum 10000 rows per import"})
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }

--- a/backend/internal/handler/marketing/leads_export.go
+++ b/backend/internal/handler/marketing/leads_export.go
@@ -22,7 +22,7 @@ func (h *LeadsHandler) export(w http.ResponseWriter, r *http.Request) {
 
 	items, _, _, _, err := h.service.ListLeads(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -50,7 +50,7 @@ func (h *LeadsHandler) export(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 

--- a/backend/internal/handler/marketing/overview.go
+++ b/backend/internal/handler/marketing/overview.go
@@ -18,7 +18,7 @@ func NewOverviewHandler(service *marketingservice.OverviewService) *OverviewHand
 func (h *OverviewHandler) Get(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.GetOverview(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(r.Context(), w, err, "An unexpected error occurred")
 		return
 	}
 

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -1,6 +1,7 @@
 package operational
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -58,7 +59,7 @@ func (h *KanbanHandler) createColumn(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.CreateColumn(r.Context(), projectID, input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -74,7 +75,7 @@ func (h *KanbanHandler) listColumns(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.ListColumns(r.Context(), projectID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -98,7 +99,7 @@ func (h *KanbanHandler) updateColumn(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.UpdateColumn(r.Context(), projectID, columnID, input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -117,7 +118,7 @@ func (h *KanbanHandler) deleteColumn(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.DeleteColumn(r.Context(), projectID, columnID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -137,7 +138,7 @@ func (h *KanbanHandler) reorderColumns(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.ReorderColumns(r.Context(), projectID, input); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -164,7 +165,7 @@ func (h *KanbanHandler) createTask(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.CreateTask(r.Context(), projectID, input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -180,7 +181,7 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.ListTasks(r.Context(), projectID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -210,7 +211,7 @@ func (h *KanbanHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.UpdateTask(r.Context(), projectID, taskID, input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -229,7 +230,7 @@ func (h *KanbanHandler) deleteTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.DeleteTask(r.Context(), projectID, taskID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -253,7 +254,7 @@ func (h *KanbanHandler) moveTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.MoveTask(r.Context(), projectID, taskID, input); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -275,7 +276,7 @@ func (h *KanbanHandler) decodeAndValidate(w http.ResponseWriter, r *http.Request
 	return true
 }
 
-func (h *KanbanHandler) writeError(w http.ResponseWriter, err error) {
+func (h *KanbanHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, operationalservice.ErrKanbanColumnNotFound):
 		response.WriteError(w, http.StatusNotFound, "KANBAN_COLUMN_NOT_FOUND", err.Error(), nil)
@@ -285,7 +286,7 @@ func (h *KanbanHandler) writeError(w http.ResponseWriter, err error) {
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"assignee_id": "must belong to the project"})
 	default:
 		slog.Error("unexpected kanban handler error", "error", err)
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }
 

--- a/backend/internal/handler/operational/overview.go
+++ b/backend/internal/handler/operational/overview.go
@@ -18,7 +18,7 @@ func NewOverviewHandler(service *operationalservice.OverviewService) *OverviewHa
 func (h *OverviewHandler) Get(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.GetOverview(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(r.Context(), w, err, "An unexpected error occurred")
 		return
 	}
 

--- a/backend/internal/handler/operational/projects.go
+++ b/backend/internal/handler/operational/projects.go
@@ -1,6 +1,7 @@
 package operational
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -68,7 +69,7 @@ func (h *ProjectsHandler) createProject(w http.ResponseWriter, r *http.Request) 
 
 	result, err := h.service.CreateProject(r.Context(), input, principal.UserID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -84,7 +85,7 @@ func (h *ProjectsHandler) listProjects(w http.ResponseWriter, r *http.Request) {
 
 	projects, total, page, perPage, err := h.service.ListProjects(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -103,7 +104,7 @@ func (h *ProjectsHandler) getProject(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.GetProject(r.Context(), projectID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -123,7 +124,7 @@ func (h *ProjectsHandler) updateProject(w http.ResponseWriter, r *http.Request) 
 
 	result, err := h.service.UpdateProject(r.Context(), projectID, input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -138,7 +139,7 @@ func (h *ProjectsHandler) deleteProject(w http.ResponseWriter, r *http.Request) 
 	}
 
 	if err := h.service.DeleteProject(r.Context(), projectID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -161,7 +162,7 @@ func (h *ProjectsHandler) mutateMembers(w http.ResponseWriter, r *http.Request) 
 
 	result, err := h.service.MutateProjectMember(r.Context(), projectID, input)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -172,7 +173,7 @@ func (h *ProjectsHandler) mutateMembers(w http.ResponseWriter, r *http.Request) 
 func (h *ProjectsHandler) listAvailableUsers(w http.ResponseWriter, r *http.Request) {
 	users, err := h.repo.ListActiveUsers(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list available users", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to list available users")
 		return
 	}
 
@@ -226,7 +227,7 @@ func (h *ProjectsHandler) parseListQuery(w http.ResponseWriter, r *http.Request)
 	return query, true
 }
 
-func (h *ProjectsHandler) writeError(w http.ResponseWriter, err error) {
+func (h *ProjectsHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, operationalservice.ErrProjectNotFound):
 		response.WriteError(w, http.StatusNotFound, "PROJECT_NOT_FOUND", err.Error(), nil)
@@ -237,7 +238,7 @@ func (h *ProjectsHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, operationalservice.ErrProjectMemberNotFound):
 		response.WriteError(w, http.StatusNotFound, "USER_NOT_FOUND", err.Error(), nil)
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }
 

--- a/backend/internal/handler/operational/projects_export.go
+++ b/backend/internal/handler/operational/projects_export.go
@@ -25,7 +25,7 @@ func (h *ProjectsHandler) exportList(w http.ResponseWriter, r *http.Request) {
 
 	items, _, _, _, err := h.service.ListProjects(r.Context(), query)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -53,7 +53,7 @@ func (h *ProjectsHandler) exportList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -71,24 +71,24 @@ func (h *ProjectsHandler) exportDetail(w http.ResponseWriter, r *http.Request) {
 	projectID := chi.URLParam(r, "projectID")
 	detail, err := h.service.GetProject(r.Context(), projectID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
 	columns, err := h.kanban.ListColumns(r.Context(), projectID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	tasks, err := h.kanban.ListTasks(r.Context(), projectID)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
 	payload, err := renderProjectDetailPDF(detail.Project, detail.Members, columns, tasks, exportutil.ResolveGeneratedBy(r.Context(), h.users))
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 

--- a/backend/internal/handler/operational/tracker.go
+++ b/backend/internal/handler/operational/tracker.go
@@ -1,6 +1,7 @@
 package operational
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -63,7 +64,7 @@ func (h *TrackerHandler) getConsent(w http.ResponseWriter, r *http.Request) {
 
 	consent, err := h.service.GetConsent(r.Context(), principal.UserID)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load tracker consent", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load tracker consent")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, consent, nil)
@@ -79,7 +80,7 @@ func (h *TrackerHandler) giveConsent(w http.ResponseWriter, r *http.Request) {
 	consent, err := h.service.GiveConsent(r.Context(), principal.UserID, platformmiddleware.ClientIPFromContext(r.Context()), time.Now())
 	if err != nil {
 		platformmiddleware.LoggerFromContext(r.Context()).Error("tracker give consent failed", "error", err, "user_id", principal.UserID)
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to save tracker consent", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to save tracker consent")
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "operational", "tracker_consent", principal.UserID, nil, consent)
@@ -96,7 +97,7 @@ func (h *TrackerHandler) revokeConsent(w http.ResponseWriter, r *http.Request) {
 	consent, err := h.service.RevokeConsent(r.Context(), principal.UserID, platformmiddleware.ClientIPFromContext(r.Context()), time.Now())
 	if err != nil {
 		platformmiddleware.LoggerFromContext(r.Context()).Error("tracker revoke consent failed", "error", err, "user_id", principal.UserID)
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to revoke tracker consent", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to revoke tracker consent")
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "operational", "tracker_consent", principal.UserID, nil, consent)
@@ -119,7 +120,7 @@ func (h *TrackerHandler) startSession(w http.ResponseWriter, r *http.Request) {
 
 	session, err := h.service.StartSession(r.Context(), principal.UserID, request, time.Now())
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusCreated, map[string]string{"session_id": session.ID}, nil)
@@ -146,7 +147,7 @@ func (h *TrackerHandler) endSession(w http.ResponseWriter, r *http.Request) {
 
 	session, err := h.service.EndSession(r.Context(), principal.UserID, chi.URLParam(r, "sessionID"), endedAt)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, session, nil)
@@ -166,7 +167,7 @@ func (h *TrackerHandler) heartbeat(w http.ResponseWriter, r *http.Request) {
 
 	entry, session, err := h.service.RecordHeartbeat(r.Context(), principal.UserID, request)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -190,7 +191,7 @@ func (h *TrackerHandler) batchEntries(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.RecordBatch(r.Context(), principal.UserID, request)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 
@@ -212,7 +213,7 @@ func (h *TrackerHandler) getMyActivity(w http.ResponseWriter, r *http.Request) {
 	activity, err := h.service.GetMyActivity(r.Context(), principal.UserID, dateFrom, dateTo)
 	if err != nil {
 		slog.Error("failed to load tracker activity", "error", err, "userID", principal.UserID)
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load tracker activity", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load tracker activity")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, activity, nil)
@@ -246,7 +247,7 @@ func (h *TrackerHandler) getTeamActivity(w http.ResponseWriter, r *http.Request)
 
 	activity, err := h.service.GetTeamActivity(r.Context(), dateFrom, dateTo, userID)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load team tracker activity", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load team tracker activity")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, activity, nil)
@@ -260,7 +261,7 @@ func (h *TrackerHandler) getUserActivity(w http.ResponseWriter, r *http.Request)
 
 	activity, err := h.service.GetUserActivity(r.Context(), chi.URLParam(r, "userID"), dateFrom, dateTo)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load user tracker activity", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load user tracker activity")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, activity, nil)
@@ -279,7 +280,7 @@ func (h *TrackerHandler) getSummary(w http.ResponseWriter, r *http.Request) {
 
 	summary, err := h.service.GetDailySummary(r.Context(), date)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load tracker summary", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load tracker summary")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, summary, nil)
@@ -288,7 +289,7 @@ func (h *TrackerHandler) getSummary(w http.ResponseWriter, r *http.Request) {
 func (h *TrackerHandler) listDomains(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListDomainCategories(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list tracker domains", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to list tracker domains")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -297,7 +298,7 @@ func (h *TrackerHandler) listDomains(w http.ResponseWriter, r *http.Request) {
 func (h *TrackerHandler) listObservedDomains(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListObservedDomains(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list tracked domains", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to list tracked domains")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -306,7 +307,7 @@ func (h *TrackerHandler) listObservedDomains(w http.ResponseWriter, r *http.Requ
 func (h *TrackerHandler) listConsentAudit(w http.ResponseWriter, r *http.Request) {
 	items, err := h.service.ListConsentAudit(r.Context())
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load tracker consent audit", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load tracker consent audit")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, items, nil)
@@ -320,7 +321,7 @@ func (h *TrackerHandler) createDomain(w http.ResponseWriter, r *http.Request) {
 
 	item, err := h.service.CreateDomainCategory(r.Context(), request)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create tracker domain", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to create tracker domain")
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "operational", "tracker_domain", item.ID, nil, item)
@@ -335,7 +336,7 @@ func (h *TrackerHandler) bulkClassifyObservedDomains(w http.ResponseWriter, r *h
 
 	result, err := h.service.BulkClassifyObservedDomains(r.Context(), request)
 	if err != nil {
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to bulk classify tracker domains", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to bulk classify tracker domains")
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "operational", "tracker_observed_domains", strings.Join(result.Domains, ","), nil, result)
@@ -350,7 +351,7 @@ func (h *TrackerHandler) updateDomain(w http.ResponseWriter, r *http.Request) {
 
 	item, err := h.service.UpdateDomainCategory(r.Context(), chi.URLParam(r, "domainID"), request)
 	if err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "operational", "tracker_domain", item.ID, nil, item)
@@ -360,7 +361,7 @@ func (h *TrackerHandler) updateDomain(w http.ResponseWriter, r *http.Request) {
 func (h *TrackerHandler) deleteDomain(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	if err := h.service.DeleteDomainCategory(r.Context(), domainID); err != nil {
-		h.writeError(w, err)
+		h.writeError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "delete", "operational", "tracker_domain", domainID, nil, nil)
@@ -380,7 +381,7 @@ func (h *TrackerHandler) decodeAndValidate(w http.ResponseWriter, r *http.Reques
 	return true
 }
 
-func (h *TrackerHandler) writeError(w http.ResponseWriter, err error) {
+func (h *TrackerHandler) writeError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, operationalservice.ErrConsentRequired):
 		response.WriteError(w, http.StatusForbidden, "CONSENT_REQUIRED", err.Error(), nil)
@@ -389,7 +390,7 @@ func (h *TrackerHandler) writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, operationalservice.ErrDomainCategoryNotFound):
 		response.WriteError(w, http.StatusNotFound, "DOMAIN_CATEGORY_NOT_FOUND", err.Error(), nil)
 	default:
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }
 

--- a/backend/internal/handler/operational/tracker_reminder.go
+++ b/backend/internal/handler/operational/tracker_reminder.go
@@ -39,7 +39,7 @@ func (h *TrackerReminderHandler) getConfig(w http.ResponseWriter, r *http.Reques
 	cfg, err := h.service.GetConfig(r.Context())
 	if err != nil {
 		platformmiddleware.LoggerFromContext(r.Context()).Error("tracker reminder get config failed", "error", err)
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load reminder config", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load reminder config")
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, h.toResponse(cfg), nil)
@@ -67,7 +67,7 @@ func (h *TrackerReminderHandler) updateConfig(w http.ResponseWriter, r *http.Req
 			return
 		}
 		platformmiddleware.LoggerFromContext(r.Context()).Error("tracker reminder update config failed", "error", err)
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update reminder config", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to update reminder config")
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "operational", "tracker_reminder_config", cfg.TenantID, before, cfg)
@@ -83,7 +83,7 @@ func (h *TrackerReminderHandler) sendTest(w http.ResponseWriter, r *http.Request
 	inApp, wa, waErr, err := h.service.SendTestReminder(r.Context(), principal.UserID)
 	if err != nil {
 		platformmiddleware.LoggerFromContext(r.Context()).Error("tracker reminder test dispatch failed", "error", err, "user_id", principal.UserID)
-		response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to send test reminder", nil)
+		response.WriteInternalError(r.Context(), w, err, "Failed to send test reminder")
 		return
 	}
 	res := operationaldto.TrackerReminderTestResponse{

--- a/backend/internal/handler/whatsapp/handler.go
+++ b/backend/internal/handler/whatsapp/handler.go
@@ -1,6 +1,7 @@
 package whatsapp
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -73,7 +74,7 @@ func (h *Handler) RegisterRoutes(router chi.Router) {
 func (h *Handler) getWAConfig(w http.ResponseWriter, r *http.Request) {
 	cfg, err := h.service.GetWAConfig(r.Context())
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, map[string]interface{}{
@@ -108,7 +109,7 @@ func (h *Handler) updateWAConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.service.UpdateWAConfig(r.Context(), cfg); err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 
@@ -201,7 +202,7 @@ func (h *Handler) listTemplates(w http.ResponseWriter, r *http.Request) {
 
 	templates, err := h.service.ListTemplates(r.Context(), category, triggerType)
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, templates, nil)
@@ -231,7 +232,7 @@ func (h *Handler) createTemplate(w http.ResponseWriter, r *http.Request) {
 		CreatedBy:          &principal.UserID,
 	})
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "operational", "wa_template", result.ID, nil, result)
@@ -241,7 +242,7 @@ func (h *Handler) createTemplate(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) generateDefaultTemplates(w http.ResponseWriter, r *http.Request) {
 	result, err := h.service.EnsureDefaultTemplates(r.Context())
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 
@@ -257,7 +258,7 @@ func (h *Handler) updateTemplate(w http.ResponseWriter, r *http.Request) {
 			response.WriteError(w, http.StatusNotFound, "TEMPLATE_NOT_FOUND", "Template not found", nil)
 			return
 		}
-		h.writeInternalError(w, previousErr)
+		h.writeInternalError(r.Context(), w, previousErr)
 		return
 	}
 
@@ -280,7 +281,7 @@ func (h *Handler) updateTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "operational", "wa_template", id, previous, result)
@@ -291,7 +292,7 @@ func (h *Handler) deleteTemplate(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "templateID")
 	previous, previousErr := h.service.GetTemplate(r.Context(), id)
 	if previousErr != nil && !errors.Is(previousErr, waservice.ErrTemplateNotFound) {
-		h.writeInternalError(w, previousErr)
+		h.writeInternalError(r.Context(), w, previousErr)
 		return
 	}
 	err := h.service.DeleteTemplate(r.Context(), id)
@@ -301,7 +302,7 @@ func (h *Handler) deleteTemplate(w http.ResponseWriter, r *http.Request) {
 	case errors.Is(err, waservice.ErrSystemTemplate):
 		response.WriteError(w, http.StatusForbidden, "SYSTEM_TEMPLATE", "Cannot delete system template", nil)
 	case err != nil:
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 	default:
 		platformmiddleware.AuditLog(r.Context(), "delete", "operational", "wa_template", id, previous, nil)
 		response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Template deleted"}, nil)
@@ -316,7 +317,7 @@ func (h *Handler) previewTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, map[string]string{"preview": preview}, nil)
@@ -327,7 +328,7 @@ func (h *Handler) previewTemplate(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) listSchedules(w http.ResponseWriter, r *http.Request) {
 	schedules, err := h.service.ListSchedules(r.Context())
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, schedules, nil)
@@ -356,7 +357,7 @@ func (h *Handler) createSchedule(w http.ResponseWriter, r *http.Request) {
 		CreatedBy:      &principal.UserID,
 	})
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "create", "operational", "wa_schedule", result.ID, nil, result)
@@ -371,7 +372,7 @@ func (h *Handler) updateSchedule(w http.ResponseWriter, r *http.Request) {
 			response.WriteError(w, http.StatusNotFound, "SCHEDULE_NOT_FOUND", "Schedule not found", nil)
 			return
 		}
-		h.writeInternalError(w, previousErr)
+		h.writeInternalError(r.Context(), w, previousErr)
 		return
 	}
 
@@ -394,7 +395,7 @@ func (h *Handler) updateSchedule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "operational", "wa_schedule", id, previous, result)
@@ -405,7 +406,7 @@ func (h *Handler) deleteSchedule(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "scheduleID")
 	previous, previousErr := h.service.GetSchedule(r.Context(), id)
 	if previousErr != nil && !errors.Is(previousErr, waservice.ErrScheduleNotFound) {
-		h.writeInternalError(w, previousErr)
+		h.writeInternalError(r.Context(), w, previousErr)
 		return
 	}
 	err := h.service.DeleteSchedule(r.Context(), id)
@@ -414,7 +415,7 @@ func (h *Handler) deleteSchedule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "delete", "operational", "wa_schedule", id, previous, nil)
@@ -451,7 +452,7 @@ func (h *Handler) toggleSchedule(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	platformmiddleware.AuditLog(r.Context(), "update", "operational", "wa_schedule", id, nil, result)
@@ -477,7 +478,7 @@ func (h *Handler) listLogs(w http.ResponseWriter, r *http.Request) {
 		Search:       q.Get("search"),
 	})
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 
@@ -499,7 +500,7 @@ func (h *Handler) getLogSummary(w http.ResponseWriter, r *http.Request) {
 	date := r.URL.Query().Get("date")
 	summary, err := h.service.GetLogSummary(r.Context(), date)
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, summary, nil)
@@ -549,7 +550,7 @@ func (h *Handler) getUserPhone(w http.ResponseWriter, r *http.Request) {
 
 	phone, err := h.service.GetUserPhone(r.Context(), principal.UserID)
 	if err != nil {
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, map[string]interface{}{"phone": phone}, nil)
@@ -573,7 +574,7 @@ func (h *Handler) updateUserPhone(w http.ResponseWriter, r *http.Request) {
 			response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"phone": "must use 08xx, 8xx, 628xx, or +628xx format"})
 			return
 		}
-		h.writeInternalError(w, err)
+		h.writeInternalError(r.Context(), w, err)
 		return
 	}
 	response.WriteJSON(w, http.StatusOK, map[string]string{"message": "Phone updated"}, nil)
@@ -593,8 +594,8 @@ func (h *Handler) decodeAndValidate(w http.ResponseWriter, r *http.Request, targ
 	return true
 }
 
-func (h *Handler) writeInternalError(w http.ResponseWriter, _ error) {
-	response.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred", nil)
+func (h *Handler) writeInternalError(ctx context.Context, w http.ResponseWriter, err error) {
+	response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 }
 
 func validationDetails(err error) map[string]string {

--- a/backend/internal/response/response.go
+++ b/backend/internal/response/response.go
@@ -1,7 +1,9 @@
 package response
 
 import (
+	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 )
 
@@ -35,6 +37,15 @@ func WriteError(w http.ResponseWriter, status int, code string, message string, 
 			Details: details,
 		},
 	})
+}
+
+// WriteInternalError logs the underlying error with the request context and
+// returns a 500 response with the standard INTERNAL_ERROR envelope. Handlers
+// MUST use this for unexpected/unhandled failures so server-side observability
+// captures every 500.
+func WriteInternalError(ctx context.Context, w http.ResponseWriter, err error, message string) {
+	slog.ErrorContext(ctx, "internal server error", "error", err, "user_message", message)
+	WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", message, nil)
 }
 
 func write(w http.ResponseWriter, status int, payload Envelope) {


### PR DESCRIPTION
## Summary
- Adds `response.WriteInternalError(ctx, w, err, message)` that writes the existing `INTERNAL_ERROR` envelope while emitting `slog.ErrorContext` with the underlying error.
- Replaces every direct `response.WriteError(w, 500, "INTERNAL_ERROR", ...)` site across `admin`, `auth`, `files`, `hris`, `marketing`, `operational` and `whatsapp` handlers with the new helper.
- Threads `context.Context` through `writeError` / `writeAuthError` / `writeRoleError` / `writeInternalError` helper methods so structured logs carry trace_id, request_id, and the authenticated principal that other context-aware loggers attach.

## Why
Per #72, most handler `default:` branches were silently dropping the underlying error and only returning the user-facing 500. Server logs had no trace, no error class, and no PII-safe stack hint, so debugging required the client to reproduce. Centralizing the helper makes "log on 500" a single point we can extend later (metrics, sentry, etc.) and prevents any future handler from forgetting it.

## Test plan
- [ ] `go build ./...` succeeds
- [ ] Trigger any handler 500 path (e.g. force a DB error in tracker) and confirm `slog` records `internal server error` with `error=`, `user_message=`, plus the existing context fields
- [ ] Confirm response envelope on the wire is unchanged (`{success:false, error:{code:"INTERNAL_ERROR", message:..., details:null}}`)

Closes #72

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>