### PR TITLE
fix(marketing): map lead CSV import columns by header name, not position

### DIFF
--- a/backend/internal/handler/marketing/leads.go
+++ b/backend/internal/handler/marketing/leads.go
@@ -277,6 +277,8 @@ func (h *LeadsHandler) writeError(ctx context.Context, w http.ResponseWriter, er
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"phone": "phone or email required", "email": "phone or email required"})
 	case errors.Is(err, marketingservice.ErrLeadImportLimitExceeded):
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"file": "maximum 10000 rows per import"})
+	case errors.Is(err, marketingservice.ErrLeadImportMissingHeader):
+		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error(), map[string]string{"file": "missing required header columns"})
 	default:
 		response.WriteInternalError(ctx, w, err, "An unexpected error occurred")
 	}

--- a/backend/internal/service/marketing/leads.go
+++ b/backend/internal/service/marketing/leads.go
@@ -21,7 +21,27 @@ var (
 	ErrLeadCampaignNotFound     = errors.New("lead campaign not found")
 	ErrLeadContactRequired      = errors.New("lead must include at least phone or email")
 	ErrLeadImportLimitExceeded  = errors.New("lead import exceeds 10000 rows")
+	ErrLeadImportMissingHeader  = errors.New("lead CSV is missing required header columns")
 )
+
+// leadCSVRequiredHeaders are the header columns the importer needs to find in
+// the first row of the CSV. The importer is header-driven (not positional) so
+// callers can produce CSVs from any tool as long as the columns are named.
+var leadCSVRequiredHeaders = []string{"name", "source_channel", "pipeline_status"}
+
+// leadCSVKnownHeaders is the full set of columns the importer recognises.
+// Anything not in this list is ignored without an error.
+var leadCSVKnownHeaders = []string{
+	"name",
+	"phone",
+	"email",
+	"source_channel",
+	"pipeline_status",
+	"assigned_to",
+	"notes",
+	"company_name",
+	"estimated_value",
+}
 
 const maxLeadImportRows = 10000
 
