### PR TITLE
fix(security): derive AES key with Argon2id, keep SHA-256 fallback for legacy data

### DIFF
--- a/backend/internal/security/encryption.go
+++ b/backend/internal/security/encryption.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"golang.org/x/crypto/argon2"
 )
 
 // Encrypter uses AES-256-GCM for application-layer encryption.
@@ -18,11 +20,38 @@ import (
 //
 // Ciphertext format: "v<version>:<base64 payload>"
 // Unversioned ciphertext (legacy) is treated as version 1.
+//
+// Key derivation:
+//   - New writes use Argon2id (memory-hard) over the secret with a
+//     deterministic per-version salt. Argon2id parameters target ~250 ms on
+//     a server-class CPU, which makes brute-force of low-entropy
+//     DATA_ENCRYPTION_KEY values prohibitively expensive.
+//   - For each registered secret we ALSO keep a SHA-256 key. Existing
+//     ciphertext was written when the project derived keys via a single
+//     SHA-256 pass, and we must remain able to decrypt it without forcing
+//     an immediate re-encryption sweep. Decryption tries Argon2id first,
+//     then falls back to SHA-256.
 type Encrypter struct {
 	primaryVersion int
 	primaryKey     []byte
-	keys           map[int][]byte // version -> key
+	keys           map[int]derivedKeys // version -> {argon2id, sha256}
 }
+
+type derivedKeys struct {
+	primary []byte // Argon2id-derived key (new scheme)
+	legacy  []byte // SHA-256 of the same secret (legacy scheme)
+}
+
+// argon2KDFParams are the Argon2id parameters used for the primary key
+// derivation. These are intentionally exported via constants so any review
+// catches when they change. The values target ~250 ms on a 4-core server CPU
+// while keeping memory pressure under 64 MiB.
+const (
+	argon2Time    uint32 = 2
+	argon2Memory  uint32 = 64 * 1024 // KiB
+	argon2Threads uint8  = 4
+	argon2KeyLen  uint32 = 32 // AES-256
+)
 
 // NewEncrypter creates an encrypter with the primary key for encryption.
 // Previous keys are used only for decryption during key rotation.
@@ -40,8 +69,7 @@ func NewEncrypter(secret string, previousSecrets ...string) (*Encrypter, error) 
 
 	e := &Encrypter{
 		primaryVersion: len(previousSecrets) + 1,
-		primaryKey:     deriveKey(secret),
-		keys:           make(map[int][]byte),
+		keys:           make(map[int]derivedKeys),
 	}
 
 	// Previous keys get versions 1, 2, ... in order
@@ -49,20 +77,48 @@ func NewEncrypter(secret string, previousSecrets ...string) (*Encrypter, error) 
 		if strings.TrimSpace(prev) == "" {
 			continue
 		}
-		e.keys[i+1] = deriveKey(prev)
+		version := i + 1
+		argonKey, err := deriveKeyArgon2id(prev, version)
+		if err != nil {
+			return nil, fmt.Errorf("derive argon2id key for version %d: %w", version, err)
+		}
+		e.keys[version] = derivedKeys{
+			primary: argonKey,
+			legacy:  deriveKeySHA256(prev),
+		}
 	}
 
 	// Current key gets the highest version
-	e.keys[e.primaryVersion] = e.primaryKey
+	primaryArgon, err := deriveKeyArgon2id(secret, e.primaryVersion)
+	if err != nil {
+		return nil, fmt.Errorf("derive argon2id primary key: %w", err)
+	}
+	e.primaryKey = primaryArgon
+	e.keys[e.primaryVersion] = derivedKeys{
+		primary: primaryArgon,
+		legacy:  deriveKeySHA256(secret),
+	}
 
 	return e, nil
 }
 
