### PR TITLE
fix(security): add JTI claim and access-token blacklist

### DIFF
--- a/backend/cmd/seed/main.go
+++ b/backend/cmd/seed/main.go
@@ -67,7 +67,7 @@ func run(ctx context.Context) error {
 	authRepository := authrepo.New(pool)
 	employeesRepository := hrisrepo.NewEmployeesRepository(pool)
 	permissionCache := rbac.NewPermissionCache(pool, 0)
-	authService := authservice.New(authRepository, employeesRepository, cfg, permissionCache, encrypter)
+	authService := authservice.New(authRepository, employeesRepository, cfg, permissionCache, encrypter, nil)
 
 	tenantsSeeded := 0
 	if err := platformmiddleware.ForEachTenant(ctx, pool, func(tCtx context.Context, t tenant.Info) error {

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	backendauth "github.com/kana-consultant/kantor/backend/internal/auth"
 	"github.com/kana-consultant/kantor/backend/internal/config"
 	"github.com/kana-consultant/kantor/backend/internal/metrics"
 	adminhandler "github.com/kana-consultant/kantor/backend/internal/handler/admin"
@@ -57,13 +58,14 @@ import (
 )
 
 type App struct {
-	cfg              config.Config
-	db               *pgxpool.Pool
-	router           http.Handler
-	backgroundCancel context.CancelFunc
-	permissionCache  *rbac.PermissionCache
-	tenantResolver   *tenant.Resolver
-	metrics          *metrics.Registry
+	cfg                  config.Config
+	db                   *pgxpool.Pool
+	router               http.Handler
+	backgroundCancel     context.CancelFunc
+	permissionCache      *rbac.PermissionCache
+	tenantResolver       *tenant.Resolver
+	metrics              *metrics.Registry
+	accessTokenBlacklist *backendauth.AccessTokenBlacklist
 }
 
 func New(ctx context.Context, cfg config.Config) (*App, error) {
@@ -135,7 +137,8 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		pool.Close()
 		return nil, fmt.Errorf("configure data encryption: %w", err)
 	}
-	authService := authservice.New(authRepository, employeesRepository, cfg, permissionCache, encrypter)
+	accessTokenBlacklist := backendauth.NewAccessTokenBlacklist(time.Minute)
+	authService := authservice.New(authRepository, employeesRepository, cfg, permissionCache, encrypter, accessTokenBlacklist)
 
 	projectsRepository := operationalrepo.NewProjectsRepository(pool)
 	kanbanRepository := operationalrepo.NewKanbanRepository(pool)
@@ -190,11 +193,12 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	reimbursementsService.SetReminderEmailSender(emailDeliveryService)
 
 	application := &App{
-		cfg:             cfg,
-		db:              pool,
-		permissionCache: permissionCache,
-		tenantResolver:  tenantResolver,
-		metrics:         metrics.NewRegistry(),
+		cfg:                  cfg,
+		db:                   pool,
+		permissionCache:      permissionCache,
+		tenantResolver:       tenantResolver,
+		metrics:              metrics.NewRegistry(),
+		accessTokenBlacklist: accessTokenBlacklist,
 	}
 	application.router = application.buildRouter(
 		auditService,
@@ -236,6 +240,9 @@ func (a *App) DB() *pgxpool.Pool {
 func (a *App) Close() {
 	if a.backgroundCancel != nil {
 		a.backgroundCancel()
+	}
+	if a.accessTokenBlacklist != nil {
+		a.accessTokenBlacklist.Stop()
 	}
 	if a.db != nil {
 		a.db.Close()
@@ -326,7 +333,7 @@ func (a *App) buildRouter(
 			})
 
 			r.Group(func(protected chi.Router) {
-				protected.Use(platformmiddleware.AuthMiddleware(authService.ParseAccessToken, a.permissionCache.Load))
+				protected.Use(platformmiddleware.AuthMiddleware(authService.ParseAccessToken, a.permissionCache.Load, a.accessTokenBlacklist))
 				// Per-user throttle so a single compromised token cannot hammer
 				// expensive endpoints (e.g. HRIS overview, exports). 240 req/min
 				// is high enough to leave normal UI navigation untouched.

--- a/backend/internal/auth/blacklist.go
+++ b/backend/internal/auth/blacklist.go
@@ -1,0 +1,113 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+// AccessTokenBlacklist tracks JWT IDs (JTI) that have been explicitly revoked
+// before their natural expiry. The store is in-memory and process-local; for
+// a multi-instance deployment this should be replaced with a shared store
+// (Redis SET, postgres table) but the API stays the same.
+//
+// Entries auto-expire when their record passes the access-token expiry, so
+// the map cannot grow unbounded under normal traffic. A periodic GC runs in
+// the background to drop stale records eagerly.
+type AccessTokenBlacklist struct {
+	mu      sync.RWMutex
+	entries map[string]time.Time
+	now     func() time.Time
+	gcStop  chan struct{}
+}
+
+// NewAccessTokenBlacklist returns a blacklist with a goroutine that sweeps
+// expired entries every gcInterval. Pass 0 to skip the goroutine — useful in
+// tests where the caller drives time manually.
+func NewAccessTokenBlacklist(gcInterval time.Duration) *AccessTokenBlacklist {
+	b := &AccessTokenBlacklist{
+		entries: make(map[string]time.Time),
+		now:     time.Now,
+		gcStop:  make(chan struct{}),
+	}
+	if gcInterval > 0 {
+		go b.runGC(gcInterval)
+	}
+	return b
+}
+
+func (b *AccessTokenBlacklist) runGC(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-b.gcStop:
+			return
+		case <-ticker.C:
+			b.gc()
+		}
+	}
+}
+
+// Stop terminates the background sweeper. Idempotent.
+func (b *AccessTokenBlacklist) Stop() {
+	select {
+	case <-b.gcStop:
+		return
+	default:
+		close(b.gcStop)
+	}
+}
+
+// Revoke marks the given JTI as invalid until its corresponding access token
+// would have expired anyway. Calls after expiresAt are no-ops.
+func (b *AccessTokenBlacklist) Revoke(jti string, expiresAt time.Time) {
+	if jti == "" {
+		return
+	}
+	if expiresAt.Before(b.now().UTC()) {
+		return
+	}
+	b.mu.Lock()
+	b.entries[jti] = expiresAt
+	b.mu.Unlock()
+}
+
+// IsRevoked reports whether the given JTI has been revoked and is still
+// within its expiry window. Expired entries are dropped lazily on read.
+func (b *AccessTokenBlacklist) IsRevoked(jti string) bool {
+	if jti == "" {
+		return false
+	}
+	b.mu.RLock()
+	exp, ok := b.entries[jti]
+	b.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	if exp.Before(b.now().UTC()) {
+		b.mu.Lock()
+		delete(b.entries, jti)
+		b.mu.Unlock()
+		return false
+	}
+	return true
+}
+
+// Size returns the current number of tracked entries. Intended for tests and
+// observability — the production code does not consult it.
+func (b *AccessTokenBlacklist) Size() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.entries)
+}
+
+func (b *AccessTokenBlacklist) gc() {
+	now := b.now().UTC()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for jti, exp := range b.entries {
+		if exp.Before(now) {
+			delete(b.entries, jti)
+		}
+	}
+}

--- a/backend/internal/auth/blacklist_test.go
+++ b/backend/internal/auth/blacklist_test.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAccessTokenBlacklist_RevokeAndCheck(t *testing.T) {
+	b := NewAccessTokenBlacklist(0)
+	defer b.Stop()
+
+	b.Revoke("jti-1", time.Now().Add(time.Hour))
+	if !b.IsRevoked("jti-1") {
+		t.Fatal("expected jti-1 to be revoked")
+	}
+	if b.IsRevoked("jti-2") {
+		t.Fatal("unrelated jti must not appear revoked")
+	}
+}
+
+func TestAccessTokenBlacklist_EmptyJTIIsIgnored(t *testing.T) {
+	b := NewAccessTokenBlacklist(0)
+	defer b.Stop()
+
+	b.Revoke("", time.Now().Add(time.Hour))
+	if b.Size() != 0 {
+		t.Fatalf("empty JTI should not be stored, got size %d", b.Size())
+	}
+	if b.IsRevoked("") {
+		t.Fatal("empty JTI lookup must not match")
+	}
+}
+
+func TestAccessTokenBlacklist_DropsExpiredOnRead(t *testing.T) {
+	b := NewAccessTokenBlacklist(0)
+	defer b.Stop()
+
+	now := time.Now().UTC()
+	clock := atomic.Pointer[time.Time]{}
+	clock.Store(&now)
+	b.now = func() time.Time { return *clock.Load() }
+
+	b.Revoke("jti-1", now.Add(time.Second))
+	if !b.IsRevoked("jti-1") {
+		t.Fatal("expected jti-1 to be revoked at t=0")
+	}
+
+	advanced := now.Add(2 * time.Second)
+	clock.Store(&advanced)
+	if b.IsRevoked("jti-1") {
+		t.Fatal("expired entry must not appear revoked")
+	}
+	if b.Size() != 0 {
+		t.Fatalf("expired entry should be evicted, got size %d", b.Size())
+	}
+}
+
+func TestAccessTokenBlacklist_RejectsAlreadyExpiredEntries(t *testing.T) {
+	b := NewAccessTokenBlacklist(0)
+	defer b.Stop()
+
+	b.Revoke("jti-1", time.Now().Add(-time.Hour))
+	if b.Size() != 0 {
+		t.Fatal("Revoke must drop entries with past expiry")
+	}
+}
+
+func TestGenerateAccessToken_IncludesJTI(t *testing.T) {
+	tm := NewTokenManager("super-secret-please-replace", 5*time.Minute, time.Hour)
+	signed, _, err := tm.GenerateAccessToken("user-1", "tenant-1", time.Now())
+	if err != nil {
+		t.Fatalf("GenerateAccessToken: %v", err)
+	}
+
+	claims, err := tm.ParseAccessToken(signed)
+	if err != nil {
+		t.Fatalf("ParseAccessToken: %v", err)
+	}
+	if claims.ID == "" {
+		t.Fatal("expected non-empty JTI in access token")
+	}
+
+	// Two consecutive tokens must carry distinct JTIs so individual revocation
+	// is meaningful.
+	signed2, _, err := tm.GenerateAccessToken("user-1", "tenant-1", time.Now())
+	if err != nil {
+		t.Fatalf("second GenerateAccessToken: %v", err)
+	}
+	claims2, err := tm.ParseAccessToken(signed2)
+	if err != nil {
+		t.Fatalf("ParseAccessToken: %v", err)
+	}
+	if claims.ID == claims2.ID {
+		t.Fatalf("expected distinct JTIs, both were %q", claims.ID)
+	}
+}

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -17,6 +17,17 @@ type AccessClaims struct {
 	jwt.RegisteredClaims
 }
 
+// newJTI returns a 128-bit random identifier suitable for the standard `jti`
+// claim. It lets the auth middleware revoke a specific access token before
+// its natural expiry by adding the JTI to the in-memory blacklist.
+func newJTI() (string, error) {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(bytes), nil
+}
+
 type TokenManager struct {
 	secret        []byte
 	accessExpiry  time.Duration
@@ -33,10 +44,15 @@ func NewTokenManager(secret string, accessExpiry time.Duration, refreshExpiry ti
 
 func (m *TokenManager) GenerateAccessToken(userID string, tenantID string, now time.Time) (string, time.Time, error) {
 	expiresAt := now.Add(m.accessExpiry)
+	jti, err := newJTI()
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("generate jti: %w", err)
+	}
 	claims := AccessClaims{
 		Type:     "access",
 		TenantID: tenantID,
 		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        jti,
 			Subject:   userID,
 			IssuedAt:  jwt.NewNumericDate(now),
 			NotBefore: jwt.NewNumericDate(now),

--- a/backend/internal/handler/auth/handler.go
+++ b/backend/internal/handler/auth/handler.go
@@ -275,6 +275,14 @@ func (h *Handler) logout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Best-effort revoke the access token attached to the request so it cannot
+	// be replayed for the rest of its 15-minute window after sign-out.
+	if header := strings.TrimSpace(r.Header.Get("Authorization")); strings.HasPrefix(strings.ToLower(header), "bearer ") {
+		if raw := strings.TrimSpace(header[len("bearer "):]); raw != "" {
+			h.service.RevokeAccessToken(raw)
+		}
+	}
+
 	refreshToken, err := h.readRefreshTokenCookie(r)
 	if err == nil {
 		if userID, logoutErr := h.service.Logout(r.Context(), refreshToken); logoutErr == nil {

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -27,6 +27,7 @@ const principalContextKey contextKey = "principal"
 func AuthMiddleware(
 	parseToken func(string) (*backendauth.AccessClaims, error),
 	loadPermissions func(context.Context, string) (*rbac.CachedPermissions, error),
+	blacklist *backendauth.AccessTokenBlacklist,
 ) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -45,6 +46,11 @@ func AuthMiddleware(
 			claims, err := parseToken(parts[1])
 			if err != nil {
 				response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Access token is invalid or expired", nil)
+				return
+			}
+
+			if blacklist != nil && blacklist.IsRevoked(claims.ID) {
+				response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Access token has been revoked", nil)
 				return
 			}
 

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -124,6 +124,7 @@ type Service struct {
 	permissionCache *rbac.PermissionCache
 	passwordMailer  passwordResetMailer
 	encrypter       *security.Encrypter
+	tokenBlacklist  *backendauth.AccessTokenBlacklist
 	fallbackAppURL  string
 }
 
@@ -149,7 +150,7 @@ type mailDeliveryRuntimeConfig struct {
 	PasswordResetTTL time.Duration
 }
 
-func New(repo authRepository, employeeRepo authEmployeesRepository, cfg config.Config, permissionCache *rbac.PermissionCache, encrypter *security.Encrypter) *Service {
+func New(repo authRepository, employeeRepo authEmployeesRepository, cfg config.Config, permissionCache *rbac.PermissionCache, encrypter *security.Encrypter, tokenBlacklist *backendauth.AccessTokenBlacklist) *Service {
 	return &Service{
 		repo:            repo,
 		employeeRepo:    employeeRepo,
@@ -157,8 +158,29 @@ func New(repo authRepository, employeeRepo authEmployeesRepository, cfg config.C
 		permissionCache: permissionCache,
 		passwordMailer:  newResendMailer(),
 		encrypter:       encrypter,
+		tokenBlacklist:  tokenBlacklist,
 		fallbackAppURL:  strings.TrimRight(strings.TrimSpace(cfg.AppURL), "/"),
 	}
+}
+
+// RevokeAccessToken adds the JTI of the supplied access token to the in-memory
+// blacklist so subsequent requests carrying the same token are rejected before
+// they ever reach a handler. Best-effort: invalid or already-expired tokens
+// are silently ignored — the only goal here is to shorten the natural expiry
+// window for a token the user just signed off.
+func (s *Service) RevokeAccessToken(rawToken string) {
+	if s.tokenBlacklist == nil {
+		return
+	}
+	claims, err := s.tokenManager.ParseAccessToken(rawToken)
+	if err != nil || claims == nil || claims.ID == "" {
+		return
+	}
+	exp := time.Time{}
+	if claims.ExpiresAt != nil {
+		exp = claims.ExpiresAt.Time
+	}
+	s.tokenBlacklist.Revoke(claims.ID, exp)
 }
 
 func (s *Service) EnsureSeedSuperAdmin(ctx context.Context, email string, password string, fullName string) error {


### PR DESCRIPTION
## Summary
- Access tokens now carry a 128-bit \`jti\` claim. Two consecutive tokens for the same user are guaranteed distinct.
- New in-memory \`AccessTokenBlacklist\` keyed by JTI with per-entry expiry. Includes a background GC goroutine on a one-minute cadence and a \`Stop()\` for clean shutdown.
- \`AuthMiddleware\` consults the blacklist on every authenticated request and returns 401 if the JTI has been revoked.
- \`/auth/logout\` parses the bearer token from \`Authorization\` and revokes its JTI, so the access token expires immediately on sign-out instead of waiting up to 15 minutes for the natural expiry.
- Tests cover Revoke / IsRevoked / size accounting / expired entries, plus a JTI-presence/uniqueness assertion on \`GenerateAccessToken\`.

For a multi-instance deployment the in-memory store should be replaced with a shared one (Redis SET, postgres table) — the API surface is small enough that the swap is mechanical.

Closes #60

## Test plan
- [x] \`cd backend && go test ./internal/auth/...\`
- [x] \`cd backend && go test ./...\`
- [ ] Hit \`/auth/logout\` with a fresh access token in the Authorization header, then re-use the same token against any protected endpoint and confirm 401 \`UNAUTHORIZED\` with \`Access token has been revoked\`.
- [ ] After 15 minutes (natural expiry) confirm the blacklist entry has been swept.