### PR TITLE
feat(auth): gate self-registration with rotating code + domain allowlist

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -264,7 +264,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		fileshandler.New(filesService),
 		wahandler.New(whatsappService),
 	)
-	application.startBackgroundJobs(subscriptionsService, trackerService, trackerReminderService, reimbursementsService, whatsappService, emailDeliveryService)
+	application.startBackgroundJobs(authService, subscriptionsService, trackerService, trackerReminderService, reimbursementsService, whatsappService, emailDeliveryService)
 
 	return application, nil
 }
@@ -407,6 +407,10 @@ func (a *App) buildRouter(
 					admin.With(platformmiddleware.RequirePermission("admin:settings:manage")).Put("/settings/auto-create-employee", authHandler.UpdateAutoCreateEmployee)
 					admin.With(platformmiddleware.RequirePermission("admin:settings:manage")).Put("/settings/mail-delivery", authHandler.UpdateMailDelivery)
 					admin.With(platformmiddleware.RequirePermission("admin:settings:manage")).Put("/settings/reimbursement-reminder", authHandler.UpdateReimbursementReminder)
+
+					admin.With(platformmiddleware.SuperAdminMiddleware()).Get("/settings/registration", authHandler.GetRegistrationSettings)
+					admin.With(platformmiddleware.SuperAdminMiddleware()).Put("/settings/registration", authHandler.UpdateRegistrationSettings)
+					admin.With(platformmiddleware.SuperAdminMiddleware()).Post("/settings/registration/roll", authHandler.RollRegistrationCode)
 				})
 
 				protected.Route("/operational", func(module chi.Router) {
@@ -462,7 +466,7 @@ func (a *App) buildRouter(
 	return router
 }
 
-func (a *App) startBackgroundJobs(subscriptionsService *hrisservice.SubscriptionsService, trackerService *operationalservice.TrackerService, trackerReminderService *operationalservice.TrackerReminderService, reimbursementsService *hrisservice.ReimbursementsService, whatsappService *waservice.Service, emailDeliveryService *notificationsservice.EmailDeliveryService) {
+func (a *App) startBackgroundJobs(authService *authservice.Service, subscriptionsService *hrisservice.SubscriptionsService, trackerService *operationalservice.TrackerService, trackerReminderService *operationalservice.TrackerReminderService, reimbursementsService *hrisservice.ReimbursementsService, whatsappService *waservice.Service, emailDeliveryService *notificationsservice.EmailDeliveryService) {
 	ctx, cancel := context.WithCancel(context.Background())
 	a.backgroundCancel = cancel
 
@@ -500,6 +504,10 @@ func (a *App) startBackgroundJobs(subscriptionsService *hrisservice.Subscription
 			_, err := trackerService.PurgeOldData(tCtx, time.Now())
 			return err
 		})
+		runPerTenant("registration_auto_roll", func(tCtx context.Context, t tenant.Info) error {
+			_, _, err := authService.AutoRollRegistrationCodeIfExpired(tCtx, time.Now())
+			return err
+		})
 
 		for {
 			select {
@@ -511,6 +519,10 @@ func (a *App) startBackgroundJobs(subscriptionsService *hrisservice.Subscription
 				})
 				runPerTenant("tracker_retention", func(tCtx context.Context, t tenant.Info) error {
 					_, err := trackerService.PurgeOldData(tCtx, tickAt)
+					return err
+				})
+				runPerTenant("registration_auto_roll", func(tCtx context.Context, t tenant.Info) error {
+					_, _, err := authService.AutoRollRegistrationCodeIfExpired(tCtx, tickAt)
 					return err
 				})
 			}

--- a/backend/internal/dto/auth.go
+++ b/backend/internal/dto/auth.go
@@ -1,9 +1,21 @@
 package dto
 
 type RegisterRequest struct {
-	Email    string `json:"email" validate:"required,email"`
-	Password string `json:"password" validate:"required,min=8"`
-	FullName string `json:"full_name" validate:"required,min=3,max=120"`
+	Email            string `json:"email" validate:"required,email"`
+	Password         string `json:"password" validate:"required,min=8"`
+	FullName         string `json:"full_name" validate:"required,min=3,max=120"`
+	RegistrationCode string `json:"registration_code" validate:"required,min=8,max=128"`
+}
+
+type UpdateRegistrationSettingsRequest struct {
+	Enabled              bool     `json:"enabled"`
+	RotationIntervalDays int      `json:"rotation_interval_days" validate:"omitempty,min=1,max=90"`
+	AllowedEmailDomains  []string `json:"allowed_email_domains"`
+}
+
+type RollRegistrationCodeResponse struct {
+	Code     string      `json:"code"`
+	Settings interface{} `json:"settings"`
 }
 
 type LoginRequest struct {

--- a/backend/internal/handler/auth/admin_registration.go
+++ b/backend/internal/handler/auth/admin_registration.go
@@ -1,0 +1,69 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/kana-consultant/kantor/backend/internal/dto"
+	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
+	"github.com/kana-consultant/kantor/backend/internal/response"
+)
+
+func (h *Handler) GetRegistrationSettings(w http.ResponseWriter, r *http.Request) {
+	view, err := h.service.GetRegistrationSettings(r.Context())
+	if err != nil {
+		response.WriteInternalError(r.Context(), w, err, "Gagal memuat pengaturan registrasi")
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, view, nil)
+}
+
+func (h *Handler) UpdateRegistrationSettings(w http.ResponseWriter, r *http.Request) {
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Sesi login tidak ditemukan", nil)
+		return
+	}
+
+	previous, err := h.service.GetRegistrationSettings(r.Context())
+	if err != nil {
+		response.WriteInternalError(r.Context(), w, err, "Gagal memuat pengaturan registrasi")
+		return
+	}
+
+	var input dto.UpdateRegistrationSettingsRequest
+	if !h.decodeAndValidate(w, r, &input) {
+		return
+	}
+
+	updated, err := h.service.UpdateRegistrationSettings(r.Context(), principal.UserID, input)
+	if err != nil {
+		response.WriteInternalError(r.Context(), w, err, "Gagal menyimpan pengaturan registrasi")
+		return
+	}
+
+	platformmiddleware.AuditLog(r.Context(), "update", "admin", "system_setting", "registration", previous, updated)
+	response.WriteJSON(w, http.StatusOK, updated, nil)
+}
+
+func (h *Handler) RollRegistrationCode(w http.ResponseWriter, r *http.Request) {
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Sesi login tidak ditemukan", nil)
+		return
+	}
+
+	code, view, err := h.service.RollRegistrationCode(r.Context(), principal.UserID)
+	if err != nil {
+		response.WriteInternalError(r.Context(), w, err, "Gagal memutar kode registrasi")
+		return
+	}
+
+	platformmiddleware.AuditLog(r.Context(), "roll", "admin", "system_setting", "registration_code", nil, map[string]any{
+		"expires_at": view.CodeExpiresAt,
+	})
+
+	response.WriteJSON(w, http.StatusOK, dto.RollRegistrationCodeResponse{
+		Code:     code,
+		Settings: view,
+	}, nil)
+}

--- a/backend/internal/handler/auth/handler.go
+++ b/backend/internal/handler/auth/handler.go
@@ -143,6 +143,26 @@ func (h *Handler) register(w http.ResponseWriter, r *http.Request) {
 
 	result, err := h.service.Register(r.Context(), input, r.UserAgent(), clientIP(r))
 	if err != nil {
+		// Audit failed attempts (no user ID available).
+		reason := ""
+		switch {
+		case errors.Is(err, authservice.ErrRegistrationDisabled):
+			reason = "registration_disabled"
+		case errors.Is(err, authservice.ErrRegistrationCodeMissing):
+			reason = "code_missing"
+		case errors.Is(err, authservice.ErrRegistrationCodeExpired):
+			reason = "code_expired"
+		case errors.Is(err, authservice.ErrRegistrationCodeInvalid):
+			reason = "code_invalid"
+		case errors.Is(err, authservice.ErrRegistrationDomainDeny):
+			reason = "domain_denied"
+		}
+		if reason != "" {
+			platformmiddleware.AuditLog(r.Context(), "register_denied", "admin", "auth", "register", nil, map[string]any{
+				"email":  strings.ToLower(strings.TrimSpace(input.Email)),
+				"reason": reason,
+			})
+		}
 		h.writeAuthError(r.Context(), w, err)
 		return
 	}
@@ -349,6 +369,16 @@ func (h *Handler) writeAuthError(ctx context.Context, w http.ResponseWriter, err
 		response.WriteError(w, http.StatusServiceUnavailable, "PASSWORD_RESET_DISABLED", err.Error(), nil)
 	case errors.Is(err, authservice.ErrPasswordUnchanged):
 		response.WriteError(w, http.StatusBadRequest, "PASSWORD_UNCHANGED", err.Error(), nil)
+	case errors.Is(err, authservice.ErrRegistrationDisabled):
+		response.WriteError(w, http.StatusForbidden, "REGISTRATION_DISABLED", err.Error(), nil)
+	case errors.Is(err, authservice.ErrRegistrationCodeMissing):
+		response.WriteError(w, http.StatusBadRequest, "REGISTRATION_CODE_REQUIRED", err.Error(), map[string]string{"registration_code": "required"})
+	case errors.Is(err, authservice.ErrRegistrationCodeExpired):
+		response.WriteError(w, http.StatusForbidden, "REGISTRATION_CODE_EXPIRED", err.Error(), nil)
+	case errors.Is(err, authservice.ErrRegistrationCodeInvalid):
+		response.WriteError(w, http.StatusForbidden, "REGISTRATION_CODE_INVALID", err.Error(), nil)
+	case errors.Is(err, authservice.ErrRegistrationDomainDeny):
+		response.WriteError(w, http.StatusForbidden, "REGISTRATION_DOMAIN_DENIED", err.Error(), map[string]string{"email": err.Error()})
 	default:
 		response.WriteInternalError(ctx, w, err, "Terjadi kesalahan yang tidak terduga")
 	}

--- a/backend/internal/rbac/seeder.go
+++ b/backend/internal/rbac/seeder.go
@@ -201,6 +201,19 @@ func seedSettings(ctx context.Context, tx pgx.Tx, roleIDs map[string]string) err
 		return fmt.Errorf("marshal mail delivery setting: %w", err)
 	}
 
+	registrationJSON, err := json.Marshal(map[string]any{
+		"enabled":                false,
+		"code_hash":              "",
+		"code_expires_at":        nil,
+		"last_rolled_by":         nil,
+		"last_rolled_at":         nil,
+		"rotation_interval_days": 7,
+		"allowed_email_domains":  []string{},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal registration setting: %w", err)
+	}
+
 	reimbursementReminderJSON, err := json.Marshal(map[string]any{
 		"enabled": false,
 		"review": map[string]any{
@@ -270,6 +283,16 @@ func seedSettings(ctx context.Context, tx pgx.Tx, roleIDs map[string]string) err
 		"Konfigurasi reminder reimbursement tenant",
 	); err != nil {
 		return fmt.Errorf("seed reimbursement_reminder setting: %w", err)
+	}
+
+	if _, err := tx.Exec(
+		ctx,
+		query,
+		"registration",
+		string(registrationJSON),
+		"Konfigurasi self-registration: kode, domain allowlist, rotasi",
+	); err != nil {
+		return fmt.Errorf("seed registration setting: %w", err)
 	}
 
 	return nil

--- a/backend/internal/repository/auth/admin_rbac.go
+++ b/backend/internal/repository/auth/admin_rbac.go
@@ -141,6 +141,7 @@ type MailDeliverySettingRecord struct {
 
 type PublicAuthOptions struct {
 	ForgotPasswordEnabled bool `json:"forgot_password_enabled"`
+	RegistrationEnabled   bool `json:"registration_enabled"`
 }
 
 func (r *Repository) ListSettingsDepartments(ctx context.Context) ([]model.Department, error) {

--- a/backend/internal/repository/auth/registration.go
+++ b/backend/internal/repository/auth/registration.go
@@ -1,0 +1,155 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	repository "github.com/kana-consultant/kantor/backend/internal/repository"
+)
+
+const registrationSettingDescription = "Konfigurasi self-registration: kode, domain allowlist, rotasi"
+
+type RegistrationSettings struct {
+	Enabled              bool       `json:"enabled"`
+	CodeEncrypted        string     `json:"code_encrypted"`
+	CodeExpiresAt        *time.Time `json:"code_expires_at"`
+	LastRolledBy         *string    `json:"last_rolled_by"`
+	LastRolledAt         *time.Time `json:"last_rolled_at"`
+	RotationIntervalDays int        `json:"rotation_interval_days"`
+	AllowedEmailDomains  []string   `json:"allowed_email_domains"`
+}
+
+type RegistrationSettingsView struct {
+	Enabled              bool       `json:"enabled"`
+	HasCode              bool       `json:"has_code"`
+	Code                 *string    `json:"code,omitempty"`
+	CodeExpiresAt        *time.Time `json:"code_expires_at"`
+	LastRolledBy         *string    `json:"last_rolled_by"`
+	LastRolledByName     *string    `json:"last_rolled_by_name"`
+	LastRolledAt         *time.Time `json:"last_rolled_at"`
+	RotationIntervalDays int        `json:"rotation_interval_days"`
+	AllowedEmailDomains  []string   `json:"allowed_email_domains"`
+}
+
+func defaultRegistrationSettings() RegistrationSettings {
+	return RegistrationSettings{
+		Enabled:              false,
+		CodeEncrypted:        "",
+		CodeExpiresAt:        nil,
+		LastRolledBy:         nil,
+		LastRolledAt:         nil,
+		RotationIntervalDays: 7,
+		AllowedEmailDomains:  []string{},
+	}
+}
+
+func normalizeRegistrationSettings(s RegistrationSettings) RegistrationSettings {
+	n := s
+	n.CodeEncrypted = strings.TrimSpace(n.CodeEncrypted)
+	if n.RotationIntervalDays < 1 {
+		n.RotationIntervalDays = 7
+	}
+	if n.RotationIntervalDays > 90 {
+		n.RotationIntervalDays = 90
+	}
+
+	if n.AllowedEmailDomains == nil {
+		n.AllowedEmailDomains = []string{}
+	}
+	cleaned := make([]string, 0, len(n.AllowedEmailDomains))
+	seen := make(map[string]struct{}, len(n.AllowedEmailDomains))
+	for _, d := range n.AllowedEmailDomains {
+		domain := strings.ToLower(strings.TrimSpace(d))
+		domain = strings.TrimPrefix(domain, "@")
+		if domain == "" {
+			continue
+		}
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		cleaned = append(cleaned, domain)
+	}
+	n.AllowedEmailDomains = cleaned
+
+	return n
+}
+
+func (s RegistrationSettings) View() RegistrationSettingsView {
+	return RegistrationSettingsView{
+		Enabled:              s.Enabled,
+		HasCode:              strings.TrimSpace(s.CodeEncrypted) != "",
+		Code:                 nil,
+		CodeExpiresAt:        s.CodeExpiresAt,
+		LastRolledBy:         s.LastRolledBy,
+		LastRolledByName:     nil,
+		LastRolledAt:         s.LastRolledAt,
+		RotationIntervalDays: s.RotationIntervalDays,
+		AllowedEmailDomains:  s.AllowedEmailDomains,
+	}
+}
+
+// ResolveUserFullName returns the user's full_name for the given UUID within
+// the current tenant context. Used to enrich registration settings view.
+func (r *Repository) ResolveUserFullName(ctx context.Context, userID string) (string, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var fullName string
+	err := repository.DB(ctx, r.db).QueryRow(ctx, `SELECT full_name FROM users WHERE id = $1::uuid`, userID).Scan(&fullName)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", ErrNotFound
+		}
+		return "", err
+	}
+	return fullName, nil
+}
+
+func (r *Repository) GetRegistrationSettings(ctx context.Context) (RegistrationSettings, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var raw []byte
+	err := repository.DB(ctx, r.db).QueryRow(ctx, `SELECT value FROM system_settings WHERE key = 'registration'`).Scan(&raw)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return defaultRegistrationSettings(), nil
+		}
+		return RegistrationSettings{}, err
+	}
+
+	setting := defaultRegistrationSettings()
+	if err := json.Unmarshal(raw, &setting); err != nil {
+		return RegistrationSettings{}, err
+	}
+	return normalizeRegistrationSettings(setting), nil
+}
+
+func (r *Repository) UpdateRegistrationSettings(ctx context.Context, updatedBy string, setting RegistrationSettings) error {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	normalized := normalizeRegistrationSettings(setting)
+	raw, err := json.Marshal(normalized)
+	if err != nil {
+		return err
+	}
+
+	_, err = repository.DB(ctx, r.db).Exec(ctx, `
+		INSERT INTO system_settings (key, value, description, updated_by, updated_at)
+		VALUES ('registration', $1::jsonb, $2, NULLIF($3, '')::uuid, NOW())
+		ON CONFLICT (tenant_id, key) DO UPDATE
+		SET value = EXCLUDED.value,
+		    description = EXCLUDED.description,
+		    updated_by = EXCLUDED.updated_by,
+		    updated_at = NOW()
+	`, string(raw), registrationSettingDescription, updatedBy)
+	return err
+}
+

--- a/backend/internal/repository/auth/settings_mail.go
+++ b/backend/internal/repository/auth/settings_mail.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -133,8 +134,21 @@ func (r *Repository) GetPublicAuthOptions(ctx context.Context) (PublicAuthOption
 		return PublicAuthOptions{}, err
 	}
 
+	registration, err := r.GetRegistrationSettings(ctx)
+	if err != nil {
+		return PublicAuthOptions{}, err
+	}
+
+	// Registration requires both the feature toggle and a live (non-expired) code
+	// so the UI never shows a register form the backend will reject outright.
+	registrationReady := registration.Enabled &&
+		strings.TrimSpace(registration.CodeEncrypted) != "" &&
+		registration.CodeExpiresAt != nil &&
+		registration.CodeExpiresAt.After(time.Now().UTC())
+
 	return PublicAuthOptions{
 		ForgotPasswordEnabled: setting.ForgotPasswordEnabled(),
+		RegistrationEnabled:   registrationReady,
 	}, nil
 }
 

