### PR TITLE
fix(security): rate-limit authenticated routes per user

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -360,6 +360,13 @@ func (a *App) buildRouter(
 
 			r.Group(func(protected chi.Router) {
 				protected.Use(platformmiddleware.AuthMiddleware(authService.ParseAccessToken, a.permissionCache.Load))
+				// Per-user throttle so a single compromised token cannot hammer
+				// expensive endpoints (e.g. HRIS overview, exports). 240 req/min
+				// is high enough to leave normal UI navigation untouched.
+				protected.Use(platformmiddleware.NewUserRateLimit(240, time.Minute,
+					"AUTH_RATE_LIMITED",
+					"Terlalu banyak request. Coba lagi sebentar.",
+				))
 				protected.Get("/auth/me", authHandler.Me)
 				protected.Put("/auth/client-context", authHandler.UpdateClientContext)
 				protected.Get("/auth/profile", authHandler.GetProfile)

--- a/backend/internal/middleware/rate_limit.go
+++ b/backend/internal/middleware/rate_limit.go
@@ -25,6 +25,25 @@ type rateLimitEntry struct {
 }
 
 func NewIPRateLimit(maxRequests int, window time.Duration, code string, message string) func(http.Handler) http.Handler {
+	return newRateLimit(maxRequests, window, code, message, func(r *http.Request) string {
+		return clientIPFromRequest(r)
+	})
+}
+
+// NewUserRateLimit returns a middleware that throttles authenticated traffic
+// by the authenticated user ID. When no principal is in the context (e.g. on
+// public routes accidentally wrapped with this middleware) it falls back to
+// the request IP so that anonymous traffic is still bounded.
+func NewUserRateLimit(maxRequests int, window time.Duration, code string, message string) func(http.Handler) http.Handler {
+	return newRateLimit(maxRequests, window, code, message, func(r *http.Request) string {
+		if principal, ok := PrincipalFromContext(r.Context()); ok && principal.UserID != "" {
+			return "user:" + principal.UserID
+		}
+		return "ip:" + clientIPFromRequest(r)
+	})
+}
+
+func newRateLimit(maxRequests int, window time.Duration, code string, message string, keyFn func(*http.Request) string) func(http.Handler) http.Handler {
 	limiter := &ipRateLimiter{
 		maxRequests: maxRequests,
 		window:      window,
@@ -33,7 +52,7 @@ func NewIPRateLimit(maxRequests int, window time.Duration, code string, message 
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			retryAfter := limiter.retryAfter(clientIPFromRequest(r), time.Now().UTC())
+			retryAfter := limiter.retryAfter(keyFn(r), time.Now().UTC())
 			if retryAfter > 0 {
 				retryAfterSeconds := int(math.Ceil(retryAfter.Seconds()))
 				if retryAfterSeconds < 1 {

--- a/backend/internal/middleware/rate_limit_test.go
+++ b/backend/internal/middleware/rate_limit_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -81,5 +82,64 @@ func TestNewIPRateLimitIsScopedPerIP(t *testing.T) {
 
 	if secondRecorder.Code != http.StatusOK {
 		t.Fatalf("expected second IP to pass independently, got %d", secondRecorder.Code)
+	}
+}
+
+func requestWithPrincipal(userID string, remoteAddr string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil)
+	r.RemoteAddr = remoteAddr
+	ctx := context.WithValue(r.Context(), principalContextKey, Principal{UserID: userID})
+	return r.WithContext(ctx)
+}
+
+func TestNewUserRateLimitScopesByUserID(t *testing.T) {
+	mw := NewUserRateLimit(2, time.Minute, "RATE_LIMITED", "Too many requests")
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for range 2 {
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, requestWithPrincipal("user-a", "10.0.0.1:1111"))
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("expected pass for user-a, got %d", recorder.Code)
+		}
+	}
+
+	blocked := httptest.NewRecorder()
+	handler.ServeHTTP(blocked, requestWithPrincipal("user-a", "10.0.0.1:1111"))
+	if blocked.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429 for user-a after limit, got %d", blocked.Code)
+	}
+
+	// Different user from the same IP must not be punished by user-a's quota.
+	other := httptest.NewRecorder()
+	handler.ServeHTTP(other, requestWithPrincipal("user-b", "10.0.0.1:1111"))
+	if other.Code != http.StatusOK {
+		t.Fatalf("expected user-b to pass independently, got %d", other.Code)
+	}
+}
+
+func TestNewUserRateLimitFallsBackToIP(t *testing.T) {
+	// When no principal is set, the limiter should still bound traffic by IP.
+	mw := NewUserRateLimit(1, time.Minute, "RATE_LIMITED", "Too many requests")
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	first := httptest.NewRecorder()
+	r1 := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r1.RemoteAddr = "10.0.0.2:1234"
+	handler.ServeHTTP(first, r1)
+	if first.Code != http.StatusOK {
+		t.Fatalf("expected first to pass, got %d", first.Code)
+	}
+
+	second := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/x", nil)
+	r2.RemoteAddr = "10.0.0.2:1234"
+	handler.ServeHTTP(second, r2)
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected anonymous fallback to throttle by IP, got %d", second.Code)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds \`middleware.NewUserRateLimit\` — a sibling of the existing \`NewIPRateLimit\` that keys throttling by the authenticated principal's user ID, falling back to client IP if no principal is on the context.
- Wires it into \`app.go\`'s protected route group at 240 req/min so a single compromised token cannot loop on expensive endpoints (HRIS overview decrypts every salary in memory) without hitting a 429.
- Refactors the rate-limit middleware to share a single keyed implementation behind both the IP and user constructors.
- Adds tests for per-user isolation and the IP fallback path.

Closes #54

## Test plan
- [x] \`cd backend && go test ./internal/middleware/...\`
- [x] \`cd backend && go test ./...\`
- [ ] Hit a protected endpoint 300 times in under a minute with the same access token and confirm a 429 with \`Retry-After\` after request 240.
- [ ] Confirm a second user (different token) on the same IP is not throttled by the first user's quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)