### PR TITLE
fix(security): require custom header on cookie-only auth endpoints

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -276,7 +276,7 @@ func (a *App) buildRouter(
 	router.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   a.cfg.CORSOrigins,
 		AllowedMethods:   []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-Requested-With", "X-Csrf-Token"},
 		ExposedHeaders:   []string{"Link"},
 		AllowCredentials: true,
 		MaxAge:           300,

--- a/backend/internal/handler/auth/handler.go
+++ b/backend/internal/handler/auth/handler.go
@@ -216,6 +216,16 @@ func (h *Handler) login(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) refresh(w http.ResponseWriter, r *http.Request) {
+	// /auth/refresh authenticates with a SameSite=Lax HTTP-only cookie. Lax
+	// blocks cross-site form posts but not top-level navigations and not
+	// custom-content-type submissions, so we add a CSRF guard: the request
+	// must carry a custom header that browsers cannot set on cross-origin
+	// non-fetch submissions without a CORS preflight.
+	if !hasCSRFHeader(r) {
+		response.WriteError(w, http.StatusForbidden, "CSRF_REQUIRED", "X-Requested-With header is required", nil)
+		return
+	}
+
 	refreshToken, err := h.readRefreshTokenCookie(r)
 	if err != nil {
 		platformmiddleware.AuditLog(r.Context(), "token_refresh_failed", "admin", "auth", "refresh", nil, map[string]any{
@@ -257,6 +267,14 @@ func (h *Handler) refresh(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) logout(w http.ResponseWriter, r *http.Request) {
+	// Logout is not destructive enough to be a real CSRF target, but it does
+	// rely on the same cookie as /refresh. Apply the same custom-header
+	// guard so an attacker cannot remotely sign a victim out either.
+	if !hasCSRFHeader(r) {
+		response.WriteError(w, http.StatusForbidden, "CSRF_REQUIRED", "X-Requested-With header is required", nil)
+		return
+	}
+
 	refreshToken, err := h.readRefreshTokenCookie(r)
 	if err == nil {
 		if userID, logoutErr := h.service.Logout(r.Context(), refreshToken); logoutErr == nil {
@@ -434,6 +452,21 @@ func loginFailureReason(err error) string {
 	default:
 		return ""
 	}
+}
+
+// hasCSRFHeader returns true when the caller proved the request originated
+// from a same-origin script. Browsers refuse to set custom headers on
+// cross-site form posts and image/iframe loads without a CORS preflight, so
+// the presence of either X-Requested-With or X-Csrf-Token is enough to
+// distinguish a legitimate fetch() from a CSRF-style submission.
+func hasCSRFHeader(r *http.Request) bool {
+	if strings.TrimSpace(r.Header.Get("X-Requested-With")) != "" {
+		return true
+	}
+	if strings.TrimSpace(r.Header.Get("X-Csrf-Token")) != "" {
+		return true
+	}
+	return false
 }
 
 func clientIP(r *http.Request) string {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -53,6 +53,14 @@ export async function requestEnvelope<TData>(
     headers.set("Authorization", `Bearer ${token}`);
   }
 
+  // Always advertise XHR. The backend requires this header on cookie-only
+  // endpoints (/auth/refresh, /auth/logout) as a CSRF guard, and tagging
+  // every request keeps the header set even when callers go through
+  // requestEnvelope directly.
+  if (!headers.has("X-Requested-With")) {
+    headers.set("X-Requested-With", "XMLHttpRequest");
+  }
+
   const response = await fetch(`${API_BASE_URL}${path}`, {
     ...init,
     headers,
@@ -120,6 +128,10 @@ async function refreshAuthenticatedSession() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          // CSRF guard — backend requires this header on /auth/refresh.
+          // Browsers cannot set it on cross-site form posts without a CORS
+          // preflight, so it shuts down navigation/CSRF replays of the cookie.
+          "X-Requested-With": "XMLHttpRequest",
         },
         body: JSON.stringify({}),
         credentials: "include",


### PR DESCRIPTION
## Summary
- \`/auth/refresh\` and \`/auth/logout\` use only a \`SameSite=Lax\` HTTP-only cookie. Lax doesn't block top-level navigations or non-form posts, so a CSRF replay could rotate a refresh token (and grab the response) or sign the user out.
- Both endpoints now reject requests that don't carry \`X-Requested-With\` (or \`X-Csrf-Token\`). Browsers can't set custom headers on cross-site form/image/iframe submissions without a CORS preflight, and our CORS allowlist is origin-scoped, so the header check reliably distinguishes same-origin fetch from CSRF.
- CORS \`AllowedHeaders\` extended with \`X-Requested-With\` and \`X-Csrf-Token\`.
- Frontend \`requestEnvelope\` now tags every fetch with \`X-Requested-With: XMLHttpRequest\` by default.

Closes #58

## Test plan
- [x] \`cd backend && go build ./...\`
- [x] \`cd backend && go test ./...\`
- [x] \`cd frontend && npm run build\`
- [ ] curl -X POST \`/auth/refresh\` without the header → 403 \`CSRF_REQUIRED\`.
- [ ] Refresh through the app and confirm it still rotates the cookie/token.
- [ ] Logout through the app and confirm it still revokes.