### PR TITLE
fix(security): cut RBAC permission cache TTL and invalidate on revocation

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -118,7 +118,10 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	auditService := auditservice.NewService(auditRepository)
 
 	authRepository := authrepo.New(pool)
-	permissionCache := rbac.NewPermissionCache(pool, 5*time.Minute)
+	// Short TTL — a revoked token / deactivated user must lose access in seconds,
+	// not minutes. Mutating endpoints (role change, deactivate, password change,
+	// password reset) explicitly call Invalidate() but the TTL is the safety net.
+	permissionCache := rbac.NewPermissionCache(pool, 60*time.Second)
 	employeesRepository := hrisrepo.NewEmployeesRepository(pool) // used by both auth & hris
 	var previousKeys []string
 	if cfg.DataEncryptionKeyPrevious != "" {

--- a/backend/internal/rbac/cache_test.go
+++ b/backend/internal/rbac/cache_test.go
@@ -1,0 +1,103 @@
+package rbac
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func newCacheForTest(ttl time.Duration) *PermissionCache {
+	return &PermissionCache{
+		store: make(map[string]*CachedPermissions),
+		ttl:   ttl,
+	}
+}
+
+func TestNewPermissionCache_DefaultTTLWhenZero(t *testing.T) {
+	c := NewPermissionCache(nil, 0)
+	if c.ttl <= 0 {
+		t.Fatalf("expected positive default TTL, got %v", c.ttl)
+	}
+}
+
+func TestPermissionCache_GetReturnsCachedValue(t *testing.T) {
+	c := newCacheForTest(time.Minute)
+	key := c.cacheKey(context.Background(), "user-1")
+	c.store[key] = &CachedPermissions{
+		IsSuperAdmin: true,
+		CachedAt:     time.Now().UTC(),
+		TTL:          time.Minute,
+	}
+
+	got := c.Get(context.Background(), "user-1")
+	if got == nil || !got.IsSuperAdmin {
+		t.Fatalf("expected cached entry to be returned")
+	}
+}
+
+func TestPermissionCache_GetExpiresAfterTTL(t *testing.T) {
+	c := newCacheForTest(time.Minute)
+	key := c.cacheKey(context.Background(), "user-1")
+	c.store[key] = &CachedPermissions{
+		IsSuperAdmin: true,
+		CachedAt:     time.Now().UTC().Add(-2 * time.Minute),
+		TTL:          time.Minute,
+	}
+
+	if got := c.Get(context.Background(), "user-1"); got != nil {
+		t.Fatalf("expected expired entry to be evicted, got %+v", got)
+	}
+	if _, exists := c.store[key]; exists {
+		t.Fatalf("expected expired entry to be removed from store")
+	}
+}
+
+func TestPermissionCache_InvalidateDropsEntry(t *testing.T) {
+	c := newCacheForTest(time.Minute)
+	key := c.cacheKey(context.Background(), "user-1")
+	c.store[key] = &CachedPermissions{CachedAt: time.Now().UTC(), TTL: time.Minute}
+
+	c.Invalidate(context.Background(), "user-1")
+	if _, exists := c.store[key]; exists {
+		t.Fatalf("Invalidate should drop the entry")
+	}
+}
+
+func TestPermissionCache_InvalidateByRoleDropsAffected(t *testing.T) {
+	c := newCacheForTest(time.Minute)
+
+	c.store["a"] = &CachedPermissions{
+		ModuleRoles: map[string]ModuleRole{
+			"hris": {RoleID: "role-1", RoleSlug: "viewer"},
+		},
+		CachedAt: time.Now().UTC(),
+		TTL:      time.Minute,
+	}
+	c.store["b"] = &CachedPermissions{
+		ModuleRoles: map[string]ModuleRole{
+			"hris": {RoleID: "role-2", RoleSlug: "editor"},
+		},
+		CachedAt: time.Now().UTC(),
+		TTL:      time.Minute,
+	}
+
+	c.InvalidateByRole("role-1")
+
+	if _, exists := c.store["a"]; exists {
+		t.Fatalf("entry holding role-1 should be evicted")
+	}
+	if _, exists := c.store["b"]; !exists {
+		t.Fatalf("unrelated entry should not be evicted")
+	}
+}
+
+func TestPermissionCache_InvalidateAllClearsStore(t *testing.T) {
+	c := newCacheForTest(time.Minute)
+	c.store["a"] = &CachedPermissions{}
+	c.store["b"] = &CachedPermissions{}
+
+	c.InvalidateAll()
+	if len(c.store) != 0 {
+		t.Fatalf("expected store to be empty, got %d entries", len(c.store))
+	}
+}

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -319,7 +319,13 @@ func (s *Service) ChangePassword(ctx context.Context, userID string, currentPass
 		return err
 	}
 
-	return s.repo.ChangePasswordAndRevokeTokens(ctx, userID, newHash)
+	if err := s.repo.ChangePasswordAndRevokeTokens(ctx, userID, newHash); err != nil {
+		return err
+	}
+	// Drop cached permissions so any compromised access token reissued
+	// before this point does not retain its old role set.
+	s.permissionCache.Invalidate(ctx, userID)
+	return nil
 }
 
 func (s *Service) RequestPasswordReset(ctx context.Context, email string, meta PasswordResetRequestMeta) error {
@@ -454,6 +460,7 @@ func (s *Service) ResetPasswordWithToken(ctx context.Context, rawToken string, n
 		return "", err
 	}
 
+	s.permissionCache.Invalidate(ctx, token.UserID)
 	return token.UserID, nil
 }
 
@@ -628,7 +635,13 @@ func (s *Service) UpdateUserRoles(ctx context.Context, userID string, roles []rb
 }
 
 func (s *Service) SetUserActive(ctx context.Context, userID string, active bool) error {
-	return s.repo.SetUserActive(ctx, userID, active)
+	if err := s.repo.SetUserActive(ctx, userID, active); err != nil {
+		return err
+	}
+	// Drop the cached permissions so a deactivated user loses access on the
+	// very next request instead of waiting up to TTL minutes.
+	s.permissionCache.Invalidate(ctx, userID)
+	return nil
 }
 
 func (s *Service) ListRoles(ctx context.Context, params authrepo.RoleListParams) ([]authrepo.RoleListItem, error) {


### PR DESCRIPTION
## Summary
- Permission cache TTL drops from **5 min** → **60 s**. After a deactivation / role rotation a stale token now loses permissions in seconds, not minutes.
- Three mutating endpoints that previously left the cache untouched now call \`Invalidate\`: \`SetUserActive\`, \`ChangePassword\`, \`ResetPasswordWithToken\`. Role and super-admin toggles already invalidated.
- New \`cache_test.go\` covers Get / Invalidate / InvalidateByRole / InvalidateAll plus the default-TTL fallback.

Closes #59

## Test plan
- [x] \`cd backend && go test ./internal/rbac/...\`
- [x] \`cd backend && go test ./...\`
- [ ] Toggle a user inactive in admin UI and confirm their next protected request returns 401/403 immediately (not after 5 minutes).
- [ ] Change a password from the profile page and confirm the cached permissions are dropped.