### PR TITLE
refactor(seed): move demo user seeding from boot into cmd/seed CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,31 +21,11 @@ JWT_ACCESS_EXPIRY=15m
 JWT_REFRESH_EXPIRY=168h
 TRACKER_RETENTION_DAYS=90
 CORS_ORIGINS=http://localhost:3000
-SEED_SUPERADMIN_ENABLED=false
-SEED_SUPERADMIN_EMAIL=superadmin@kantor.local
-SEED_SUPERADMIN_PASSWORD=replace-me-before-enabling-seed
-SEED_SUPERADMIN_FULL_NAME=Seeded Super Admin
-SEED_DEMO_USERS_ENABLED=false
-SEED_STAFF_EMAIL=staff.ops@kantor.local
-SEED_STAFF_PASSWORD=replace-me-before-enabling-seed
-SEED_STAFF_FULL_NAME=Operational Staff
-SEED_STAFF_DEPARTMENT=engineering
-SEED_STAFF_SKILLS=frontend,kanban
-SEED_VIEWER_EMAIL=viewer.ops@kantor.local
-SEED_VIEWER_PASSWORD=replace-me-before-enabling-seed
-SEED_VIEWER_FULL_NAME=Operational Viewer
-SEED_VIEWER_DEPARTMENT=finance
-SEED_VIEWER_SKILLS=qa,reporting
-SEED_MARKETING_STAFF_EMAIL=staff.marketing@kantor.local
-SEED_MARKETING_STAFF_PASSWORD=replace-me-before-enabling-seed
-SEED_MARKETING_STAFF_FULL_NAME=Marketing Staff
-SEED_MARKETING_STAFF_DEPARTMENT=marketing
-SEED_MARKETING_STAFF_SKILLS=copywriting,ads,crm
-SEED_MARKETING_VIEWER_EMAIL=viewer.marketing@kantor.local
-SEED_MARKETING_VIEWER_PASSWORD=replace-me-before-enabling-seed
-SEED_MARKETING_VIEWER_FULL_NAME=Marketing Viewer
-SEED_MARKETING_VIEWER_DEPARTMENT=marketing
-SEED_MARKETING_VIEWER_SKILLS=reporting
+
+# Demo users (super admin + 4 module staff/viewer accounts) are not seeded
+# automatically anymore. Run `go run ./cmd/seed` from the backend dir to
+# create them after the server has been booted at least once. The fixtures
+# live in internal/seed/data.go — never run the CLI in production.
 
 # Tenants (seeded on startup, first tenant owns existing data)
 # Format: name|slug|domain1,domain2;name2|slug2|domain3

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ docker compose up --build -d
 http://localhost:3000
 ```
 
-Default credentials (when seed is enabled):
+Demo accounts (created by `cd backend && go run ./cmd/seed`):
 
 | Role             | Email                           | Password       |
 | ---------------- | ------------------------------- | -------------- |
@@ -143,7 +143,7 @@ Default credentials (when seed is enabled):
 | Marketing Staff  | `staff.marketing@kantor.local`  | `Password123!` |
 | Marketing Viewer | `viewer.marketing@kantor.local` | `Password123!` |
 
-> **Note:** Disable seed users in production by setting `SEED_SUPERADMIN_ENABLED=false` and `SEED_DEMO_USERS_ENABLED=false`.
+> **Note:** Run `cmd/seed` only against local/staging databases — the demo accounts use a publicly known password.
 
 ---
 

--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -1,0 +1,122 @@
+// cmd/seed creates the demo super admin and demo users for every tenant
+// configured in TENANTS. Intended for local development and demo setups —
+// running it in production would expose accounts with publicly known
+// passwords and is therefore a deliberate, explicit step.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	_ "time/tzdata"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/kana-consultant/kantor/backend/internal/config"
+	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
+	"github.com/kana-consultant/kantor/backend/internal/rbac"
+	authrepo "github.com/kana-consultant/kantor/backend/internal/repository/auth"
+	hrisrepo "github.com/kana-consultant/kantor/backend/internal/repository/hris"
+	"github.com/kana-consultant/kantor/backend/internal/seed"
+	"github.com/kana-consultant/kantor/backend/internal/security"
+	authservice "github.com/kana-consultant/kantor/backend/internal/service/auth"
+	"github.com/kana-consultant/kantor/backend/internal/tenant"
+)
+
+func main() {
+	configureLogger()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx); err != nil {
+		slog.Error("seed failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	pool, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer pool.Close()
+
+	if err := pool.Ping(ctx); err != nil {
+		return fmt.Errorf("ping db: %w", err)
+	}
+
+	var previousKeys []string
+	if cfg.DataEncryptionKeyPrevious != "" {
+		previousKeys = append(previousKeys, cfg.DataEncryptionKeyPrevious)
+	}
+	encrypter, err := security.NewEncrypter(cfg.DataEncryptionKey, previousKeys...)
+	if err != nil {
+		return fmt.Errorf("encrypter: %w", err)
+	}
+
+	authRepository := authrepo.New(pool)
+	employeesRepository := hrisrepo.NewEmployeesRepository(pool)
+	permissionCache := rbac.NewPermissionCache(pool, 0)
+	authService := authservice.New(authRepository, employeesRepository, cfg, permissionCache, encrypter)
+
+	tenantsSeeded := 0
+	if err := platformmiddleware.ForEachTenant(ctx, pool, func(tCtx context.Context, t tenant.Info) error {
+		slog.InfoContext(tCtx, "seeding demo accounts", "tenant", t.Slug)
+
+		if err := authService.EnsureSeedSuperAdmin(
+			tCtx,
+			seed.DemoSuperAdmin.Email,
+			seed.DemoSuperAdmin.Password,
+			seed.DemoSuperAdmin.FullName,
+		); err != nil {
+			return fmt.Errorf("seed super admin for %s: %w", t.Slug, err)
+		}
+
+		for _, user := range seed.DemoUsers {
+			department := user.Department
+			params := authrepo.CreateUserParams{
+				Email:      user.Email,
+				FullName:   user.FullName,
+				Department: stringPtr(department),
+				Skills:     append([]string(nil), user.Skills...),
+			}
+			if err := authService.EnsureSeedUserWithRoles(tCtx, params, user.Roles, user.Password); err != nil {
+				return fmt.Errorf("seed user %s for %s: %w", user.Email, t.Slug, err)
+			}
+		}
+
+		tenantsSeeded++
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if tenantsSeeded == 0 {
+		return errors.New("no tenants found — run the server once or seed tenants via TENANTS env first")
+	}
+
+	slog.Info("seed completed", "tenants", tenantsSeeded, "users_per_tenant", len(seed.DemoUsers)+1)
+	return nil
+}
+
+func configureLogger() {
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+	slog.SetDefault(slog.New(platformmiddleware.NewContextHandler(handler)))
+}
+
+func stringPtr(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -131,63 +131,6 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	}
 	authService := authservice.New(authRepository, employeesRepository, cfg, permissionCache, encrypter)
 
-	// Seed super admin and demo users per-tenant.
-	if err := platformmiddleware.ForEachTenant(ctx, pool, func(tCtx context.Context, t tenant.Info) error {
-		if cfg.SeedSuperAdmin.Enabled {
-			if err := authService.EnsureSeedSuperAdmin(
-				tCtx,
-				cfg.SeedSuperAdmin.Email,
-				cfg.SeedSuperAdmin.Password,
-				cfg.SeedSuperAdmin.FullName,
-			); err != nil {
-				return fmt.Errorf("seed super admin for tenant %s: %w", t.Slug, err)
-			}
-		}
-
-		if cfg.SeedDemoUsers.Enabled {
-			if err := authService.EnsureSeedUserWithRoles(tCtx, authrepo.CreateUserParams{
-				Email:      cfg.SeedDemoUsers.Staff.Email,
-				FullName:   cfg.SeedDemoUsers.Staff.FullName,
-				Department: stringPointer(cfg.SeedDemoUsers.Staff.Department),
-				Skills:     cfg.SeedDemoUsers.Staff.Skills,
-			}, []rbac.RoleKey{{Name: "staff", Module: "operational"}}, cfg.SeedDemoUsers.Staff.Password); err != nil {
-				return fmt.Errorf("seed staff user for tenant %s: %w", t.Slug, err)
-			}
-
-			if err := authService.EnsureSeedUserWithRoles(tCtx, authrepo.CreateUserParams{
-				Email:      cfg.SeedDemoUsers.Viewer.Email,
-				FullName:   cfg.SeedDemoUsers.Viewer.FullName,
-				Department: stringPointer(cfg.SeedDemoUsers.Viewer.Department),
-				Skills:     cfg.SeedDemoUsers.Viewer.Skills,
-			}, []rbac.RoleKey{{Name: "viewer", Module: "operational"}}, cfg.SeedDemoUsers.Viewer.Password); err != nil {
-				return fmt.Errorf("seed viewer user for tenant %s: %w", t.Slug, err)
-			}
-
-			if err := authService.EnsureSeedUserWithRoles(tCtx, authrepo.CreateUserParams{
-				Email:      cfg.SeedDemoUsers.MarketingStaff.Email,
-				FullName:   cfg.SeedDemoUsers.MarketingStaff.FullName,
-				Department: stringPointer(cfg.SeedDemoUsers.MarketingStaff.Department),
-				Skills:     cfg.SeedDemoUsers.MarketingStaff.Skills,
-			}, []rbac.RoleKey{{Name: "staff", Module: "marketing"}}, cfg.SeedDemoUsers.MarketingStaff.Password); err != nil {
-				return fmt.Errorf("seed marketing staff user for tenant %s: %w", t.Slug, err)
-			}
-
-			if err := authService.EnsureSeedUserWithRoles(tCtx, authrepo.CreateUserParams{
-				Email:      cfg.SeedDemoUsers.MarketingViewer.Email,
-				FullName:   cfg.SeedDemoUsers.MarketingViewer.FullName,
-				Department: stringPointer(cfg.SeedDemoUsers.MarketingViewer.Department),
-				Skills:     cfg.SeedDemoUsers.MarketingViewer.Skills,
-			}, []rbac.RoleKey{{Name: "viewer", Module: "marketing"}}, cfg.SeedDemoUsers.MarketingViewer.Password); err != nil {
-				return fmt.Errorf("seed marketing viewer user for tenant %s: %w", t.Slug, err)
-			}
-		}
-
-		return nil
-	}); err != nil {
-		pool.Close()
-		return nil, fmt.Errorf("seed users: %w", err)
-	}
-
 	projectsRepository := operationalrepo.NewProjectsRepository(pool)
 	kanbanRepository := operationalrepo.NewKanbanRepository(pool)
 	operationalOverviewRepository := operationalrepo.NewOverviewRepository(pool)
@@ -668,14 +611,6 @@ func ensureRuntimeDirectories(cfg config.Config) error {
 	}
 
 	return nil
-}
-
-func stringPointer(value string) *string {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return nil
-	}
-	return &trimmed
 }
 
 const defaultTenantID = "00000000-0000-0000-0000-000000000001"

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -24,8 +24,6 @@ type Config struct {
 	JWTRefreshExpiry          time.Duration
 	CORSOrigins               []string
 	TrackerRetentionDays      int
-	SeedSuperAdmin            SeedSuperAdminConfig
-	SeedDemoUsers             SeedDemoUsersConfig
 	AppURL                    string
 	Tenants                   []TenantConfig
 	WAHADefaults              WAHADefaultsConfig
@@ -44,29 +42,6 @@ type WAHADefaultsConfig struct {
 	MaxDelayMS       int
 	ReminderCron     string
 	WeeklyDigestCron string
-}
-
-type SeedSuperAdminConfig struct {
-	Enabled  bool
-	Email    string
-	Password string
-	FullName string
-}
-
-type SeedDemoUsersConfig struct {
-	Enabled         bool
-	Staff           SeedUserConfig
-	Viewer          SeedUserConfig
-	MarketingStaff  SeedUserConfig
-	MarketingViewer SeedUserConfig
-}
-
-type SeedUserConfig struct {
-	Email      string
-	Password   string
-	FullName   string
-	Department string
-	Skills     []string
 }
 
 // TenantConfig describes one tenant seeded at startup.
@@ -94,16 +69,6 @@ func Load() (Config, error) {
 	dataEncryptionKey := strings.TrimSpace(os.Getenv("DATA_ENCRYPTION_KEY"))
 	dataEncryptionKeyPrevious := strings.TrimSpace(os.Getenv("DATA_ENCRYPTION_KEY_PREVIOUS"))
 
-	seedEnabled, err := parseBool("SEED_SUPERADMIN_ENABLED", false)
-	if err != nil {
-		return Config{}, err
-	}
-
-	demoUsersEnabled, err := parseBool("SEED_DEMO_USERS_ENABLED", false)
-	if err != nil {
-		return Config{}, err
-	}
-
 	wahaDefaults, err := loadWAHADefaults()
 	if err != nil {
 		return Config{}, err
@@ -124,43 +89,6 @@ func Load() (Config, error) {
 		AppURL:                    getEnv("APP_URL", "http://localhost:3000"),
 		Tenants:                   parseTenants(getEnv("TENANTS", "Default|default|localhost")),
 		WAHADefaults:              wahaDefaults,
-		SeedSuperAdmin: SeedSuperAdminConfig{
-			Enabled:  seedEnabled,
-			Email:    getEnv("SEED_SUPERADMIN_EMAIL", "superadmin@kantor.local"),
-			Password: getEnv("SEED_SUPERADMIN_PASSWORD", "Password123!"),
-			FullName: getEnv("SEED_SUPERADMIN_FULL_NAME", "Seeded Super Admin"),
-		},
-		SeedDemoUsers: SeedDemoUsersConfig{
-			Enabled: demoUsersEnabled,
-			Staff: SeedUserConfig{
-				Email:      getEnv("SEED_STAFF_EMAIL", "staff.ops@kantor.local"),
-				Password:   getEnv("SEED_STAFF_PASSWORD", "Password123!"),
-				FullName:   getEnv("SEED_STAFF_FULL_NAME", "Operational Staff"),
-				Department: getEnv("SEED_STAFF_DEPARTMENT", "engineering"),
-				Skills:     splitCSV(getEnv("SEED_STAFF_SKILLS", "frontend,kanban")),
-			},
-			Viewer: SeedUserConfig{
-				Email:      getEnv("SEED_VIEWER_EMAIL", "viewer.ops@kantor.local"),
-				Password:   getEnv("SEED_VIEWER_PASSWORD", "Password123!"),
-				FullName:   getEnv("SEED_VIEWER_FULL_NAME", "Operational Viewer"),
-				Department: getEnv("SEED_VIEWER_DEPARTMENT", "finance"),
-				Skills:     splitCSV(getEnv("SEED_VIEWER_SKILLS", "qa,reporting")),
-			},
-			MarketingStaff: SeedUserConfig{
-				Email:      getEnv("SEED_MARKETING_STAFF_EMAIL", "staff.marketing@kantor.local"),
-				Password:   getEnv("SEED_MARKETING_STAFF_PASSWORD", "Password123!"),
-				FullName:   getEnv("SEED_MARKETING_STAFF_FULL_NAME", "Marketing Staff"),
-				Department: getEnv("SEED_MARKETING_STAFF_DEPARTMENT", "marketing"),
-				Skills:     splitCSV(getEnv("SEED_MARKETING_STAFF_SKILLS", "copywriting,ads,crm")),
-			},
-			MarketingViewer: SeedUserConfig{
-				Email:      getEnv("SEED_MARKETING_VIEWER_EMAIL", "viewer.marketing@kantor.local"),
-				Password:   getEnv("SEED_MARKETING_VIEWER_PASSWORD", "Password123!"),
-				FullName:   getEnv("SEED_MARKETING_VIEWER_FULL_NAME", "Marketing Viewer"),
-				Department: getEnv("SEED_MARKETING_VIEWER_DEPARTMENT", "marketing"),
-				Skills:     splitCSV(getEnv("SEED_MARKETING_VIEWER_SKILLS", "reporting")),
-			},
-		},
 	}
 
 	if cfg.DatabaseURL == "" {
@@ -178,38 +106,6 @@ func Load() (Config, error) {
 	if cfg.AppEnv == "production" {
 		if len(cfg.JWTSecret) < 32 {
 			return Config{}, errors.New("JWT_SECRET must be at least 32 characters in production")
-		}
-	}
-
-	if cfg.SeedSuperAdmin.Enabled {
-		if strings.TrimSpace(cfg.SeedSuperAdmin.Email) == "" {
-			return Config{}, errors.New("SEED_SUPERADMIN_EMAIL is required when seed is enabled")
-		}
-
-		if strings.TrimSpace(cfg.SeedSuperAdmin.Password) == "" {
-			return Config{}, errors.New("SEED_SUPERADMIN_PASSWORD is required when seed is enabled")
-		}
-
-		if strings.TrimSpace(cfg.SeedSuperAdmin.FullName) == "" {
-			return Config{}, errors.New("SEED_SUPERADMIN_FULL_NAME is required when seed is enabled")
-		}
-	}
-
-	if cfg.SeedDemoUsers.Enabled {
-		if strings.TrimSpace(cfg.SeedDemoUsers.Staff.Email) == "" || strings.TrimSpace(cfg.SeedDemoUsers.Staff.Password) == "" || strings.TrimSpace(cfg.SeedDemoUsers.Staff.FullName) == "" {
-			return Config{}, errors.New("SEED_STAFF_EMAIL, SEED_STAFF_PASSWORD, and SEED_STAFF_FULL_NAME are required when demo seeds are enabled")
-		}
-
-		if strings.TrimSpace(cfg.SeedDemoUsers.Viewer.Email) == "" || strings.TrimSpace(cfg.SeedDemoUsers.Viewer.Password) == "" || strings.TrimSpace(cfg.SeedDemoUsers.Viewer.FullName) == "" {
-			return Config{}, errors.New("SEED_VIEWER_EMAIL, SEED_VIEWER_PASSWORD, and SEED_VIEWER_FULL_NAME are required when demo seeds are enabled")
-		}
-
-		if strings.TrimSpace(cfg.SeedDemoUsers.MarketingStaff.Email) == "" || strings.TrimSpace(cfg.SeedDemoUsers.MarketingStaff.Password) == "" || strings.TrimSpace(cfg.SeedDemoUsers.MarketingStaff.FullName) == "" {
-			return Config{}, errors.New("SEED_MARKETING_STAFF_EMAIL, SEED_MARKETING_STAFF_PASSWORD, and SEED_MARKETING_STAFF_FULL_NAME are required when demo seeds are enabled")
-		}
-
-		if strings.TrimSpace(cfg.SeedDemoUsers.MarketingViewer.Email) == "" || strings.TrimSpace(cfg.SeedDemoUsers.MarketingViewer.Password) == "" || strings.TrimSpace(cfg.SeedDemoUsers.MarketingViewer.FullName) == "" {
-			return Config{}, errors.New("SEED_MARKETING_VIEWER_EMAIL, SEED_MARKETING_VIEWER_PASSWORD, and SEED_MARKETING_VIEWER_FULL_NAME are required when demo seeds are enabled")
 		}
 	}
 

--- a/backend/internal/seed/data.go
+++ b/backend/internal/seed/data.go
@@ -1,0 +1,69 @@
+// Package seed contains hard-coded demo fixtures used by the cmd/seed CLI.
+//
+// Demo data is intentionally kept in code (not env vars / YAML) so that
+// shipping a release with a misconfigured env var cannot accidentally
+// create accounts with known passwords in production. Seeding only ever
+// runs through an explicit `go run ./cmd/seed` invocation.
+package seed
+
+import "github.com/kana-consultant/kantor/backend/internal/rbac"
+
+// SuperAdmin is the demo super admin account.
+type SuperAdmin struct {
+	Email    string
+	Password string
+	FullName string
+}
+
+// User is one demo user record with the role assignment to apply.
+type User struct {
+	Email      string
+	Password   string
+	FullName   string
+	Department string
+	Skills     []string
+	Roles      []rbac.RoleKey
+}
+
+// DemoSuperAdmin is the canonical demo super admin.
+var DemoSuperAdmin = SuperAdmin{
+	Email:    "superadmin@kantor.local",
+	Password: "Password123!",
+	FullName: "Seeded Super Admin",
+}
+
+// DemoUsers is the list of non-admin demo accounts created by the seed CLI.
+var DemoUsers = []User{
+	{
+		Email:      "staff.ops@kantor.local",
+		Password:   "Password123!",
+		FullName:   "Operational Staff",
+		Department: "engineering",
+		Skills:     []string{"frontend", "kanban"},
+		Roles:      []rbac.RoleKey{{Name: "staff", Module: "operational"}},
+	},
+	{
+		Email:      "viewer.ops@kantor.local",
+		Password:   "Password123!",
+		FullName:   "Operational Viewer",
+		Department: "finance",
+		Skills:     []string{"qa", "reporting"},
+		Roles:      []rbac.RoleKey{{Name: "viewer", Module: "operational"}},
+	},
+	{
+		Email:      "staff.marketing@kantor.local",
+		Password:   "Password123!",
+		FullName:   "Marketing Staff",
+		Department: "marketing",
+		Skills:     []string{"copywriting", "ads", "crm"},
+		Roles:      []rbac.RoleKey{{Name: "staff", Module: "marketing"}},
+	},
+	{
+		Email:      "viewer.marketing@kantor.local",
+		Password:   "Password123!",
+		FullName:   "Marketing Viewer",
+		Department: "marketing",
+		Skills:     []string{"reporting"},
+		Roles:      []rbac.RoleKey{{Name: "viewer", Module: "marketing"}},
+	},
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,14 +61,14 @@ Production environment variables no longer carry those tenant-level WA settings.
 
 ### Seed Users
 
-**Disable seed users in production:**
+Demo accounts are no longer seeded automatically at boot. Run them on demand from the backend directory:
 
-```env
-SEED_SUPERADMIN_ENABLED=false
-SEED_DEMO_USERS_ENABLED=false
+```bash
+cd backend
+go run ./cmd/seed
 ```
 
