### PR TITLE
fix(observability): use slog context variants for request_id correlation

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -106,7 +106,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		if result, err := waRepositoryForSeed.EnsureDefaultTemplates(tCtx); err != nil {
 			return fmt.Errorf("seed wa templates for tenant %s: %w", t.Slug, err)
 		} else if result.InsertedCount > 0 {
-			slog.Info("seeded wa templates", "tenant", t.Slug, "inserted", result.InsertedCount, "slugs", result.InsertedSlugs)
+			slog.InfoContext(tCtx, "seeded wa templates", "tenant", t.Slug, "inserted", result.InsertedCount, "slugs", result.InsertedSlugs)
 		}
 		return nil
 	}); err != nil {
@@ -472,7 +472,7 @@ func (a *App) startBackgroundJobs(authService *authservice.Service, subscription
 
 	runPerTenant := func(name string, fn func(ctx context.Context, t tenant.Info) error) {
 		if err := platformmiddleware.ForEachTenant(ctx, a.db, fn); err != nil {
-			slog.Error("per-tenant background job failed", "job", name, "error", err)
+			slog.ErrorContext(ctx, "per-tenant background job failed", "job", name, "error", err)
 		}
 	}
 
@@ -480,7 +480,7 @@ func (a *App) startBackgroundJobs(authService *authservice.Service, subscription
 		go func() {
 			defer func() {
 				if r := recover(); r != nil {
-					slog.Error("background job panicked", "job", name, "panic", r, "stack", string(debug.Stack()))
+					slog.ErrorContext(ctx, "background job panicked", "job", name, "panic", r, "stack", string(debug.Stack()))
 				}
 			}()
 			fn()
@@ -490,7 +490,7 @@ func (a *App) startBackgroundJobs(authService *authservice.Service, subscription
 	runBackground("background_scheduler", func() {
 		defer func() {
 			if r := recover(); r != nil {
-				slog.Error("background job panicked", "job", "background_scheduler", "panic", r, "stack", string(debug.Stack()))
+				slog.ErrorContext(ctx, "background job panicked", "job", "background_scheduler", "panic", r, "stack", string(debug.Stack()))
 			}
 		}()
 
@@ -781,7 +781,7 @@ func seedTenants(ctx context.Context, pool *pgxpool.Pool, tenants []config.Tenan
 			return fmt.Errorf("seed tracker reminder config for tenant %q: %w", tc.Slug, err)
 		}
 
-		slog.Info("tenant seeded", "name", tc.Name, "slug", tc.Slug, "domains", tc.Domains)
+		slog.InfoContext(ctx, "tenant seeded", "name", tc.Name, "slug", tc.Slug, "domains", tc.Domains)
 	}
 	return nil
 }

--- a/backend/internal/handler/auth/users.go
+++ b/backend/internal/handler/auth/users.go
@@ -35,7 +35,7 @@ func (h *Handler) ListUsers(w http.ResponseWriter, r *http.Request) {
 		SuperAdmin: superAdmin,
 	})
 	if err != nil {
-		slog.Error("failed to list users", "error", err)
+		slog.ErrorContext(r.Context(), "failed to list users", "error", err)
 		response.WriteInternalError(r.Context(), w, err, "Failed to list users")
 		return
 	}

--- a/backend/internal/handler/hris/reimbursements.go
+++ b/backend/internal/handler/hris/reimbursements.go
@@ -390,7 +390,7 @@ func (h *ReimbursementsHandler) writeError(ctx context.Context, w http.ResponseW
 	case errors.Is(err, hrisservice.ErrEmployeeNotFound):
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"employee_id": "not found"})
 	default:
-		slog.Error("unexpected reimbursement error", "error", err)
+		slog.ErrorContext(ctx, "unexpected reimbursement error", "error", err)
 		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -275,7 +275,7 @@ func (h *KanbanHandler) writeError(ctx context.Context, w http.ResponseWriter, e
 	case errors.Is(err, operationalservice.ErrKanbanTaskAssigneeNotMember):
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"assignee_id": "must belong to the project"})
 	default:
-		slog.Error("unexpected kanban handler error", "error", err)
+		slog.ErrorContext(ctx, "unexpected kanban handler error", "error", err)
 		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}
 }