-func deriveKey(secret string) []byte {
+func deriveKeySHA256(secret string) []byte {
 	sum := sha256.Sum256([]byte(secret))
 	key := make([]byte, len(sum))
 	copy(key, sum[:])
 	return key
+}
+
+// deriveKeyArgon2id produces a 32-byte AES-256 key from secret using
+// Argon2id with a deterministic, per-version salt. The salt deliberately
+// includes a project-specific domain string so two services that happen to
+// share the same DATA_ENCRYPTION_KEY do not derive the same AES key.
+func deriveKeyArgon2id(secret string, version int) ([]byte, error) {
+	if strings.TrimSpace(secret) == "" {
+		return nil, errors.New("secret is empty")
+	}
+	salt := sha256.Sum256([]byte(fmt.Sprintf("kantor.security.encryption/v%d", version)))
+	return argon2.IDKey([]byte(secret), salt[:16], argon2Time, argon2Memory, argon2Threads, argon2KeyLen), nil
 }
 
 func (e *Encrypter) EncryptString(plaintext string) (string, error) {
@@ -77,7 +133,7 @@ func (e *Encrypter) DecryptString(ciphertext string) (string, error) {
 	version, payload, hasVersion := parseVersionedCiphertext(ciphertext)
 
 	if hasVersion {
-		key, ok := e.keys[version]
+		entry, ok := e.keys[version]
 		if !ok {
 			return "", fmt.Errorf("unknown encryption key version: %d", version)
 		}
@@ -85,28 +141,38 @@ func (e *Encrypter) DecryptString(ciphertext string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("decode ciphertext: %w", err)
 		}
-		plaintext, err := decrypt(key, decoded)
-		if err != nil {
-			return "", fmt.Errorf("decrypt ciphertext (v%d): %w", version, err)
+		if plaintext, err := decrypt(entry.primary, decoded); err == nil {
+			return string(plaintext), nil
 		}
-		return string(plaintext), nil
+		// Legacy data written before Argon2id was introduced still uses the
+		// SHA-256-derived key for the same secret. Try it before giving up.
+		if entry.legacy != nil {
+			if plaintext, err := decrypt(entry.legacy, decoded); err == nil {
+				return string(plaintext), nil
+			}
+		}
+		return "", fmt.Errorf("decrypt ciphertext (v%d): no matching key", version)
 	}
 
 	// Legacy unversioned ciphertext (pre-rotation data without "v1:" prefix):
-	// try all known keys to find the one that decrypts it.
+	// try every known key, both schemes, until one succeeds.
 	decoded, err := base64.StdEncoding.DecodeString(ciphertext)
 	if err != nil {
 		return "", fmt.Errorf("decode ciphertext: %w", err)
 	}
 
 	for v := 1; v <= e.primaryVersion; v++ {
-		key, ok := e.keys[v]
+		entry, ok := e.keys[v]
 		if !ok {
 			continue
 		}
-		plaintext, err := decrypt(key, decoded)
-		if err == nil {
+		if plaintext, err := decrypt(entry.primary, decoded); err == nil {
 			return string(plaintext), nil
+		}
+		if entry.legacy != nil {
+			if plaintext, err := decrypt(entry.legacy, decoded); err == nil {
+				return string(plaintext), nil
+			}
 		}
 	}
 

--- a/backend/internal/security/encryption_test.go
+++ b/backend/internal/security/encryption_test.go
@@ -1,0 +1,118 @@
+package security
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+const testSecret = "test-secret-please-replace-32chars!"
+
+func TestEncrypter_RoundTrip(t *testing.T) {
+	e, err := NewEncrypter(testSecret)
+	if err != nil {
+		t.Fatalf("NewEncrypter: %v", err)
+	}
+
+	cipher, err := e.EncryptString("hello world")
+	if err != nil {
+		t.Fatalf("EncryptString: %v", err)
+	}
+	if !strings.HasPrefix(cipher, "v1:") {
+		t.Fatalf("expected versioned ciphertext, got %q", cipher)
+	}
+
+	plain, err := e.DecryptString(cipher)
+	if err != nil {
+		t.Fatalf("DecryptString: %v", err)
+	}
+	if plain != "hello world" {
+		t.Fatalf("expected hello world, got %q", plain)
+	}
+}
+
+func TestEncrypter_DecryptsLegacySHA256Ciphertext(t *testing.T) {
+	// Re-create what the previous (sha256-only) code would produce: derive
+	// the AES key with bare SHA-256 and encrypt directly. The new Encrypter
+	// must still decrypt it via the legacy fallback.
+	legacyKey := deriveKeySHA256(testSecret)
+	rawCipher, err := encrypt(legacyKey, []byte("legacy payload"))
+	if err != nil {
+		t.Fatalf("encrypt legacy: %v", err)
+	}
+	versioned := "v1:" + base64.StdEncoding.EncodeToString(rawCipher)
+
+	e, err := NewEncrypter(testSecret)
+	if err != nil {
+		t.Fatalf("NewEncrypter: %v", err)
+	}
+
+	got, err := e.DecryptString(versioned)
+	if err != nil {
+		t.Fatalf("expected legacy ciphertext to decrypt, got error: %v", err)
+	}
+	if got != "legacy payload" {
+		t.Fatalf("expected legacy payload, got %q", got)
+	}
+}
+
+func TestEncrypter_KeyRotation(t *testing.T) {
+	// Encrypt with the previous secret (legacy sha256-style ciphertext at v1).
+	prevKey := deriveKeySHA256("old-secret-old-secret-old-secret!")
+	rawOld, err := encrypt(prevKey, []byte("aged data"))
+	if err != nil {
+		t.Fatalf("encrypt old: %v", err)
+	}
+	oldVersioned := "v1:" + base64.StdEncoding.EncodeToString(rawOld)
+
+	// Boot the encrypter with the new secret as primary and the old as previous.
+	e, err := NewEncrypter("new-secret-new-secret-new-secret!", "old-secret-old-secret-old-secret!")
+	if err != nil {
+		t.Fatalf("NewEncrypter: %v", err)
+	}
+
+	got, err := e.DecryptString(oldVersioned)
+	if err != nil {
+		t.Fatalf("rotation decrypt failed: %v", err)
+	}
+	if got != "aged data" {
+		t.Fatalf("expected aged data, got %q", got)
+	}
+
+	// New writes go through Argon2id with primary version 2.
+	cipher, err := e.EncryptString("fresh data")
+	if err != nil {
+		t.Fatalf("EncryptString: %v", err)
+	}
+	if !strings.HasPrefix(cipher, "v2:") {
+		t.Fatalf("expected v2 prefix on new ciphertext, got %q", cipher)
+	}
+
+	plain, err := e.DecryptString(cipher)
+	if err != nil {
+		t.Fatalf("DecryptString new: %v", err)
+	}
+	if plain != "fresh data" {
+		t.Fatalf("expected fresh data, got %q", plain)
+	}
+}
+
+func TestEncrypter_DerivedKeyDiffersBetweenSchemes(t *testing.T) {
+	sha := deriveKeySHA256(testSecret)
+	argon, err := deriveKeyArgon2id(testSecret, 1)
+	if err != nil {
+		t.Fatalf("deriveKeyArgon2id: %v", err)
+	}
+	if string(sha) == string(argon) {
+		t.Fatal("Argon2id-derived key must differ from SHA-256-derived key")
+	}
+}
+
+func TestEncrypter_RejectsEmptySecret(t *testing.T) {
+	if _, err := NewEncrypter(""); err == nil {
+		t.Fatal("expected error for empty secret")
+	}
+	if _, err := NewEncrypter("   "); err == nil {
+		t.Fatal("expected error for whitespace-only secret")
+	}
+}


### PR DESCRIPTION
## Summary
- Encrypter previously stretched \`DATA_ENCRYPTION_KEY\` into the AES-256 key with a single \`sha256.Sum256\` call. No salt, no work factor — short/predictable secrets were brute-forceable offline.
- Switches the primary derivation to **Argon2id** with project-namespaced, per-version deterministic salt. Parameters target ~250 ms on a 4-core server CPU.
- Pre-existing ciphertext used the old SHA-256 path. To avoid forcing an immediate re-encryption sweep, every registered secret is also kept as a SHA-256 key. Decryption tries Argon2id first, falls back to SHA-256 only on failure. New writes are always Argon2id.
- Tests cover: round-trip, legacy decryption, rotation, empty-secret rejection, scheme separation.

Closes #56

## Test plan
- [x] \`cd backend && go test ./internal/security/...\`
- [x] \`cd backend && go test ./...\`
- [ ] Bring up the backend on staging with existing encrypted salary rows; confirm they decrypt (legacy SHA-256 fallback path) and confirm fresh writes get a \`v<n>:\` prefix and are decryptable across restarts.
- [ ] Once stable, plan a re-save pass over encrypted columns to retire the SHA-256 fallback.