### PR TITLE
fix(security): enforce file upload extension allowlist + force download

### DIFF
--- a/backend/internal/handler/auth/profile.go
+++ b/backend/internal/handler/auth/profile.go
@@ -10,13 +10,13 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/kana-consultant/kantor/backend/internal/dto"
 	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
 	"github.com/kana-consultant/kantor/backend/internal/response"
 	authservice "github.com/kana-consultant/kantor/backend/internal/service/auth"
+	"github.com/kana-consultant/kantor/backend/internal/uploads"
 )
 
 func (h *Handler) GetProfile(w http.ResponseWriter, r *http.Request) {
@@ -130,8 +130,8 @@ func (h *Handler) UploadProfileAvatar(w http.ResponseWriter, r *http.Request) {
 var unsafeCharsRe = regexp.MustCompile(`[^a-zA-Z0-9._-]`)
 
 func saveProfileAvatar(baseDir string, userID string, file *multipart.FileHeader) (string, error) {
-	if file.Size > 5<<20 {
-		return "", fmt.Errorf("avatar harus lebih kecil dari 5MB")
+	if _, err := uploads.ValidateMultipartFile(uploads.KindAvatar, file); err != nil {
+		return "", fmt.Errorf("avatar tidak valid: %w", err)
 	}
 
 	src, err := file.Open()
@@ -139,20 +139,6 @@ func saveProfileAvatar(baseDir string, userID string, file *multipart.FileHeader
 		return "", fmt.Errorf("gagal membuka file: %w", err)
 	}
 	defer src.Close()
-
-	sniff := make([]byte, 512)
-	n, readErr := src.Read(sniff)
-	if readErr != nil && !errors.Is(readErr, io.EOF) {
-		return "", fmt.Errorf("gagal membaca file: %w", readErr)
-	}
-	if _, err := src.Seek(0, 0); err != nil {
-		return "", err
-	}
-
-	contentType := http.DetectContentType(sniff[:n])
-	if !strings.HasPrefix(contentType, "image/") {
-		return "", fmt.Errorf("file harus berupa gambar")
-	}
 
 	dir := filepath.Join(baseDir, "profiles", userID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/backend/internal/handler/files/handler.go
+++ b/backend/internal/handler/files/handler.go
@@ -2,7 +2,9 @@ package files
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -49,8 +51,30 @@ func (h *Handler) Serve(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Force browsers to download instead of render uploaded files. Combined
+	// with X-Content-Type-Options: nosniff this neutralises polyglot files
+	// that pass our magic-byte check but also embed executable HTML/JS.
+	disposition := "inline"
+	if shouldForceDownload(filename) {
+		disposition = "attachment"
+	}
+	w.Header().Set("Content-Disposition", fmt.Sprintf("%s; filename=%q", disposition, filepath.Base(filename)))
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("Cache-Control", "no-store")
 	http.ServeFile(w, r, file.Path)
+}
+
+// shouldForceDownload returns true for filenames whose extension is not a
+// safe-to-render image. Documents, archives, scripts, and unknown types are
+// forced into a download rather than rendered inline.
+func shouldForceDownload(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	switch ext {
+	case ".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp":
+		return false
+	default:
+		return true
+	}
 }
 
 func hasPermission(principal platformmiddleware.Principal, permission string, ownerUserID *string) bool {

--- a/backend/internal/handler/hris/employees.go
+++ b/backend/internal/handler/hris/employees.go
@@ -21,6 +21,7 @@ import (
 	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
 	"github.com/kana-consultant/kantor/backend/internal/response"
 	hrisservice "github.com/kana-consultant/kantor/backend/internal/service/hris"
+	"github.com/kana-consultant/kantor/backend/internal/uploads"
 )
 
 type EmployeesHandler struct {
@@ -257,8 +258,8 @@ var (
 )
 
 func saveEmployeeAvatar(baseUploadsDir string, employeeID string, file *multipart.FileHeader) (string, error) {
-	if file.Size > 5<<20 {
-		return "", fmt.Errorf("%w: avatar image must be smaller than 5MB", errEmployeeAvatarValidation)
+	if _, err := uploads.ValidateMultipartFile(uploads.KindAvatar, file); err != nil {
+		return "", fmt.Errorf("%w: %w", errEmployeeAvatarValidation, err)
 	}
 
 	src, err := file.Open()
@@ -266,20 +267,6 @@ func saveEmployeeAvatar(baseUploadsDir string, employeeID string, file *multipar
 		return "", fmt.Errorf("%w: %w", errEmployeeAvatarStorage, err)
 	}
 	defer src.Close()
-
-	sniff := make([]byte, 512)
-	n, readErr := src.Read(sniff)
-	if readErr != nil && !errors.Is(readErr, io.EOF) {
-		return "", fmt.Errorf("%w: %w", errEmployeeAvatarStorage, readErr)
-	}
-	if _, err := src.Seek(0, 0); err != nil {
-		return "", fmt.Errorf("%w: %w", errEmployeeAvatarStorage, err)
-	}
-
-	contentType := http.DetectContentType(sniff[:n])
-	if !strings.HasPrefix(contentType, "image/") {
-		return "", fmt.Errorf("%w: avatar must be an image file", errEmployeeAvatarValidation)
-	}
 
 	dir := filepath.Join(baseUploadsDir, "employees", employeeID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {

--- a/backend/internal/handler/hris/reimbursements.go
+++ b/backend/internal/handler/hris/reimbursements.go
@@ -23,6 +23,7 @@ import (
 	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
 	"github.com/kana-consultant/kantor/backend/internal/response"
 	hrisservice "github.com/kana-consultant/kantor/backend/internal/service/hris"
+	"github.com/kana-consultant/kantor/backend/internal/uploads"
 )
 
 type ReimbursementsHandler struct {
@@ -34,7 +35,6 @@ type ReimbursementsHandler struct {
 
 const (
 	maxReimbursementAttachmentFiles   = 5
-	maxReimbursementAttachmentSize    = 10 << 20
 	maxReimbursementMultipartMaxBytes = 50 << 20
 )
 
@@ -408,30 +408,13 @@ func saveAttachments(baseUploadsDir string, files []*multipart.FileHeader) ([]st
 
 	paths := make([]string, 0, len(files))
 	for _, file := range files {
-		if file.Size > maxReimbursementAttachmentSize {
-			return nil, fmt.Errorf("%w: each file must be smaller than 10MB", errAttachmentValidation)
+		if _, err := uploads.ValidateMultipartFile(uploads.KindReimbursement, file); err != nil {
+			return nil, fmt.Errorf("%w: %w", errAttachmentValidation, err)
 		}
 
 		src, err := file.Open()
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", errAttachmentStorage, err)
-		}
-
-		sniff := make([]byte, 512)
-		n, readErr := src.Read(sniff)
-		if readErr != nil && !errors.Is(readErr, io.EOF) {
-			_ = src.Close()
-			return nil, fmt.Errorf("%w: %w", errAttachmentStorage, readErr)
-		}
-		if _, err := src.Seek(0, 0); err != nil {
-			_ = src.Close()
-			return nil, fmt.Errorf("%w: %w", errAttachmentStorage, err)
-		}
-
-		contentType := http.DetectContentType(sniff[:n])
-		if !allowedAttachmentType(contentType) {
-			_ = src.Close()
-			return nil, fmt.Errorf("%w: only image and PDF files are allowed", errAttachmentValidation)
 		}
 
 		filename := strconv.FormatInt(time.Now().UnixNano(), 10) + "-" + sanitizeFilename(file.Filename)
@@ -453,10 +436,6 @@ func saveAttachments(baseUploadsDir string, files []*multipart.FileHeader) ([]st
 	}
 
 	return paths, nil
-}
-
-func allowedAttachmentType(contentType string) bool {
-	return strings.HasPrefix(contentType, "image/") || contentType == "application/pdf"
 }
 
 func sanitizeFilename(value string) string {

--- a/backend/internal/handler/marketing/campaigns.go
+++ b/backend/internal/handler/marketing/campaigns.go
@@ -23,6 +23,7 @@ import (
 	marketingrepo "github.com/kana-consultant/kantor/backend/internal/repository/marketing"
 	"github.com/kana-consultant/kantor/backend/internal/response"
 	marketingservice "github.com/kana-consultant/kantor/backend/internal/service/marketing"
+	"github.com/kana-consultant/kantor/backend/internal/uploads"
 )
 
 type CampaignsHandler struct {
@@ -452,30 +453,15 @@ func saveCampaignAttachments(baseUploadsDir string, files []*multipart.FileHeade
 
 	items := make([]uploadedCampaignFile, 0, len(files))
 	for _, file := range files {
-		if file.Size > 25<<20 {
-			return nil, fmt.Errorf("%w: each file must be smaller than 25MB", errCampaignAttachmentValidation)
+		validation, err := uploads.ValidateMultipartFile(uploads.KindCampaignAttachment, file)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", errCampaignAttachmentValidation, err)
 		}
+		contentType := validation.ContentType
 
 		src, err := file.Open()
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", errCampaignAttachmentStorage, err)
-		}
-
-		sniff := make([]byte, 512)
-		n, readErr := src.Read(sniff)
-		if readErr != nil && !errors.Is(readErr, io.EOF) {
-			_ = src.Close()
-			return nil, fmt.Errorf("%w: %w", errCampaignAttachmentStorage, readErr)
-		}
-		if _, err := src.Seek(0, 0); err != nil {
-			_ = src.Close()
-			return nil, fmt.Errorf("%w: %w", errCampaignAttachmentStorage, err)
-		}
-
-		contentType := http.DetectContentType(sniff[:n])
-		if !allowedCampaignAttachmentType(contentType) {
-			_ = src.Close()
-			return nil, fmt.Errorf("%w: unsupported file type", errCampaignAttachmentValidation)
 		}
 
 		filename := strconv.FormatInt(time.Now().UnixNano(), 10) + "-" + sanitizeCampaignFilename(file.Filename)
@@ -505,27 +491,6 @@ func saveCampaignAttachments(baseUploadsDir string, files []*multipart.FileHeade
 	}
 
 	return items, nil
-}
-
-func allowedCampaignAttachmentType(contentType string) bool {
-	if strings.HasPrefix(contentType, "image/") || strings.HasPrefix(contentType, "video/") {
-		return true
-	}
-
-	switch contentType {
-	case "application/pdf",
-		"text/plain",
-		"text/plain; charset=utf-8",
-		"application/zip",
-		"application/x-zip-compressed",
-		"application/msword",
-		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-		"application/vnd.ms-powerpoint",
-		"application/vnd.openxmlformats-officedocument.presentationml.presentation":
-		return true
-	default:
-		return false
-	}
 }
 
 func sanitizeCampaignFilename(value string) string {

--- a/backend/internal/uploads/validate.go
+++ b/backend/internal/uploads/validate.go
@@ -1,0 +1,179 @@
+// Package uploads centralises file upload validation. Every uploaded file
+// must satisfy both an extension allowlist and a content-type sniff so that
+// polyglot files (valid magic bytes paired with an executable extension)
+// cannot bypass our checks.
+package uploads
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"path/filepath"
+	"strings"
+)
+
+// Kind identifies which upload category a file belongs to. Each kind has its
+// own size cap, allowed extensions and allowed content-type prefixes.
+type Kind string
+
+const (
+	KindAvatar               Kind = "avatar"
+	KindReimbursement        Kind = "reimbursement"
+	KindCampaignAttachment   Kind = "campaign"
+)
+
+// ErrValidation is the sentinel error returned for any user-facing validation
+// failure (size, extension, mismatched content type). Callers should wrap it
+// with a descriptive message and surface a 400 to the client.
+var ErrValidation = errors.New("upload validation failed")
+
+// ValidationResult is what the validator returns when a file passes. The
+// caller can use the sniffed content type for storage metadata (e.g. campaign
+// attachment file_type column).
+type ValidationResult struct {
+	ContentType string
+	Extension   string
+}
+
+type kindRules struct {
+	maxSize             int64
+	allowedExtensions   map[string]struct{}
+	allowedContentTypes []string
+	allowContentType    func(string) bool
+}
+
+func (r kindRules) extensionAllowed(ext string) bool {
+	_, ok := r.allowedExtensions[strings.ToLower(ext)]
+	return ok
+}
+
+func (r kindRules) contentTypeAllowed(ct string) bool {
+	ct = strings.ToLower(strings.TrimSpace(ct))
+	if r.allowContentType != nil && r.allowContentType(ct) {
+		return true
+	}
+	for _, allowed := range r.allowedContentTypes {
+		if ct == allowed || strings.HasPrefix(ct, allowed+";") {
+			return true
+		}
+	}
+	return false
+}
+
+func setOf(values ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(values))
+	for _, v := range values {
+		out[strings.ToLower(v)] = struct{}{}
+	}
+	return out
+}
+
+var rulesByKind = map[Kind]kindRules{
+	KindAvatar: {
+		maxSize:           5 << 20,
+		allowedExtensions: setOf(".jpg", ".jpeg", ".png", ".gif", ".webp"),
+		allowContentType: func(ct string) bool {
+			return strings.HasPrefix(ct, "image/")
+		},
+	},
+	KindReimbursement: {
+		maxSize:           10 << 20,
+		allowedExtensions: setOf(".jpg", ".jpeg", ".png", ".gif", ".webp", ".pdf"),
+		allowedContentTypes: []string{
+			"application/pdf",
+		},
+		allowContentType: func(ct string) bool {
+			return strings.HasPrefix(ct, "image/") || ct == "application/pdf"
+		},
+	},
+	KindCampaignAttachment: {
+		maxSize: 25 << 20,
+		allowedExtensions: setOf(
+			".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg",
+			".mp4", ".mov", ".webm", ".avi",
+			".pdf", ".txt",
+			".zip",
+			".doc", ".docx",
+			".ppt", ".pptx",
+			".xls", ".xlsx",
+		),
+		allowedContentTypes: []string{
+			"application/pdf",
+			"text/plain",
+			"application/zip",
+			"application/x-zip-compressed",
+			"application/msword",
+			"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+			"application/vnd.ms-powerpoint",
+			"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+			"application/vnd.ms-excel",
+			"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+		},
+		allowContentType: func(ct string) bool {
+			return strings.HasPrefix(ct, "image/") || strings.HasPrefix(ct, "video/")
+		},
+	},
+}
+
+// MaxSize reports the size cap (bytes) for the given upload kind.
+func MaxSize(kind Kind) int64 {
+	if rules, ok := rulesByKind[kind]; ok {
+		return rules.maxSize
+	}
+	return 0
+}
+
+// ValidateMultipartFile checks the multipart upload's size, file extension
+// and sniffed content type against the rules for the given kind. The file's
+// read offset is reset to 0 before returning so the caller can stream it to
+// disk afterwards.
+func ValidateMultipartFile(kind Kind, file *multipart.FileHeader) (ValidationResult, error) {
+	rules, ok := rulesByKind[kind]
+	if !ok {
+		return ValidationResult{}, fmt.Errorf("%w: unknown upload kind %q", ErrValidation, kind)
+	}
+
+	if file == nil {
+		return ValidationResult{}, fmt.Errorf("%w: missing file", ErrValidation)
+	}
+
+	if file.Size <= 0 {
+		return ValidationResult{}, fmt.Errorf("%w: file is empty", ErrValidation)
+	}
+
+	if file.Size > rules.maxSize {
+		return ValidationResult{}, fmt.Errorf("%w: file must be smaller than %d bytes", ErrValidation, rules.maxSize)
+	}
+
+	ext := strings.ToLower(filepath.Ext(file.Filename))
+	if ext == "" {
+		return ValidationResult{}, fmt.Errorf("%w: filename is missing an extension", ErrValidation)
+	}
+	if !rules.extensionAllowed(ext) {
+		return ValidationResult{}, fmt.Errorf("%w: file extension %s is not allowed", ErrValidation, ext)
+	}
+
+	src, err := file.Open()
+	if err != nil {
+		return ValidationResult{}, fmt.Errorf("%w: %w", ErrValidation, err)
+	}
+	defer src.Close()
+
+	sniff := make([]byte, 512)
+	n, readErr := src.Read(sniff)
+	if readErr != nil && !errors.Is(readErr, io.EOF) {
+		return ValidationResult{}, fmt.Errorf("%w: %w", ErrValidation, readErr)
+	}
+	if _, err := src.Seek(0, io.SeekStart); err != nil {
+		return ValidationResult{}, fmt.Errorf("%w: %w", ErrValidation, err)
+	}
+
+	contentType := http.DetectContentType(sniff[:n])
+	if !rules.contentTypeAllowed(contentType) {
+		return ValidationResult{}, fmt.Errorf("%w: detected content type %q is not allowed", ErrValidation, contentType)
+	}
+
+	return ValidationResult{ContentType: contentType, Extension: ext}, nil
+}

--- a/backend/internal/uploads/validate_test.go
+++ b/backend/internal/uploads/validate_test.go
@@ -1,0 +1,115 @@
+package uploads
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"mime/multipart"
+	"net/textproto"
+	"strings"
+	"testing"
+)
+
+// pngMagic is enough bytes to make http.DetectContentType return "image/png".
+var pngMagic = []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+
+func writeMultipartFile(t *testing.T, filename string, body []byte) *multipart.FileHeader {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	writer := multipart.NewWriter(buf)
+
+	header := textproto.MIMEHeader{}
+	header.Set("Content-Disposition", `form-data; name="file"; filename="`+filename+`"`)
+	part, err := writer.CreatePart(header)
+	if err != nil {
+		t.Fatalf("create part: %v", err)
+	}
+	if _, err := part.Write(body); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	reader := multipart.NewReader(buf, writer.Boundary())
+	form, err := reader.ReadForm(int64(len(body)) + 1024)
+	if err != nil {
+		t.Fatalf("read form: %v", err)
+	}
+	files := form.File["file"]
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	return files[0]
+}
+
+func TestValidateMultipartFile_AvatarHappyPath(t *testing.T) {
+	fh := writeMultipartFile(t, "selfie.png", append(pngMagic, bytes.Repeat([]byte{0x00}, 256)...))
+	res, err := ValidateMultipartFile(KindAvatar, fh)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Extension != ".png" {
+		t.Fatalf("expected .png, got %q", res.Extension)
+	}
+	if !strings.HasPrefix(res.ContentType, "image/png") {
+		t.Fatalf("expected image/png content type, got %q", res.ContentType)
+	}
+}
+
+func TestValidateMultipartFile_RejectsExeExtension(t *testing.T) {
+	// Polyglot: image magic bytes paired with an executable extension. The
+	// extension allowlist must reject this even though DetectContentType
+	// would happily return image/png.
+	fh := writeMultipartFile(t, "innocent.exe", append(pngMagic, bytes.Repeat([]byte{0x00}, 256)...))
+	if _, err := ValidateMultipartFile(KindAvatar, fh); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestValidateMultipartFile_RejectsMismatchedContentType(t *testing.T) {
+	// Plain text body but .png extension — content-type sniff catches it.
+	fh := writeMultipartFile(t, "fake.png", []byte("just plain text content"))
+	if _, err := ValidateMultipartFile(KindAvatar, fh); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestValidateMultipartFile_RejectsMissingExtension(t *testing.T) {
+	fh := writeMultipartFile(t, "noext", append(pngMagic, bytes.Repeat([]byte{0x00}, 256)...))
+	if _, err := ValidateMultipartFile(KindAvatar, fh); !errors.Is(err, ErrValidation) {
+		t.Fatalf("expected ErrValidation, got %v", err)
+	}
+}
+
+func TestValidateMultipartFile_ReimbursementAcceptsPDF(t *testing.T) {
+	pdf := []byte("%PDF-1.4\n")
+	pdf = append(pdf, bytes.Repeat([]byte{0x20}, 200)...)
+	fh := writeMultipartFile(t, "receipt.pdf", pdf)
+	res, err := ValidateMultipartFile(KindReimbursement, fh)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.ContentType != "application/pdf" {
+		t.Fatalf("expected application/pdf, got %q", res.ContentType)
+	}
+}
+
+func TestValidateMultipartFile_LeavesReadOffsetAtZero(t *testing.T) {
+	fh := writeMultipartFile(t, "selfie.png", append(pngMagic, bytes.Repeat([]byte{0x00}, 256)...))
+	if _, err := ValidateMultipartFile(KindAvatar, fh); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	src, err := fh.Open()
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer src.Close()
+	got, err := io.ReadAll(src)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.HasPrefix(got, pngMagic) {
+		t.Fatalf("read offset not reset; first bytes: %x", got[:8])
+	}
+}


### PR DESCRIPTION
## Summary
- Every upload handler relied on a single \`http.DetectContentType\` call. A polyglot (PNG magic bytes + JS payload, saved as \`selfie.svg\` or \`receipt.exe\`) silently passed validation.
- New \`internal/uploads\` package centralises validation. Each kind (\`KindAvatar\`, \`KindReimbursement\`, \`KindCampaignAttachment\`) declares an extension allowlist and an allowed content-type matcher; the helper enforces both.
- Avatar, employee-avatar, reimbursement-attachment and campaign-attachment handlers now go through that helper instead of open-coding their own checks.
- File-serving handler (\`handler/files\`) now forces \`Content-Disposition: attachment\` + \`X-Content-Type-Options: nosniff\` for everything except a small whitelist of safe-to-render image extensions.

Closes #64

## Test plan
- [x] \`cd backend && go build ./...\`
- [x] \`cd backend && go test ./internal/uploads/...\`
- [x] \`cd backend && go test ./...\`
- [ ] Upload an image renamed to \`.exe\` to a reimbursement and confirm 400.
- [ ] Upload an HTML file renamed to \`.png\` and confirm 400 (content type sniff).
- [ ] Download a reimbursement attachment via \`/files/...\` and confirm the response carries \`Content-Disposition: attachment\` and \`X-Content-Type-Options: nosniff\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)