-If you need an initial admin account, enable the super admin seed on first deploy only, then disable it.
+The CLI seeds the demo super admin and four module accounts (defined in `internal/seed/data.go`) for every tenant in `TENANTS`. **Do not run it in production** — the fixtures use a publicly known password.
 
 ### Encryption Key Rotation
 
@@ -92,8 +92,6 @@ JWT_ACCESS_EXPIRY=15m
 JWT_REFRESH_EXPIRY=168h
 CORS_ORIGINS=https://your-domain.com
 APP_URL=https://your-domain.com
-SEED_SUPERADMIN_ENABLED=false
-SEED_DEMO_USERS_ENABLED=false
 VITE_API_BASE_URL=/api/v1
 ```
 
@@ -188,8 +186,7 @@ The Docker Compose healthcheck already uses `/readyz`. External monitoring shoul
 - [ ] `APP_ENV=production`
 - [ ] `JWT_SECRET` is at least 32 random characters (not `change-me`)
 - [ ] `DATA_ENCRYPTION_KEY` is a strong random value
-- [ ] `SEED_SUPERADMIN_ENABLED=false`
-- [ ] `SEED_DEMO_USERS_ENABLED=false`
+- [ ] `cmd/seed` is **not** run against the production database
 - [ ] `CORS_ORIGINS` is set to your actual domain (not `*` or `localhost`)
 - [ ] TLS is terminating before traffic reaches the app
 - [ ] Database is not exposed to the public internet

--- a/module.nix
+++ b/module.nix
@@ -125,8 +125,6 @@ in
         JWT_ACCESS_EXPIRY = "15m";
         JWT_REFRESH_EXPIRY = "168h";
         TRACKER_RETENTION_DAYS = "90";
-        SEED_SUPERADMIN_ENABLED = "true";
-        SEED_DEMO_USERS_ENABLED = "false";
         WAHA_ENABLED = "true";
         WAHA_SESSION = "default";
         WAHA_MAX_DAILY_MESSAGES = "100";


### PR DESCRIPTION
## Summary
- Demo accounts (super admin + four module staff/viewer) are no longer created as a side-effect of server boot.
- New \`cmd/seed\` CLI consumes the fixtures from \`internal/seed/data.go\` and seeds every tenant returned by \`ForEachTenant\`.
- All \`SEED_*\` env vars and the \`SeedSuperAdminConfig\` / \`SeedDemoUsersConfig\` config blocks are gone — the only guard is now the explicit CLI invocation.
- RBAC defaults (\`internal/rbac/seeder.go\`) keep running at boot because the app needs roles/permissions to function.

Closes #47

## Test plan
- [x] \`cd backend && go build ./...\`
- [x] \`cd backend && go test ./...\`
- [ ] \`cd backend && go run ./cmd/seed\` against a fresh local DB and confirm the five demo accounts appear in every tenant.
- [ ] Boot the server with no \`SEED_*\` env vars and confirm no demo accounts are created automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)