--- a/backend/internal/handler/operational/tracker.go
+++ b/backend/internal/handler/operational/tracker.go
@@ -212,7 +212,7 @@ func (h *TrackerHandler) getMyActivity(w http.ResponseWriter, r *http.Request) {
 
 	activity, err := h.service.GetMyActivity(r.Context(), principal.UserID, dateFrom, dateTo)
 	if err != nil {
-		slog.Error("failed to load tracker activity", "error", err, "userID", principal.UserID)
+		slog.ErrorContext(r.Context(), "failed to load tracker activity", "error", err, "userID", principal.UserID)
 		response.WriteInternalError(r.Context(), w, err, "Failed to load tracker activity")
 		return
 	}
@@ -222,7 +222,7 @@ func (h *TrackerHandler) getMyActivity(w http.ResponseWriter, r *http.Request) {
 func (h *TrackerHandler) downloadExtension(w http.ResponseWriter, r *http.Request) {
 	archiveBytes, filename, err := h.service.BuildExtensionArchive(r.Context())
 	if err != nil {
-		slog.Error("failed to build extension archive", "error", err)
+		slog.ErrorContext(r.Context(), "failed to build extension archive", "error", err)
 		response.WriteError(w, http.StatusInternalServerError, "TRACKER_EXTENSION_UNAVAILABLE", "Tracker extension package is not available right now", nil)
 		return
 	}

--- a/backend/internal/repository/operational/tracker.go
+++ b/backend/internal/repository/operational/tracker.go
@@ -144,7 +144,7 @@ func (r *TrackerRepository) UpsertConsent(ctx context.Context, userID string, co
 		&consent.CreatedAt,
 	)
 	if err != nil {
-		slog.Error("tracker consent upsert query failed", "error", err, "user_id", userID, "consented", consented)
+		slog.ErrorContext(ctx, "tracker consent upsert query failed", "error", err, "user_id", userID, "consented", consented)
 		return model.ActivityConsent{}, err
 	}
 

--- a/backend/internal/service/audit/service.go
+++ b/backend/internal/service/audit/service.go
@@ -23,7 +23,7 @@ func NewService(repo *auditrepo.Repository) *Service {
 // failures are logged so that audit issues do not break business operations.
 func (s *Service) Log(ctx context.Context, entry Entry) {
 	if err := s.repo.Insert(ctx, entry); err != nil {
-		slog.Error("failed to write audit log",
+		slog.ErrorContext(ctx, "failed to write audit log",
 			"error", err,
 			"action", entry.Action,
 			"module", entry.Module,

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -244,7 +244,7 @@ func (s *Service) Login(ctx context.Context, input dto.LoginRequest, userAgent s
 
 	if passwordErr != nil {
 		if err := s.repo.IncrementFailedLoginAttempts(ctx, user.ID, maxFailedLoginAttempts, accountLockDuration); err != nil {
-			slog.Error("failed to increment login attempts", "error", err, "user_id", user.ID)
+			slog.ErrorContext(ctx, "failed to increment login attempts", "error", err, "user_id", user.ID)
 		}
 		return AuthResult{}, ErrInvalidCredentials
 	}
@@ -256,7 +256,7 @@ func (s *Service) Login(ctx context.Context, input dto.LoginRequest, userAgent s
 	if backendauth.NeedsRehash(user.PasswordHash) {
 		if newHash, err := backendauth.HashPassword(input.Password); err == nil {
 			if err := s.repo.UpdatePasswordHash(ctx, user.ID, newHash); err != nil {
-				slog.Error("failed to upgrade password hash", "error", err, "user_id", user.ID)
+				slog.ErrorContext(ctx, "failed to upgrade password hash", "error", err, "user_id", user.ID)
 			}
 		}
 	}
@@ -580,7 +580,7 @@ func (s *Service) ChangeEmail(ctx context.Context, userID string, newEmail strin
 
 	// Also sync to employees table
 	if err := s.repo.UpdateEmployeeEmailByUserID(ctx, userID, newEmail); err != nil {
-		slog.Warn("failed to sync email to employee", "user_id", userID, "error", err)
+		slog.WarnContext(ctx, "failed to sync email to employee", "user_id", userID, "error", err)
 	}
 
 	return nil
@@ -589,7 +589,7 @@ func (s *Service) ChangeEmail(ctx context.Context, userID string, newEmail strin
 func (s *Service) UpdateProfileAvatar(ctx context.Context, userID string, avatarURL string) error {
 	// Update employee avatar
 	if err := s.repo.UpdateEmployeeAvatarByUserID(ctx, userID, avatarURL); err != nil {
-		slog.Warn("failed to sync avatar to employee", "user_id", userID, "error", err)
+		slog.WarnContext(ctx, "failed to sync avatar to employee", "user_id", userID, "error", err)
 	}
 	// Sync to users table
 	return s.repo.UpdateUserAvatar(ctx, userID, &avatarURL)

--- a/backend/internal/service/notifications/email_delivery.go
+++ b/backend/internal/service/notifications/email_delivery.go
@@ -67,7 +67,7 @@ func (s *EmailDeliveryService) SendTaskAssignedNotification(ctx context.Context,
 	if _, err := platformmiddleware.WithScopedTenantConn(ctx, func(scopedCtx context.Context) (struct{}, error) {
 		return struct{}{}, s.sendTaskAssignedNotification(scopedCtx, taskID)
 	}); err != nil && !errors.Is(err, ErrNotificationEmailsDisabled) {
-		slog.Error("failed to send task assigned email", "task_id", taskID, "assignee_id", assigneeID, "error", err)
+		slog.ErrorContext(ctx, "failed to send task assigned email", "task_id", taskID, "assignee_id", assigneeID, "error", err)
 	}
 }
 
@@ -75,7 +75,7 @@ func (s *EmailDeliveryService) SendReimbursementStatusNotification(ctx context.C
 	if _, err := platformmiddleware.WithScopedTenantConn(ctx, func(scopedCtx context.Context) (struct{}, error) {
 		return struct{}{}, s.sendReimbursementStatusNotification(scopedCtx, reimbursementID, newStatus, reviewerNotes)
 	}); err != nil && !errors.Is(err, ErrNotificationEmailsDisabled) {
-		slog.Error("failed to send reimbursement status email", "reimbursement_id", reimbursementID, "error", err)
+		slog.ErrorContext(ctx, "failed to send reimbursement status email", "reimbursement_id", reimbursementID, "error", err)
 	}
 }
 
@@ -83,7 +83,7 @@ func (s *EmailDeliveryService) SendReimbursementReminder(ctx context.Context, re
 	if _, err := platformmiddleware.WithScopedTenantConn(ctx, func(scopedCtx context.Context) (struct{}, error) {
 		return struct{}{}, s.sendReimbursementReminder(scopedCtx, recipient, digest)
 	}); err != nil && !errors.Is(err, ErrNotificationEmailsDisabled) {
-		slog.Error("failed to send reimbursement reminder email", "user_id", recipient.UserID, "kind", digest.Kind, "error", err)
+		slog.ErrorContext(ctx, "failed to send reimbursement reminder email", "user_id", recipient.UserID, "kind", digest.Kind, "error", err)
 	}
 }
 
@@ -266,7 +266,7 @@ func (s *EmailDeliveryService) sendWeeklyDigest(ctx context.Context, now time.Ti
 			HTML:    renderWeeklyDigestHTML(item, weekStart, weekEnd, baseURL),
 			Text:    renderWeeklyDigestText(item, weekStart, weekEnd, baseURL),
 		}); err != nil {
-			slog.Error("failed to send weekly digest email", "user_id", item.UserID, "error", err)
+			slog.ErrorContext(ctx, "failed to send weekly digest email", "user_id", item.UserID, "error", err)
 		}
 	}
 

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -153,7 +153,7 @@ func (s *KanbanService) CreateTask(ctx context.Context, projectID string, reques
 
 	// Notify assignee (skip self-assign)
 	if task.AssigneeID != nil && *task.AssigneeID != createdBy {
-		slog.Info(
+		slog.InfoContext(ctx,
 			"dispatching task assigned notification",
 			"task_id", task.ID,
 			"assignee_id", *task.AssigneeID,
@@ -207,7 +207,7 @@ func (s *KanbanService) UpdateTask(ctx context.Context, projectID string, taskID
 	if task.AssigneeID != nil {
 		newAssigneeID := *task.AssigneeID
 		if newAssigneeID != oldAssigneeID && newAssigneeID != actorID {
-			slog.Info(
+			slog.InfoContext(ctx,
 				"dispatching task assigned notification",
 				"task_id", task.ID,
 				"assignee_id", newAssigneeID,
@@ -320,7 +320,7 @@ func normalizeStringPointer(value *string) *string {
 
 func (s *KanbanService) dispatchTaskAssignedNotification(ctx context.Context, taskID string, assigneeID string) {
 	if len(s.notifiers) == 0 {
-		slog.Warn("task assigned notification skipped because no notifier is registered", "task_id", taskID, "assignee_id", assigneeID)
+		slog.WarnContext(ctx, "task assigned notification skipped because no notifier is registered", "task_id", taskID, "assignee_id", assigneeID)
 		return
 	}
 
@@ -333,7 +333,7 @@ func (s *KanbanService) dispatchTaskAssignedNotification(ctx context.Context, ta
 		go func() {
 			defer func() {
 				if recovered := recover(); recovered != nil {
-					slog.Error(
+					slog.ErrorContext(notificationCtx,
 						"task assigned notifier panicked",
 						"task_id", taskID,
 						"assignee_id", assigneeID,

--- a/backend/internal/service/operational/tracker_extension.go
+++ b/backend/internal/service/operational/tracker_extension.go
@@ -15,13 +15,13 @@ import (
 
 var ErrTrackerExtensionUnavailable = errors.New("tracker extension package is unavailable")
 
-func (s *TrackerService) BuildExtensionArchive(_ context.Context) ([]byte, string, error) {
+func (s *TrackerService) BuildExtensionArchive(ctx context.Context) ([]byte, string, error) {
 	extensionDir, err := resolveExtensionDir()
 	if err != nil {
-		slog.Error("failed to resolve extension directory", "error", err)
+		slog.ErrorContext(ctx, "failed to resolve extension directory", "error", err)
 		return nil, "", ErrTrackerExtensionUnavailable
 	}
-	slog.Info("resolved extension directory", "path", extensionDir)
+	slog.InfoContext(ctx, "resolved extension directory", "path", extensionDir)
 
 	buffer := bytes.NewBuffer(nil)
 	archive := zip.NewWriter(buffer)
@@ -58,7 +58,7 @@ func (s *TrackerService) BuildExtensionArchive(_ context.Context) ([]byte, strin
 		return nil
 	}); err != nil {
 		_ = archive.Close()
-		slog.Error("failed to walk extension directory", "error", err, "dir", extensionDir)
+		slog.ErrorContext(ctx, "failed to walk extension directory", "error", err, "dir", extensionDir)
 		return nil, "", fmt.Errorf("archive tracker extension: %w", err)
 	}
 

--- a/backend/internal/service/operational/tracker_reminder.go
+++ b/backend/internal/service/operational/tracker_reminder.go
@@ -194,7 +194,7 @@ func (s *TrackerReminderService) RunReminderJobs(ctx context.Context, now time.T
 
 	loc, err := time.LoadLocation(cfg.Timezone)
 	if err != nil {
-		slog.Warn("tracker reminder falling back to UTC", "tenant_timezone", cfg.Timezone, "error", err)
+		slog.WarnContext(ctx, "tracker reminder falling back to UTC", "tenant_timezone", cfg.Timezone, "error", err)
 		loc = time.UTC
 	}
 	nowLocal := now.In(loc)
@@ -222,7 +222,7 @@ func (s *TrackerReminderService) RunReminderJobs(ctx context.Context, now time.T
 	for _, c := range candidates {
 		exists, err := s.repo.HasRecentReminder(ctx, c.UserID, dedupSince)
 		if err != nil {
-			slog.Error("tracker reminder dedup check failed", "user_id", c.UserID, "error", err)
+			slog.ErrorContext(ctx, "tracker reminder dedup check failed", "user_id", c.UserID, "error", err)
 			continue
 		}
 		if exists {
@@ -243,12 +243,12 @@ func (s *TrackerReminderService) RunReminderJobs(ctx context.Context, now time.T
 
 	if len(pendingInApp) > 0 {
 		if err := s.notifs.CreateMany(ctx, pendingInApp); err != nil {
-			slog.Error("tracker reminder in-app dispatch failed", "error", err, "count", len(pendingInApp))
+			slog.ErrorContext(ctx, "tracker reminder in-app dispatch failed", "error", err, "count", len(pendingInApp))
 		}
 	}
 	for _, c := range waTargets {
 		if err := s.wa.QuickSend(ctx, *c.Phone, trackerReminderWAMessage(c.FullName)); err != nil {
-			slog.Warn("tracker reminder WA dispatch failed", "user_id", c.UserID, "error", err)
+			slog.WarnContext(ctx, "tracker reminder WA dispatch failed", "user_id", c.UserID, "error", err)
 		}
 	}
 	return nil

--- a/backend/internal/service/whatsapp/scheduler.go
+++ b/backend/internal/service/whatsapp/scheduler.go
@@ -13,38 +13,38 @@ import (
 
 // RunDailyReminders executes UC-1 (task due today), UC-2 (task overdue), UC-4 (project deadline H-3).
 func (s *Service) RunDailyReminders(ctx context.Context) {
-	slog.Info("starting daily WA reminders")
+	slog.InfoContext(ctx, "starting daily WA reminders")
 
 	s.sendTaskDueTodayReminders(ctx)
 	s.sendTaskOverdueReminders(ctx)
 	s.sendProjectDeadlineReminders(ctx)
 
-	slog.Info("daily WA reminders completed")
+	slog.InfoContext(ctx, "daily WA reminders completed")
 }
 
 // RunWeeklyDigest executes UC-5 (weekly digest).
 func (s *Service) RunWeeklyDigest(ctx context.Context) {
-	slog.Info("starting weekly WA digest")
+	slog.InfoContext(ctx, "starting weekly WA digest")
 
 	tmpl, err := s.repo.GetTemplateBySlug(ctx, "weekly_digest")
 	if err != nil {
-		slog.Error("failed to get weekly_digest template", "error", err)
+		slog.ErrorContext(ctx, "failed to get weekly_digest template", "error", err)
 		return
 	}
 	if !tmpl.IsActive {
-		slog.Info("weekly_digest template is inactive, skipping")
+		slog.InfoContext(ctx, "weekly_digest template is inactive, skipping")
 		return
 	}
 
 	items, err := s.repo.GetWeeklyDigestData(ctx)
 	if err != nil {
-		slog.Error("failed to get weekly digest data", "error", err)
+		slog.ErrorContext(ctx, "failed to get weekly digest data", "error", err)
 		return
 	}
 
 	baseURL, err := s.resolveTenantBaseURL(ctx)
 	if err != nil {
-		slog.Error("failed to resolve tenant app url for weekly digest", "error", err)
+		slog.ErrorContext(ctx, "failed to resolve tenant app url for weekly digest", "error", err)
 		return
 	}
 
@@ -75,13 +75,13 @@ func (s *Service) RunWeeklyDigest(ctx context.Context) {
 			&item.UserID, nil, nil)
 	}
 
-	slog.Info("weekly WA digest completed", "recipients", len(items))
+	slog.InfoContext(ctx, "weekly WA digest completed", "recipients", len(items))
 }
 
 func (s *Service) sendTaskDueTodayReminders(ctx context.Context) {
 	tmpl, err := s.repo.GetTemplateBySlug(ctx, "task_due_today")
 	if err != nil {
-		slog.Error("failed to get task_due_today template", "error", err)
+		slog.ErrorContext(ctx, "failed to get task_due_today template", "error", err)
 		return
 	}
 	if !tmpl.IsActive {
@@ -90,20 +90,20 @@ func (s *Service) sendTaskDueTodayReminders(ctx context.Context) {
 
 	tasks, err := s.repo.GetTasksDueToday(ctx)
 	if err != nil {
-		slog.Error("failed to get tasks due today", "error", err)
+		slog.ErrorContext(ctx, "failed to get tasks due today", "error", err)
 		return
 	}
 
 	for _, task := range tasks {
 		s.sendTaskReminder(ctx, task, tmpl)
 	}
-	slog.Info("task due today reminders sent", "count", len(tasks))
+	slog.InfoContext(ctx, "task due today reminders sent", "count", len(tasks))
 }
 
 func (s *Service) sendTaskOverdueReminders(ctx context.Context) {
 	tmpl, err := s.repo.GetTemplateBySlug(ctx, "task_overdue")
 	if err != nil {
-		slog.Error("failed to get task_overdue template", "error", err)
+		slog.ErrorContext(ctx, "failed to get task_overdue template", "error", err)
 		return
 	}
 	if !tmpl.IsActive {
@@ -112,14 +112,14 @@ func (s *Service) sendTaskOverdueReminders(ctx context.Context) {
 
 	tasks, err := s.repo.GetTasksOverdue(ctx)
 	if err != nil {
-		slog.Error("failed to get overdue tasks", "error", err)
+		slog.ErrorContext(ctx, "failed to get overdue tasks", "error", err)
 		return
 	}
 
 	for _, task := range tasks {
 		s.sendTaskReminder(ctx, task, tmpl)
 	}
-	slog.Info("task overdue reminders sent", "count", len(tasks))
+	slog.InfoContext(ctx, "task overdue reminders sent", "count", len(tasks))
 }
 
 func (s *Service) sendTaskReminder(ctx context.Context, task warepo.TaskDueInfo, tmpl model.WAMessageTemplate) {
@@ -131,7 +131,7 @@ func (s *Service) sendTaskReminder(ctx context.Context, task warepo.TaskDueInfo,
 	// Anti-spam: check if already sent today
 	dup, err := s.repo.CheckDuplicateToday(ctx, task.AssigneeID, tmpl.Slug, task.TaskID)
 	if err != nil {
-		slog.Error("failed to check duplicate", "error", err)
+		slog.ErrorContext(ctx, "failed to check duplicate", "error", err)
 		return
 	}
 	if dup {
@@ -140,7 +140,7 @@ func (s *Service) sendTaskReminder(ctx context.Context, task warepo.TaskDueInfo,
 
 	baseURL, err := s.resolveTenantBaseURL(ctx)
 	if err != nil {
-		slog.Error("failed to resolve tenant app url for task reminder", "task_id", task.TaskID, "error", err)
+		slog.ErrorContext(ctx, "failed to resolve tenant app url for task reminder", "task_id", task.TaskID, "error", err)
 		return
 	}
 
@@ -159,7 +159,7 @@ func (s *Service) sendTaskReminder(ctx context.Context, task warepo.TaskDueInfo,
 func (s *Service) sendProjectDeadlineReminders(ctx context.Context) {
 	tmpl, err := s.repo.GetTemplateBySlug(ctx, "project_deadline_h3")
 	if err != nil {
-		slog.Error("failed to get project_deadline_h3 template", "error", err)
+		slog.ErrorContext(ctx, "failed to get project_deadline_h3 template", "error", err)
 		return
 	}
 	if !tmpl.IsActive {
@@ -168,13 +168,13 @@ func (s *Service) sendProjectDeadlineReminders(ctx context.Context) {
 
 	projects, err := s.repo.GetProjectsDeadlineIn3Days(ctx)
 	if err != nil {
-		slog.Error("failed to get projects deadline in 3 days", "error", err)
+		slog.ErrorContext(ctx, "failed to get projects deadline in 3 days", "error", err)
 		return
 	}
 
 	baseURL, err := s.resolveTenantBaseURL(ctx)
 	if err != nil {
-		slog.Error("failed to resolve tenant app url for project deadline reminder", "error", err)
+		slog.ErrorContext(ctx, "failed to resolve tenant app url for project deadline reminder", "error", err)
 		return
 	}
 
@@ -188,7 +188,7 @@ func (s *Service) sendProjectDeadlineReminders(ctx context.Context) {
 
 			dup, err := s.repo.CheckDuplicateToday(ctx, member.UserID, tmpl.Slug, project.ProjectID)
 			if err != nil {
-				slog.Error("failed to check duplicate", "error", err)
+				slog.ErrorContext(ctx, "failed to check duplicate", "error", err)
 				continue
 			}
 			if dup {
@@ -210,5 +210,5 @@ func (s *Service) sendProjectDeadlineReminders(ctx context.Context) {
 			sent++
 		}
 	}
-	slog.Info("project deadline reminders sent", "count", sent)
+	slog.InfoContext(ctx, "project deadline reminders sent", "count", sent)
 }

--- a/backend/internal/service/whatsapp/service.go
+++ b/backend/internal/service/whatsapp/service.go
@@ -174,7 +174,7 @@ func (s *Service) GetDailyStats(ctx context.Context) *DailyStats {
 	stats := client.GetDailyStats()
 	sentToday, countErr := s.repo.CountSentLogsToday(ctx)
 	if countErr != nil {
-		slog.Error("failed to count daily wa logs", "error", countErr)
+		slog.ErrorContext(ctx, "failed to count daily wa logs", "error", countErr)
 		return stats
 	}
 	stats.SentToday = sentToday
@@ -356,7 +356,7 @@ func (s *Service) QuickSend(ctx context.Context, phone string, message string) e
 		ErrorMessage:   errMsg,
 	})
 	if logErr != nil {
-		slog.Error("failed to log quick send", "error", logErr)
+		slog.ErrorContext(ctx, "failed to log quick send", "error", logErr)
 	}
 
 	return err
@@ -401,7 +401,7 @@ func (s *Service) SendTaskAssignedNotification(ctx context.Context, taskID strin
 	if _, err := platformmiddleware.WithScopedTenantConn(ctx, func(scopedCtx context.Context) (struct{}, error) {
 		task, err := s.repo.GetTaskWithProject(scopedCtx, taskID)
 		if err != nil || task == nil {
-			slog.Error("failed to get task for WA notification", "task_id", taskID, "error", err)
+			slog.ErrorContext(scopedCtx, "failed to get task for WA notification", "task_id", taskID, "error", err)
 			return struct{}{}, nil
 		}
 
@@ -412,7 +412,7 @@ func (s *Service) SendTaskAssignedNotification(ctx context.Context, taskID strin
 
 		tmpl, err := s.repo.GetTemplateBySlug(scopedCtx, "task_assigned")
 		if err != nil {
-			slog.Error("failed to get task_assigned template", "error", err)
+			slog.ErrorContext(scopedCtx, "failed to get task_assigned template", "error", err)
 			return struct{}{}, nil
 		}
 		if !tmpl.IsActive {
@@ -438,7 +438,7 @@ func (s *Service) SendTaskAssignedNotification(ctx context.Context, taskID strin
 			&assigneeID, stringPtr("task"), &task.TaskID)
 		return struct{}{}, nil
 	}); err != nil {
-		slog.Error("failed to send task assigned WA notification", "task_id", taskID, "error", err)
+		slog.ErrorContext(ctx, "failed to send task assigned WA notification", "task_id", taskID, "error", err)
 	}
 }
 
@@ -447,7 +447,7 @@ func (s *Service) SendReimbursementStatusNotification(ctx context.Context, reimb
 	if _, err := platformmiddleware.WithScopedTenantConn(ctx, func(scopedCtx context.Context) (struct{}, error) {
 		info, err := s.repo.GetReimbursementWithSubmitter(scopedCtx, reimbursementID)
 		if err != nil || info == nil {
-			slog.Error("failed to get reimbursement for WA notification", "reimbursement_id", reimbursementID, "error", err)
+			slog.ErrorContext(scopedCtx, "failed to get reimbursement for WA notification", "reimbursement_id", reimbursementID, "error", err)
 			return struct{}{}, nil
 		}
 
@@ -458,7 +458,7 @@ func (s *Service) SendReimbursementStatusNotification(ctx context.Context, reimb
 
 		tmpl, err := s.repo.GetTemplateBySlug(scopedCtx, "reimbursement_status")
 		if err != nil {
-			slog.Error("failed to get reimbursement_status template", "error", err)
+			slog.ErrorContext(scopedCtx, "failed to get reimbursement_status template", "error", err)
 			return struct{}{}, nil
 		}
 		if !tmpl.IsActive {
@@ -484,7 +484,7 @@ func (s *Service) SendReimbursementStatusNotification(ctx context.Context, reimb
 			&info.SubmitterID, stringPtr("reimbursement"), &reimbursementID)
 		return struct{}{}, nil
 	}); err != nil {
-		slog.Error("failed to send reimbursement WA notification", "reimbursement_id", reimbursementID, "error", err)
+		slog.ErrorContext(ctx, "failed to send reimbursement WA notification", "reimbursement_id", reimbursementID, "error", err)
 	}
 }
 
@@ -503,7 +503,7 @@ func (s *Service) SendReimbursementReminder(ctx context.Context, recipient model
 
 		tmpl, err := s.repo.GetTemplateBySlug(scopedCtx, slug)
 		if err != nil {
-			slog.Error("failed to get reimbursement reminder template", "slug", slug, "error", err)
+			slog.ErrorContext(scopedCtx, "failed to get reimbursement reminder template", "slug", slug, "error", err)
 			return struct{}{}, nil
 		}
 		if !tmpl.IsActive {
@@ -528,7 +528,7 @@ func (s *Service) SendReimbursementReminder(ctx context.Context, recipient model
 		s.sendAndLog(scopedCtx, *recipient.Phone, body, "auto_scheduled", &tmpl.ID, &tmpl.Slug, &recipient.UserID, &referenceType, nil)
 		return struct{}{}, nil
 	}); err != nil {
-		slog.Error("failed to send reimbursement reminder WA", "user_id", recipient.UserID, "kind", digest.Kind, "error", err)
+		slog.ErrorContext(ctx, "failed to send reimbursement reminder WA", "user_id", recipient.UserID, "kind", digest.Kind, "error", err)
 	}
 }
 
@@ -576,7 +576,7 @@ func (s *Service) sendAndLogWithSchedule(ctx context.Context, scheduleID *string
 		ReferenceID:     refID,
 	})
 	if logErr != nil {
-		slog.Error("failed to create broadcast log", "error", logErr)
+		slog.ErrorContext(ctx, "failed to create broadcast log", "error", logErr)
 	}
 	if status == "sent" {
 		s.createInAppNotification(ctx, templateSlug, userID, refType, refID)
@@ -599,7 +599,7 @@ func (s *Service) logSkippedWithSchedule(ctx context.Context, scheduleID *string
 		ReferenceID:     refID,
 	})
 	if err != nil {
-		slog.Error("failed to log skipped message", "error", err)
+		slog.ErrorContext(ctx, "failed to log skipped message", "error", err)
 	}
 }
 
@@ -628,7 +628,7 @@ func (s *Service) RunCronJobs(ctx context.Context, now time.Time) error {
 			continue
 		}
 		if err := s.runSchedule(ctx, schedule, "auto_scheduled"); err != nil {
-			slog.Error("failed to execute scheduled WA broadcast", "schedule_id", schedule.ID, "error", err)
+			slog.ErrorContext(ctx, "failed to execute scheduled WA broadcast", "schedule_id", schedule.ID, "error", err)
 		}
 	}
 
@@ -684,7 +684,7 @@ func (s *Service) createInAppNotification(ctx context.Context, templateSlug *str
 			ReferenceID:   refID,
 		},
 	}); err != nil {
-		slog.Error("failed to create in-app notification for wa delivery", "template_slug", *templateSlug, "user_id", recipientUserID, "error", err)
+		slog.ErrorContext(ctx, "failed to create in-app notification for wa delivery", "template_slug", *templateSlug, "user_id", recipientUserID, "error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replaces ~60+ plain `slog.{Error,Warn,Info}` calls in handler/service/repo layers with the `*Context` variants so the existing `ContextHandler` (`middleware/logging.go`) can stamp `request_id` onto the records.
- Coverage: `app/app.go`, `service/audit`, `service/auth`, `service/notifications`, `service/operational`, `service/whatsapp`, `repository/operational/tracker.go`, plus the `handler/auth/users.go`, `handler/operational/{kanban,tracker}.go`, `handler/hris/reimbursements.go` packages.
- The four `slog` calls in `service/whatsapp/waha_client.go` are intentionally left as-is — the `WAHAClient` HTTP wrapper methods do not currently take a `context.Context` and threading one through is out of scope here.

Closes #73

## Test plan
- [x] \`cd backend && go build ./...\`
- [x] \`cd backend && go test ./...\`
- [ ] Tail backend logs in dev and confirm \`request_id\` shows up on a service-layer error path (e.g. force a tracker reminder failure or a quick send failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)