--- a/backend/internal/service/auth/registration.go
+++ b/backend/internal/service/auth/registration.go
@@ -1,0 +1,270 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/kana-consultant/kantor/backend/internal/dto"
+	authrepo "github.com/kana-consultant/kantor/backend/internal/repository/auth"
+)
+
+const (
+	registrationCodeByteLen   = 18 // 24 base64 chars
+	registrationMinRotationDs = 1
+	registrationMaxRotationDs = 90
+)
+
+var (
+	ErrRegistrationDisabled    = errors.New("registrasi mandiri tidak diaktifkan")
+	ErrRegistrationCodeMissing = errors.New("kode registrasi wajib diisi")
+	ErrRegistrationCodeExpired = errors.New("kode registrasi sudah kedaluwarsa, hubungi admin")
+	ErrRegistrationCodeInvalid = errors.New("kode registrasi tidak valid")
+	ErrRegistrationDomainDeny  = errors.New("domain email tidak diizinkan untuk registrasi")
+	errRegistrationNoEncrypter = errors.New("encrypter for registration code is not configured")
+)
+
+func (s *Service) GetRegistrationSettings(ctx context.Context) (authrepo.RegistrationSettingsView, error) {
+	setting, err := s.repo.GetRegistrationSettings(ctx)
+	if err != nil {
+		return authrepo.RegistrationSettingsView{}, err
+	}
+	return s.enrichRegistrationView(ctx, setting), nil
+}
+
+// enrichRegistrationView decorates the raw settings with derived fields —
+// the plaintext code (decrypted) and the rolled-by user full name.
+func (s *Service) enrichRegistrationView(ctx context.Context, setting authrepo.RegistrationSettings) authrepo.RegistrationSettingsView {
+	view := setting.View()
+
+	if view.LastRolledBy != nil {
+		id := strings.TrimSpace(*view.LastRolledBy)
+		if id != "" {
+			if name, err := s.repo.ResolveUserFullName(ctx, id); err == nil {
+				trimmed := strings.TrimSpace(name)
+				if trimmed != "" {
+					view.LastRolledByName = &trimmed
+				}
+			}
+		}
+	}
+
+	if plaintext, err := s.decryptRegistrationCode(setting.CodeEncrypted); err == nil && plaintext != "" {
+		view.Code = &plaintext
+	}
+
+	return view
+}
+
+func (s *Service) UpdateRegistrationSettings(ctx context.Context, updatedBy string, input dto.UpdateRegistrationSettingsRequest) (authrepo.RegistrationSettingsView, error) {
+	existing, err := s.repo.GetRegistrationSettings(ctx)
+	if err != nil {
+		return authrepo.RegistrationSettingsView{}, err
+	}
+
+	updated := existing
+	updated.Enabled = input.Enabled
+	if input.RotationIntervalDays > 0 {
+		updated.RotationIntervalDays = input.RotationIntervalDays
+	}
+	updated.AllowedEmailDomains = input.AllowedEmailDomains
+
+	if err := s.repo.UpdateRegistrationSettings(ctx, updatedBy, updated); err != nil {
+		return authrepo.RegistrationSettingsView{}, err
+	}
+
+	refreshed, err := s.repo.GetRegistrationSettings(ctx)
+	if err != nil {
+		return authrepo.RegistrationSettingsView{}, err
+	}
+	return s.enrichRegistrationView(ctx, refreshed), nil
+}
+
+func (s *Service) RollRegistrationCode(ctx context.Context, rolledBy string) (string, authrepo.RegistrationSettingsView, error) {
+	if s.encrypter == nil {
+		return "", authrepo.RegistrationSettingsView{}, errRegistrationNoEncrypter
+	}
+
+	existing, err := s.repo.GetRegistrationSettings(ctx)
+	if err != nil {
+		return "", authrepo.RegistrationSettingsView{}, err
+	}
+
+	rawCode, err := generateRegistrationCode()
+	if err != nil {
+		return "", authrepo.RegistrationSettingsView{}, err
+	}
+
+	ciphertext, err := s.encrypter.EncryptString(rawCode)
+	if err != nil {
+		return "", authrepo.RegistrationSettingsView{}, err
+	}
+
+	now := time.Now().UTC()
+	interval := clampRotationInterval(existing.RotationIntervalDays)
+	expires := now.Add(time.Duration(interval) * 24 * time.Hour)
+
+	updated := existing
+	updated.CodeEncrypted = ciphertext
+	updated.CodeExpiresAt = &expires
+	updated.LastRolledAt = &now
+	trimmedBy := strings.TrimSpace(rolledBy)
+	if trimmedBy != "" {
+		updated.LastRolledBy = &trimmedBy
+	} else {
+		updated.LastRolledBy = nil
+	}
+	updated.RotationIntervalDays = interval
+
+	if err := s.repo.UpdateRegistrationSettings(ctx, trimmedBy, updated); err != nil {
+		return "", authrepo.RegistrationSettingsView{}, err
+	}
+
+	refreshed, err := s.repo.GetRegistrationSettings(ctx)
+	if err != nil {
+		return "", authrepo.RegistrationSettingsView{}, err
+	}
+	return rawCode, s.enrichRegistrationView(ctx, refreshed), nil
+}
+
+// AutoRollRegistrationCodeIfExpired rotates the code when enabled and either
+// unset or expired. Returns (rolled, settingsView, err). No-op otherwise.
+func (s *Service) AutoRollRegistrationCodeIfExpired(ctx context.Context, now time.Time) (bool, authrepo.RegistrationSettingsView, error) {
+	existing, err := s.repo.GetRegistrationSettings(ctx)
+	if err != nil {
+		return false, authrepo.RegistrationSettingsView{}, err
+	}
+	if !existing.Enabled {
+		return false, s.enrichRegistrationView(ctx, existing), nil
+	}
+
+	hasCode := strings.TrimSpace(existing.CodeEncrypted) != ""
+	expired := existing.CodeExpiresAt == nil || !existing.CodeExpiresAt.After(now.UTC())
+	if hasCode && !expired {
+		return false, s.enrichRegistrationView(ctx, existing), nil
+	}
+
+	if s.encrypter == nil {
+		return false, s.enrichRegistrationView(ctx, existing), errRegistrationNoEncrypter
+	}
+
+	rawCode, err := generateRegistrationCode()
+	if err != nil {
+		return false, authrepo.RegistrationSettingsView{}, err
+	}
+	ciphertext, err := s.encrypter.EncryptString(rawCode)
+	if err != nil {
+		return false, authrepo.RegistrationSettingsView{}, err
+	}
+
+	interval := clampRotationInterval(existing.RotationIntervalDays)
+	nowUTC := now.UTC()
+	expires := nowUTC.Add(time.Duration(interval) * 24 * time.Hour)
+
+	updated := existing
+	updated.CodeEncrypted = ciphertext
+	updated.CodeExpiresAt = &expires
+	updated.LastRolledAt = &nowUTC
+	updated.LastRolledBy = nil
+	updated.RotationIntervalDays = interval
+
+	if err := s.repo.UpdateRegistrationSettings(ctx, "", updated); err != nil {
+		return false, authrepo.RegistrationSettingsView{}, err
+	}
+
+	refreshed, err := s.repo.GetRegistrationSettings(ctx)
+	if err != nil {
+		return false, authrepo.RegistrationSettingsView{}, err
+	}
+	return true, s.enrichRegistrationView(ctx, refreshed), nil
+}
+
+func (s *Service) validateRegistrationPolicy(ctx context.Context, email string, rawCode string) error {
+	setting, err := s.repo.GetRegistrationSettings(ctx)
+	if err != nil {
+		return err
+	}
+
+	if !setting.Enabled {
+		return ErrRegistrationDisabled
+	}
+
+	trimmedCode := strings.TrimSpace(rawCode)
+	if trimmedCode == "" {
+		return ErrRegistrationCodeMissing
+	}
+
+	if strings.TrimSpace(setting.CodeEncrypted) == "" {
+		return ErrRegistrationCodeInvalid
+	}
+	if setting.CodeExpiresAt == nil || !setting.CodeExpiresAt.After(time.Now().UTC()) {
+		return ErrRegistrationCodeExpired
+	}
+
+	storedPlain, err := s.decryptRegistrationCode(setting.CodeEncrypted)
+	if err != nil || storedPlain == "" {
+		return ErrRegistrationCodeInvalid
+	}
+	if subtle.ConstantTimeCompare([]byte(storedPlain), []byte(trimmedCode)) != 1 {
+		return ErrRegistrationCodeInvalid
+	}
+
+	if len(setting.AllowedEmailDomains) > 0 {
+		domain := extractEmailDomain(email)
+		if domain == "" || !domainAllowed(domain, setting.AllowedEmailDomains) {
+			return ErrRegistrationDomainDeny
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) decryptRegistrationCode(ciphertext string) (string, error) {
+	if strings.TrimSpace(ciphertext) == "" {
+		return "", nil
+	}
+	if s.encrypter == nil {
+		return "", errRegistrationNoEncrypter
+	}
+	return s.encrypter.DecryptString(ciphertext)
+}
+
+func clampRotationInterval(days int) int {
+	if days < registrationMinRotationDs {
+		return 7
+	}
+	if days > registrationMaxRotationDs {
+		return registrationMaxRotationDs
+	}
+	return days
+}
+
+func generateRegistrationCode() (string, error) {
+	entropy := make([]byte, registrationCodeByteLen)
+	if _, err := rand.Read(entropy); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(entropy), nil
+}
+
+func extractEmailDomain(email string) string {
+	at := strings.LastIndex(email, "@")
+	if at < 0 || at == len(email)-1 {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(email[at+1:]))
+}
+
+func domainAllowed(domain string, allowed []string) bool {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	for _, d := range allowed {
+		if strings.EqualFold(strings.TrimSpace(d), domain) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -87,6 +87,9 @@ type authRepository interface {
 	GetReimbursementReminderSetting(ctx context.Context) (model.ReimbursementReminderSetting, error)
 	GetTenantPrimaryDomain(ctx context.Context) (string, error)
 	GetPublicAuthOptions(ctx context.Context) (authrepo.PublicAuthOptions, error)
+	GetRegistrationSettings(ctx context.Context) (authrepo.RegistrationSettings, error)
+	UpdateRegistrationSettings(ctx context.Context, updatedBy string, setting authrepo.RegistrationSettings) error
+	ResolveUserFullName(ctx context.Context, userID string) (string, error)
 	UpdateDefaultRoles(ctx context.Context, updatedBy string, mapping map[string]*string) error
 	UpdateAutoCreateEmployee(ctx context.Context, updatedBy string, setting authrepo.AutoCreateEmployeeSetting) error
 	UpdateMailDelivery(ctx context.Context, updatedBy string, setting authrepo.MailDeliverySettingRecord) error
@@ -186,6 +189,11 @@ func (s *Service) EnsureSeedUserWithRoles(ctx context.Context, params authrepo.C
 }
 
 func (s *Service) Register(ctx context.Context, input dto.RegisterRequest, userAgent string, ipAddress string) (AuthResult, error) {
+	normalizedEmail := strings.ToLower(strings.TrimSpace(input.Email))
+	if err := s.validateRegistrationPolicy(ctx, normalizedEmail, input.RegistrationCode); err != nil {
+		return AuthResult{}, err
+	}
+
 	defaultRoles, err := s.repo.GetDefaultRoleAssignments(ctx)
 	if err != nil {
 		return AuthResult{}, err
@@ -197,7 +205,7 @@ func (s *Service) Register(ctx context.Context, input dto.RegisterRequest, userA
 	}
 
 	user, err := s.repo.CreateUserWithRoles(ctx, authrepo.CreateUserParams{
-		Email:        strings.ToLower(strings.TrimSpace(input.Email)),
+		Email:        normalizedEmail,
 		PasswordHash: passwordHash,
 		FullName:     strings.TrimSpace(input.FullName),
 	}, defaultRoles)

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -14,6 +14,7 @@ import {
   BarChart3,
   UserPlus,
   Shield,
+  ShieldCheck,
   ScrollText,
   Settings2,
 } from "lucide-react";
@@ -196,6 +197,15 @@ export function Sidebar({ collapsed = false, mobile = false, onNavigate, onToggl
         permission: permissions.adminSettingsView,
       },
     ].filter((item) => hasPermission(item.permission));
+
+    if (isSuperAdmin) {
+      adminItems.push({
+        to: "/admin/registration",
+        label: "Registrasi",
+        icon: ShieldCheck,
+        permission: "__super_admin__",
+      });
+    }
 
     if (adminItems.length > 0) {
       visibleSections.push({

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as AuthenticatedHrisDepartmentsRouteImport } from './routes/_auth
 import { Route as AuthenticatedAdminUsersRouteImport } from './routes/_authenticated/admin/users'
 import { Route as AuthenticatedAdminSettingsRouteImport } from './routes/_authenticated/admin/settings'
 import { Route as AuthenticatedAdminRolesRouteImport } from './routes/_authenticated/admin/roles'
+import { Route as AuthenticatedAdminRegistrationRouteImport } from './routes/_authenticated/admin/registration'
 import { Route as AuthenticatedAdminAuditLogsRouteImport } from './routes/_authenticated/admin/audit-logs'
 import { Route as AuthenticatedOperationalProjectsIndexRouteImport } from './routes/_authenticated/operational/projects/index'
 import { Route as AuthenticatedHrisReimbursementsIndexRouteImport } from './routes/_authenticated/hris/reimbursements/index'
@@ -187,6 +188,12 @@ const AuthenticatedAdminRolesRoute = AuthenticatedAdminRolesRouteImport.update({
   path: '/admin/roles',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedAdminRegistrationRoute =
+  AuthenticatedAdminRegistrationRouteImport.update({
+    id: '/admin/registration',
+    path: '/admin/registration',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAdminAuditLogsRoute =
   AuthenticatedAdminAuditLogsRouteImport.update({
     id: '/admin/audit-logs',
@@ -239,6 +246,7 @@ export interface FileRoutesByFullPath {
   '/forbidden': typeof AuthenticatedForbiddenRoute
   '/profile': typeof AuthenticatedProfileRoute
   '/admin/audit-logs': typeof AuthenticatedAdminAuditLogsRoute
+  '/admin/registration': typeof AuthenticatedAdminRegistrationRoute
   '/admin/roles': typeof AuthenticatedAdminRolesRoute
   '/admin/settings': typeof AuthenticatedAdminSettingsRoute
   '/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -273,6 +281,7 @@ export interface FileRoutesByTo {
   '/forbidden': typeof AuthenticatedForbiddenRoute
   '/profile': typeof AuthenticatedProfileRoute
   '/admin/audit-logs': typeof AuthenticatedAdminAuditLogsRoute
+  '/admin/registration': typeof AuthenticatedAdminRegistrationRoute
   '/admin/roles': typeof AuthenticatedAdminRolesRoute
   '/admin/settings': typeof AuthenticatedAdminSettingsRoute
   '/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -309,6 +318,7 @@ export interface FileRoutesById {
   '/_authenticated/forbidden': typeof AuthenticatedForbiddenRoute
   '/_authenticated/profile': typeof AuthenticatedProfileRoute
   '/_authenticated/admin/audit-logs': typeof AuthenticatedAdminAuditLogsRoute
+  '/_authenticated/admin/registration': typeof AuthenticatedAdminRegistrationRoute
   '/_authenticated/admin/roles': typeof AuthenticatedAdminRolesRoute
   '/_authenticated/admin/settings': typeof AuthenticatedAdminSettingsRoute
   '/_authenticated/admin/users': typeof AuthenticatedAdminUsersRoute
@@ -345,6 +355,7 @@ export interface FileRouteTypes {
     | '/forbidden'
     | '/profile'
     | '/admin/audit-logs'
+    | '/admin/registration'
     | '/admin/roles'
     | '/admin/settings'
     | '/admin/users'
@@ -379,6 +390,7 @@ export interface FileRouteTypes {
     | '/forbidden'
     | '/profile'
     | '/admin/audit-logs'
+    | '/admin/registration'
     | '/admin/roles'
     | '/admin/settings'
     | '/admin/users'
@@ -414,6 +426,7 @@ export interface FileRouteTypes {
     | '/_authenticated/forbidden'
     | '/_authenticated/profile'
     | '/_authenticated/admin/audit-logs'
+    | '/_authenticated/admin/registration'
     | '/_authenticated/admin/roles'
     | '/_authenticated/admin/settings'
     | '/_authenticated/admin/users'
@@ -633,6 +646,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminRolesRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/admin/registration': {
+      id: '/_authenticated/admin/registration'
+      path: '/admin/registration'
+      fullPath: '/admin/registration'
+      preLoaderRoute: typeof AuthenticatedAdminRegistrationRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/admin/audit-logs': {
       id: '/_authenticated/admin/audit-logs'
       path: '/admin/audit-logs'
@@ -689,6 +709,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedForbiddenRoute: typeof AuthenticatedForbiddenRoute
   AuthenticatedProfileRoute: typeof AuthenticatedProfileRoute
   AuthenticatedAdminAuditLogsRoute: typeof AuthenticatedAdminAuditLogsRoute
+  AuthenticatedAdminRegistrationRoute: typeof AuthenticatedAdminRegistrationRoute
   AuthenticatedAdminRolesRoute: typeof AuthenticatedAdminRolesRoute
   AuthenticatedAdminSettingsRoute: typeof AuthenticatedAdminSettingsRoute
   AuthenticatedAdminUsersRoute: typeof AuthenticatedAdminUsersRoute
@@ -719,6 +740,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedForbiddenRoute: AuthenticatedForbiddenRoute,
   AuthenticatedProfileRoute: AuthenticatedProfileRoute,
   AuthenticatedAdminAuditLogsRoute: AuthenticatedAdminAuditLogsRoute,
+  AuthenticatedAdminRegistrationRoute: AuthenticatedAdminRegistrationRoute,
   AuthenticatedAdminRolesRoute: AuthenticatedAdminRolesRoute,
   AuthenticatedAdminSettingsRoute: AuthenticatedAdminSettingsRoute,
   AuthenticatedAdminUsersRoute: AuthenticatedAdminUsersRoute,

--- a/frontend/src/routes/_authenticated/admin/registration.tsx
+++ b/frontend/src/routes/_authenticated/admin/registration.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useState } from "react";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Copy, Eye, EyeOff, RefreshCw, Save, ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { ApiError } from "@/lib/api-client";
+import { ensureModuleAccess } from "@/lib/rbac";
+import { useAuthStore } from "@/stores/auth-store";
+import {
+  adminRbacKeys,
+  getRegistrationSettings,
+  rollRegistrationCode,
+  updateRegistrationSettings,
+  type RegistrationSettingsView,
+} from "@/services/admin-rbac";
+import { toast } from "@/stores/toast-store";
+
+export const Route = createFileRoute("/_authenticated/admin/registration")({
+  beforeLoad: async () => {
+    await ensureModuleAccess("admin");
+    const session = useAuthStore.getState().session;
+    if (!session?.is_super_admin) {
+      throw redirect({ to: "/admin/audit-logs" });
+    }
+  },
+  component: AdminRegistrationPage,
+});
+
+const registrationKey = ["admin-rbac", "registration"] as const;
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "-";
+  try {
+    return new Date(value).toLocaleString("id-ID", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    });
+  } catch {
+    return value;
+  }
+}
+
+function AdminRegistrationPage() {
+  const queryClient = useQueryClient();
+
+  const settingsQuery = useQuery({
+    queryKey: registrationKey,
+    queryFn: getRegistrationSettings,
+  });
+
+  const [enabled, setEnabled] = useState(false);
+  const [rotationDays, setRotationDays] = useState(7);
+  const [domainsInput, setDomainsInput] = useState("");
+  const [codeVisible, setCodeVisible] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!settingsQuery.data) return;
+    setEnabled(settingsQuery.data.enabled);
+    setRotationDays(settingsQuery.data.rotation_interval_days);
+    setDomainsInput(settingsQuery.data.allowed_email_domains.join(", "));
+  }, [settingsQuery.data]);
+
+  const saveMutation = useMutation({
+    mutationFn: updateRegistrationSettings,
+    onSuccess: (data) => {
+      queryClient.setQueryData<RegistrationSettingsView>(registrationKey, data);
+      void queryClient.invalidateQueries({ queryKey: adminRbacKeys.settings() });
+      toast.success("Pengaturan registrasi disimpan", "");
+      setFormError(null);
+    },
+    onError: (error) => {
+      setFormError(error instanceof ApiError ? error.message : "Gagal menyimpan pengaturan");
+    },
+  });
+
+  const rollMutation = useMutation({
+    mutationFn: rollRegistrationCode,
+    onSuccess: (data) => {
+      queryClient.setQueryData<RegistrationSettingsView>(registrationKey, data.settings);
+      setCodeVisible(true);
+      toast.success("Kode registrasi diperbarui", "");
+    },
+    onError: (error) => {
+      toast.error(
+        "Gagal memutar kode",
+        error instanceof ApiError ? error.message : "Terjadi kesalahan",
+      );
+    },
+  });
+
+  const onSave = () => {
+    const normalizedDomains = domainsInput
+      .split(",")
+      .map((d) => d.trim().replace(/^@/, "").toLowerCase())
+      .filter((d) => d.length > 0);
+
+    saveMutation.mutate({
+      enabled,
+      rotation_interval_days: rotationDays,
+      allowed_email_domains: normalizedDomains,
+    });
+  };
+
+  const onCopy = async () => {
+    const code = settingsQuery.data?.code ?? null;
+    if (!code) return;
+    if (navigator.clipboard && window.isSecureContext) {
+      try {
+        await navigator.clipboard.writeText(code);
+        toast.success("Kode disalin", "");
+        return;
+      } catch {
+        // fall through to legacy path
+      }
+    }
+    // Legacy fallback for non-secure contexts (HTTP on non-localhost).
+    const textarea = document.createElement("textarea");
+    textarea.value = code;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+    let ok = false;
+    try {
+      ok = document.execCommand("copy");
+    } catch {
+      ok = false;
+    }
+    document.body.removeChild(textarea);
+    if (ok) {
+      toast.success("Kode disalin", "");
+    } else {
+      toast.error("Gagal menyalin kode", "Salin manual dari kotak di atas.");
+    }
+  };
+
+  const data = settingsQuery.data;
+  const hasCode = data?.has_code ?? false;
+  const code = data?.code ?? null;
+  const expiresAt = data?.code_expires_at ?? null;
+  const expired = expiresAt ? new Date(expiresAt).getTime() <= Date.now() : true;
+  const maskedCode = code ? "•".repeat(Math.min(code.length, 24)) : "";
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-ops-light text-ops">
+          <ShieldCheck className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-[20px] font-[700] text-text-primary">Pengaturan Registrasi</h1>
+          <p className="text-[13px] text-text-secondary">
+            Kelola kode registrasi dan domain email yang diizinkan untuk self-registration.
+          </p>
+        </div>
+      </div>
+
+      <Card className="space-y-5 p-6">
+        <div className="space-y-3">
+          <h2 className="text-[15px] font-[700] text-text-primary">Aktivasi</h2>
+          <label className="flex items-start gap-3">
+            <input
+              checked={enabled}
+              className="mt-1 h-4 w-4 rounded border-border text-ops focus:ring-ops"
+              onChange={(event) => setEnabled(event.target.checked)}
+              type="checkbox"
+            />
+            <span className="text-[14px] text-text-primary">
+              Aktifkan self-registration.
+              <span className="block text-[12px] text-text-secondary">
+                Form registrasi publik hanya muncul saat aktif dan kode masih valid.
+              </span>
+            </span>
+          </label>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-[13px] font-[600] text-text-primary">
+            Rotasi otomatis (hari)
+          </label>
+          <Input
+            className="h-10 w-32 rounded-[6px]"
+            max={90}
+            min={1}
+            onChange={(event) => setRotationDays(Number(event.target.value) || 7)}
+            type="number"
+            value={rotationDays}
+          />
+          <p className="text-[12px] text-text-secondary">
+            Kode di-roll otomatis setelah periode ini jika sudah kadaluwarsa. Default 7 hari.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-[13px] font-[600] text-text-primary">
+            Domain email yang diizinkan
+          </label>
+          <Input
+            className="h-10 rounded-[6px]"
+            onChange={(event) => setDomainsInput(event.target.value)}
+            placeholder="perusahaan.com, partner.co.id"
+            value={domainsInput}
+          />
+          <p className="text-[12px] text-text-secondary">
+            Pisahkan dengan koma. Kosongkan untuk mengizinkan semua domain.
+          </p>
+        </div>
+
+        {formError ? (
+          <div className="rounded-[8px] border border-error/20 bg-error-light px-4 py-3 text-[13px] text-error">
+            {formError}
+          </div>
+        ) : null}
+
+        <div className="flex justify-end">
+          <Button
+            className="gap-2 bg-ops text-white hover:bg-ops-dark"
+            disabled={saveMutation.isPending}
+            onClick={onSave}
+            type="button"
+          >
+            <Save className="h-4 w-4" />
+            {saveMutation.isPending ? "Menyimpan..." : "Simpan"}
+          </Button>
+        </div>
+      </Card>
+
+      <Card className="space-y-5 p-6">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-[15px] font-[700] text-text-primary">Kode Registrasi</h2>
+            <p className="text-[13px] text-text-secondary">
+              Bagikan kode ini ke calon user. Klik mata untuk tampilkan.
+            </p>
+          </div>
+          <Button
+            className="gap-2"
+            disabled={rollMutation.isPending}
+            onClick={() => rollMutation.mutate()}
+            type="button"
+            variant="outline"
+          >
+            <RefreshCw className={cn("h-4 w-4", rollMutation.isPending && "animate-spin")} />
+            {rollMutation.isPending ? "Memutar..." : "Roll kode baru"}
+          </Button>
+        </div>
+
+        {code ? (
+          <div className="rounded-[8px] border border-border bg-surface-muted p-4">
+            <div className="flex items-center gap-2">
+              <code className="flex-1 rounded-[6px] bg-surface px-3 py-2 font-mono text-[14px] text-text-primary">
+                {codeVisible ? code : maskedCode}
+              </code>
+              <Button
+                className="gap-2"
+                onClick={() => setCodeVisible((v) => !v)}
+                type="button"
+                variant="outline"
+              >
+                {codeVisible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                {codeVisible ? "Sembunyikan" : "Tampilkan"}
+              </Button>
+              <Button className="gap-2" onClick={onCopy} type="button" variant="outline">
+                <Copy className="h-4 w-4" />
+                Salin
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-[8px] border border-border bg-surface-muted px-4 py-3 text-[13px] text-text-secondary">
+            Belum ada kode. Klik "Roll kode baru" untuk generate.
+          </div>
+        )}
+
+        <dl className="grid gap-3 text-[13px] sm:grid-cols-2">
+          <div>
+            <dt className="text-text-secondary">Status kode</dt>
+            <dd className="font-[600] text-text-primary">
+              {hasCode ? (expired ? "Kadaluwarsa" : "Aktif") : "Belum ada"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-text-secondary">Berlaku sampai</dt>
+            <dd className="font-[600] text-text-primary">{formatDateTime(expiresAt)}</dd>
+          </div>
+          <div>
+            <dt className="text-text-secondary">Terakhir di-roll</dt>
+            <dd className="font-[600] text-text-primary">
+              {formatDateTime(data?.last_rolled_at)}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-text-secondary">Di-roll oleh</dt>
+            <dd className="font-[600] text-text-primary">
+              {data?.last_rolled_by_name ?? data?.last_rolled_by ?? "-"}
+            </dd>
+          </div>
+        </dl>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -142,14 +142,16 @@ function LoginPage() {
           </div>
         </form>
 
-        <div className="mt-6 text-center">
-          <p className="text-[14px] text-text-secondary">
-            Belum punya akun?{" "}
-            <Link className="font-[600] text-ops hover:underline" to="/register">
-              Daftar
-            </Link>
-          </p>
-        </div>
+        {authPublicOptionsQuery.data?.registration_enabled ? (
+          <div className="mt-6 text-center">
+            <p className="text-[14px] text-text-secondary">
+              Belum punya akun?{" "}
+              <Link className="font-[600] text-ops hover:underline" to="/register">
+                Daftar
+              </Link>
+            </p>
+          </div>
+        ) : null}
       </Card>
     </div>
   );

--- a/frontend/src/routes/register.tsx
+++ b/frontend/src/routes/register.tsx
@@ -10,7 +10,7 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { ApiError } from "@/lib/api-client";
 import { getDefaultAuthorizedPath } from "@/lib/rbac";
-import { getValidStoredSession, register } from "@/services/auth";
+import { getAuthPublicOptions, getValidStoredSession, register } from "@/services/auth";
 import { toast } from "@/stores/toast-store";
 
 const registerSchema = z
@@ -19,6 +19,7 @@ const registerSchema = z
     email: z.email("Email wajib valid"),
     password: z.string().min(8, "Kata sandi minimal 8 karakter"),
     confirmPassword: z.string().min(8, "Konfirmasi kata sandi wajib diisi"),
+    registration_code: z.string().min(8, "Kode registrasi wajib diisi"),
   })
   .refine((value) => value.password === value.confirmPassword, {
     message: "Konfirmasi kata sandi tidak sama",
@@ -34,6 +35,18 @@ export const Route = createFileRoute("/register")({
       throw redirect({
         to: getDefaultAuthorizedPath(session),
       });
+    }
+
+    try {
+      const options = await getAuthPublicOptions();
+      if (!options.registration_enabled) {
+        throw redirect({ to: "/login" });
+      }
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw redirect({ to: "/login" });
+      }
+      throw error;
     }
   },
   component: RegisterPage,
@@ -52,6 +65,7 @@ function RegisterPage() {
       email: "",
       password: "",
       confirmPassword: "",
+      registration_code: "",
     },
   });
 
@@ -61,6 +75,7 @@ function RegisterPage() {
         email: values.email,
         password: values.password,
         full_name: values.full_name,
+        registration_code: values.registration_code,
       }),
     onSuccess: () => {
       toast.success("Akun berhasil dibuat", "Silakan masuk dengan akun yang baru Anda daftarkan.");
@@ -125,6 +140,14 @@ function RegisterPage() {
               autoComplete="new-password"
               placeholder="Ulangi kata sandi"
               type="password"
+              className="h-10 rounded-[6px] border-transparent bg-surface-muted px-3 text-[14px] focus:border-ops focus:bg-surface focus:ring-2 focus:ring-ops/20"
+            />
+          </Field>
+          <Field label="Kode Registrasi" error={errors.registration_code?.message} required>
+            <Input
+              {...registerField("registration_code")}
+              autoComplete="off"
+              placeholder="Minta kode ke admin"
               className="h-10 rounded-[6px] border-transparent bg-surface-muted px-3 text-[14px] focus:border-ops focus:bg-surface focus:ring-2 focus:ring-ops/20"
             />
           </Field>

--- a/frontend/src/services/admin-rbac.ts
+++ b/frontend/src/services/admin-rbac.ts
@@ -256,3 +256,43 @@ export function updateReimbursementReminder(payload: {
 export function listModules() {
   return authGetJSON<ModuleItem[]>("/modules");
 }
+
+export interface RegistrationSettingsView {
+  enabled: boolean;
+  has_code: boolean;
+  code?: string | null;
+  code_expires_at: string | null;
+  last_rolled_by: string | null;
+  last_rolled_by_name: string | null;
+  last_rolled_at: string | null;
+  rotation_interval_days: number;
+  allowed_email_domains: string[];
+}
+
+export interface RollRegistrationCodeResponse {
+  code: string;
+  settings: RegistrationSettingsView;
+}
+
+export function getRegistrationSettings() {
+  return authGetJSON<RegistrationSettingsView>("/admin/settings/registration");
+}
+
+export function updateRegistrationSettings(payload: {
+  enabled: boolean;
+  rotation_interval_days: number;
+  allowed_email_domains: string[];
+}) {
+  return authRequestJSON<RegistrationSettingsView>("/admin/settings/registration", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}
+
+export function rollRegistrationCode() {
+  return authRequestJSON<RollRegistrationCodeResponse>(
+    "/admin/settings/registration/roll",
+    { method: "POST" },
+  );
+}

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -11,6 +11,7 @@ interface RegisterRequest {
   email: string;
   password: string;
   full_name: string;
+  registration_code: string;
 }
 
 interface ChangePasswordRequest {
@@ -41,6 +42,7 @@ interface ResetPasswordResponse {
 
 export interface AuthPublicOptions {
   forgot_password_enabled: boolean;
+  registration_enabled: boolean;
 }
 
 export function login(payload: LoginRequest) {


### PR DESCRIPTION
Closes the open self-registration gap on the KANTOR instance. Register endpoint now requires a shared code (AES-256-GCM encrypted, admin-managed) plus optional per-tenant email domain allowlist. Super admin manages the code via a dedicated /admin/registration page: toggle feature, roll code manually, set rotation interval (auto-roll background job runs daily), and list allowed domains. /auth/public-options exposes a readiness flag so the register form/link hide when disabled or code is missing/expired.

Default is disabled per tenant via rbac seeder — no schema migration required (new system_settings key inserted idempotently on next boot).

## Summary

- What changed?
- Why was it needed?

## Scope

- Modules affected:
- Backend / Frontend / Extension / Infra:

## Testing

- [ ] `go build ./cmd/server`
- [ ] `npm run build`
- [ ] Manual testing completed
- [ ] Screenshots attached for UI changes

## Migrations / Env

- [ ] No migration
- [ ] Migration added
- [ ] No env change
- [ ] Env change required

## Risks

- Any known risk, edge case, or follow-up?

## Checklist

- [ ] RBAC considered for affected endpoints and UI
- [ ] Related queries invalidated where needed
- [ ] No secrets or local-only files included
- [ ] Documentation updated if needed