@@ -161,6 +181,7 @@ func (s *LeadsService) CreateActivity(ctx context.Context, leadID string, reques
 func (s *LeadsService) ImportCSV(ctx context.Context, reader io.Reader, actorID string) (model.LeadImportSummary, error) {
 	csvReader := csv.NewReader(reader)
 	csvReader.TrimLeadingSpace = true
+	csvReader.FieldsPerRecord = -1
 
 	header, err := csvReader.Read()
 	if err != nil {
@@ -171,6 +192,11 @@ func (s *LeadsService) ImportCSV(ctx context.Context, reader io.Reader, actorID 
 	}
 	if len(header) == 0 {
 		return model.LeadImportSummary{}, nil
+	}
+
+	headerIndex, missing := buildLeadCSVHeaderIndex(header)
+	if len(missing) > 0 {
+		return model.LeadImportSummary{}, fmt.Errorf("%w: %s", ErrLeadImportMissingHeader, strings.Join(missing, ", "))
 	}
 
 	summary := model.LeadImportSummary{
@@ -198,7 +224,7 @@ func (s *LeadsService) ImportCSV(ctx context.Context, reader io.Reader, actorID 
 			return summary, ErrLeadImportLimitExceeded
 		}
 
-		request, parseErr := parseLeadCSVRow(row)
+		request, parseErr := parseLeadCSVRow(row, headerIndex)
 		if parseErr != nil {
 			summary.FailedCount++
 			summary.Errors = append(summary.Errors, model.LeadImportError{
@@ -221,6 +247,51 @@ func (s *LeadsService) ImportCSV(ctx context.Context, reader io.Reader, actorID 
 	}
 
 	return summary, nil
+}
+
+// buildLeadCSVHeaderIndex normalises the header row (lower-case, trimmed,
+// underscores instead of spaces/dashes) and returns a map from canonical
+// header name to column index. Unknown columns are kept in the map so the
+// caller can decide whether to ignore them. Required headers that are not
+// present are returned in `missing`.
+func buildLeadCSVHeaderIndex(header []string) (map[string]int, []string) {
+	known := make(map[string]struct{}, len(leadCSVKnownHeaders))
+	for _, name := range leadCSVKnownHeaders {
+		known[name] = struct{}{}
+	}
+
+	index := make(map[string]int, len(header))
+	for i, raw := range header {
+		key := normaliseLeadCSVHeader(raw)
+		if key == "" {
+			continue
+		}
+		if _, ok := known[key]; !ok {
+			continue
+		}
+		if _, exists := index[key]; exists {
+			continue
+		}
+		index[key] = i
+	}
+
+	missing := make([]string, 0, len(leadCSVRequiredHeaders))
+	for _, required := range leadCSVRequiredHeaders {
+		if _, ok := index[required]; !ok {
+			missing = append(missing, required)
+		}
+	}
+	return index, missing
+}
+
+func normaliseLeadCSVHeader(value string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(value))
+	trimmed = strings.ReplaceAll(trimmed, "-", "_")
+	trimmed = strings.ReplaceAll(trimmed, " ", "_")
+	for strings.Contains(trimmed, "__") {
+		trimmed = strings.ReplaceAll(trimmed, "__", "_")
+	}
+	return trimmed
 }
 
 func isBlankLeadCSVRow(row []string) bool {
@@ -272,12 +343,17 @@ func mapLeadError(err error) error {
 	}
 }
 
-func parseLeadCSVRow(row []string) (marketingdto.CreateLeadRequest, error) {
-	columns := make([]string, 9)
-	copy(columns, row)
+func parseLeadCSVRow(row []string, headerIndex map[string]int) (marketingdto.CreateLeadRequest, error) {
+	get := func(key string) string {
+		idx, ok := headerIndex[key]
+		if !ok || idx < 0 || idx >= len(row) {
+			return ""
+		}
+		return row[idx]
+	}
 
 	estimatedValue := int64(0)
-	if value := strings.TrimSpace(columns[8]); value != "" {
+	if value := strings.TrimSpace(get("estimated_value")); value != "" {
 		parsed, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return marketingdto.CreateLeadRequest{}, errors.New("estimated_value must be a number")
@@ -286,15 +362,15 @@ func parseLeadCSVRow(row []string) (marketingdto.CreateLeadRequest, error) {
 	}
 
 	return marketingdto.CreateLeadRequest{
-		Name:           strings.TrimSpace(columns[0]),
-		Phone:          stringPointer(columns[1]),
-		Email:          stringPointer(columns[2]),
-		SourceChannel:  strings.TrimSpace(columns[3]),
-		PipelineStatus: strings.TrimSpace(columns[4]),
+		Name:           strings.TrimSpace(get("name")),
+		Phone:          stringPointer(get("phone")),
+		Email:          stringPointer(get("email")),
+		SourceChannel:  strings.TrimSpace(get("source_channel")),
+		PipelineStatus: strings.TrimSpace(get("pipeline_status")),
 		CampaignID:     nil,
-		AssignedTo:     stringPointer(columns[5]),
-		Notes:          stringPointer(columns[6]),
-		CompanyName:    stringPointer(columns[7]),
+		AssignedTo:     stringPointer(get("assigned_to")),
+		Notes:          stringPointer(get("notes")),
+		CompanyName:    stringPointer(get("company_name")),
 		EstimatedValue: estimatedValue,
 	}, nil
 }

--- a/backend/internal/service/marketing/leads_csv_test.go
+++ b/backend/internal/service/marketing/leads_csv_test.go
@@ -1,0 +1,112 @@
+package marketing
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestBuildLeadCSVHeaderIndex_AllHeadersPresent(t *testing.T) {
+	header := []string{
+		"Name", "Phone", "Email",
+		"Source Channel", "Pipeline-Status",
+		"assigned_to", "notes", "Company Name", "Estimated_Value",
+	}
+	index, missing := buildLeadCSVHeaderIndex(header)
+	if len(missing) != 0 {
+		t.Fatalf("expected no missing headers, got %v", missing)
+	}
+
+	want := map[string]int{
+		"name":            0,
+		"phone":           1,
+		"email":           2,
+		"source_channel":  3,
+		"pipeline_status": 4,
+		"assigned_to":     5,
+		"notes":           6,
+		"company_name":    7,
+		"estimated_value": 8,
+	}
+	if !reflect.DeepEqual(index, want) {
+		t.Fatalf("index mismatch:\n got: %v\nwant: %v", index, want)
+	}
+}
+
+func TestBuildLeadCSVHeaderIndex_ReorderedColumns(t *testing.T) {
+	// Pipeline export tools often reorder columns. The importer must follow
+	// the headers, not column position.
+	header := []string{"email", "name", "source_channel", "pipeline_status", "phone"}
+	index, missing := buildLeadCSVHeaderIndex(header)
+	if len(missing) != 0 {
+		t.Fatalf("expected no missing headers, got %v", missing)
+	}
+	if index["name"] != 1 {
+		t.Fatalf("name should be at column 1, got %d", index["name"])
+	}
+	if index["email"] != 0 {
+		t.Fatalf("email should be at column 0, got %d", index["email"])
+	}
+}
+
+func TestBuildLeadCSVHeaderIndex_MissingRequired(t *testing.T) {
+	header := []string{"name", "phone"}
+	_, missing := buildLeadCSVHeaderIndex(header)
+	sort.Strings(missing)
+	want := []string{"pipeline_status", "source_channel"}
+	if !reflect.DeepEqual(missing, want) {
+		t.Fatalf("missing mismatch:\n got: %v\nwant: %v", missing, want)
+	}
+}
+
+func TestBuildLeadCSVHeaderIndex_UnknownColumnsIgnored(t *testing.T) {
+	header := []string{"name", "source_channel", "pipeline_status", "internal_score"}
+	index, missing := buildLeadCSVHeaderIndex(header)
+	if len(missing) != 0 {
+		t.Fatalf("expected no missing headers, got %v", missing)
+	}
+	if _, ok := index["internal_score"]; ok {
+		t.Fatalf("unknown column internal_score should be ignored")
+	}
+}
+
+func TestParseLeadCSVRow_MapsByHeaderName(t *testing.T) {
+	// Importing a CSV where columns are reordered relative to the legacy
+	// positional schema must still yield the correct fields.
+	header := []string{"email", "name", "source_channel", "pipeline_status", "phone", "estimated_value"}
+	index, _ := buildLeadCSVHeaderIndex(header)
+	row := []string{"a@b.test", "Alice", "wa", "new", "+62811", "150000"}
+
+	got, err := parseLeadCSVRow(row, index)
+	if err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if got.Name != "Alice" {
+		t.Fatalf("expected Name=Alice, got %q", got.Name)
+	}
+	if got.SourceChannel != "wa" {
+		t.Fatalf("expected SourceChannel=wa, got %q", got.SourceChannel)
+	}
+	if got.PipelineStatus != "new" {
+		t.Fatalf("expected PipelineStatus=new, got %q", got.PipelineStatus)
+	}
+	if got.Phone == nil || *got.Phone != "+62811" {
+		t.Fatalf("expected Phone=+62811, got %v", got.Phone)
+	}
+	if got.Email == nil || *got.Email != "a@b.test" {
+		t.Fatalf("expected Email=a@b.test, got %v", got.Email)
+	}
+	if got.EstimatedValue != 150000 {
+		t.Fatalf("expected EstimatedValue=150000, got %d", got.EstimatedValue)
+	}
+}
+
+func TestParseLeadCSVRow_InvalidEstimatedValue(t *testing.T) {
+	header := []string{"name", "source_channel", "pipeline_status", "estimated_value"}
+	index, _ := buildLeadCSVHeaderIndex(header)
+	row := []string{"Alice", "wa", "new", "not-a-number"}
+
+	if _, err := parseLeadCSVRow(row, index); err == nil {
+		t.Fatalf("expected error for non-numeric estimated_value, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Lead CSV importer in \`service/marketing/leads.go\` decoded each data row by column index 0–8 even though the first row was always treated as a header. A CSV with reordered columns silently produced wrong leads.
- Now \`buildLeadCSVHeaderIndex\` normalises the header row (lower-case, spaces/dashes → underscores) and maps known column names → row index. Required headers (\`name\`, \`source_channel\`, \`pipeline_status\`) are validated up front; missing ones return \`ErrLeadImportMissingHeader\` → \`400\`.
- Each row is decoded through that map, so column order no longer matters.
- Adds \`leads_csv_test.go\` covering reordered columns, missing required headers, unknown columns being ignored, and invalid \`estimated_value\`.

Closes #63

## Test plan
- [x] \`cd backend && go build ./...\`
- [x] \`cd backend && go test ./internal/service/marketing/...\`
- [ ] Upload a CSV with reordered columns through the UI and confirm leads land on the correct fields.
- [ ] Upload a CSV missing \`pipeline_status\` and confirm a 400 with the validation message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)