### PR TITLE
fix(security): bind refresh token to client User-Agent fingerprint

### DIFF
--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -31,4 +31,5 @@ type RefreshToken struct {
 	RevokedAt  *time.Time
 	CreatedAt  time.Time
 	LastUsedAt *time.Time
+	UserAgent  *string
 }

--- a/backend/internal/repository/auth/repository.go
+++ b/backend/internal/repository/auth/repository.go
@@ -288,7 +288,7 @@ func (r *Repository) GetRefreshTokenByHash(ctx context.Context, tokenHash string
 	ctx, cancel := repository.QueryContext(ctx)
 	defer cancel()
 	query := `
-		SELECT id::text, user_id::text, token_hash, expires_at, revoked_at, created_at, last_used_at
+		SELECT id::text, user_id::text, token_hash, expires_at, revoked_at, created_at, last_used_at, user_agent
 		FROM refresh_tokens
 		WHERE token_hash = $1
 	`
@@ -302,6 +302,7 @@ func (r *Repository) GetRefreshTokenByHash(ctx context.Context, tokenHash string
 		&refreshToken.RevokedAt,
 		&refreshToken.CreatedAt,
 		&refreshToken.LastUsedAt,
+		&refreshToken.UserAgent,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/backend/internal/service/auth/refresh_pop_test.go
+++ b/backend/internal/service/auth/refresh_pop_test.go
@@ -1,0 +1,54 @@
+package auth
+
+import "testing"
+
+func ptr(s string) *string { return &s }
+
+func TestRefreshUserAgentMatches_EmptyStoredAcceptsAnything(t *testing.T) {
+	if !refreshUserAgentMatches(nil, "Mozilla/5.0 ...") {
+		t.Fatal("nil stored UA should be treated as a match (legacy rows)")
+	}
+	if !refreshUserAgentMatches(ptr(""), "anything") {
+		t.Fatal("empty stored UA should be treated as a match")
+	}
+}
+
+func TestRefreshUserAgentMatches_SameBrowserWithMinorUpdate(t *testing.T) {
+	old := ptr("Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/605.1.15")
+	updated := "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Chrome/125.0.4321.99 Safari/605.1.15"
+	if !refreshUserAgentMatches(old, updated) {
+		t.Fatal("minor browser version bump must not invalidate the refresh token")
+	}
+}
+
+func TestRefreshUserAgentMatches_DifferentBrowserRejected(t *testing.T) {
+	stored := ptr("Mozilla/5.0 (Windows NT 10.0) Gecko/20100101 Firefox/123.0")
+	other := "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 Chrome/124.0.0.0"
+	if refreshUserAgentMatches(stored, other) {
+		t.Fatal("a different browser must not be treated as the same client")
+	}
+}
+
+func TestRefreshUserAgentMatches_CurlReplayRejected(t *testing.T) {
+	stored := ptr("Mozilla/5.0 (Macintosh) Chrome/124.0.0.0 Safari/605.1.15")
+	curl := "curl/8.4.0"
+	if refreshUserAgentMatches(stored, curl) {
+		t.Fatal("curl replay of a browser-issued refresh token must be rejected")
+	}
+}
+
+func TestUserAgentFingerprint_StableForSameVendor(t *testing.T) {
+	a := userAgentFingerprint("Mozilla/5.0 ... Chrome/124 ... Safari/605")
+	b := userAgentFingerprint("Mozilla/5.0 ... Chrome/126 ... Safari/605")
+	if a != b {
+		t.Fatalf("fingerprints should match across minor Chrome versions, got %q vs %q", a, b)
+	}
+}
+
+func TestUserAgentFingerprint_DistinguishesVendors(t *testing.T) {
+	a := userAgentFingerprint("Mozilla/5.0 ... Firefox/123")
+	b := userAgentFingerprint("Mozilla/5.0 ... Chrome/124 Safari/605")
+	if a == b {
+		t.Fatalf("Firefox and Chrome must produce different fingerprints, both got %q", a)
+	}
+}

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -284,6 +284,14 @@ func (s *Service) Refresh(ctx context.Context, refreshToken string, userAgent st
 		return AuthResult{}, ErrExpiredRefreshToken
 	}
 
+	// Proof-of-possession: a refresh request from a different User-Agent than
+	// the one the cookie was issued to is treated as theft. Revoke the token
+	// to invalidate the active session and force the caller to log in again.
+	if !refreshUserAgentMatches(storedToken.UserAgent, userAgent) {
+		_ = s.repo.RevokeRefreshToken(ctx, tokenHash)
+		return AuthResult{}, ErrInvalidRefreshToken
+	}
+
 	user, err := s.repo.GetUserByID(ctx, storedToken.UserID)
 	if err != nil {
 		if errors.Is(err, authrepo.ErrNotFound) {
@@ -912,6 +920,62 @@ func toModuleRoleDTOs(items map[string]rbac.ModuleRole) map[string]dto.ModuleRol
 		}
 	}
 	return moduleRoles
+}
+
+// refreshUserAgentMatches checks whether the User-Agent presented on a refresh
+// request matches the one the refresh cookie was issued to. The match is
+// intentionally lenient — User-Agent strings drift on browser auto-update —
+// so we compare a canonical prefix rather than the raw string. An empty
+// stored value is treated as a match for backwards compatibility with rows
+// created before fingerprint binding existed.
+func refreshUserAgentMatches(stored *string, current string) bool {
+	if stored == nil || strings.TrimSpace(*stored) == "" {
+		return true
+	}
+	return userAgentFingerprint(*stored) == userAgentFingerprint(current)
+}
+
+// userAgentFingerprint reduces the User-Agent to a coarse vendor signature.
+// This keeps the binding strict enough to catch a stolen cookie replayed
+// from curl / a different browser, while tolerating point-release updates
+// of the same browser.
+func userAgentFingerprint(ua string) string {
+	trimmed := strings.ToLower(strings.TrimSpace(ua))
+	if trimmed == "" {
+		return ""
+	}
+
+	tokens := []string{
+		"firefox",
+		"edg/",
+		"opr/",
+		"chrome",
+		"safari",
+		"mobile",
+		"android",
+		"iphone",
+		"ipad",
+		"linux",
+		"windows",
+		"macintosh",
+		"curl",
+		"go-http-client",
+	}
+	matched := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		if strings.Contains(trimmed, token) {
+			matched = append(matched, token)
+		}
+	}
+	if len(matched) == 0 {
+		// Fall back to the first whitespace-delimited segment of the UA so we
+		// at least bind to "something" rather than treating every UA equally.
+		if idx := strings.IndexAny(trimmed, " \t"); idx > 0 {
+			return trimmed[:idx]
+		}
+		return trimmed
+	}
+	return strings.Join(matched, "|")
 }
 
 func generatePasswordResetToken() (string, string, error) {


### PR DESCRIPTION
## Summary
- A stolen refresh cookie was perfectly usable from any client (curl, a different browser, a different device). The token's opaque hash was the only check.
- Adds a coarse User-Agent fingerprint binding on the refresh path. The repository already stored \`user_agent\` at issue time; we now hydrate it onto \`model.RefreshToken\` and compare it on every refresh.
- The fingerprint is lenient on purpose: it ignores point-release version bumps (so Chrome auto-update doesn't log everyone out) but rejects vendor swaps (Firefox vs Chrome), OS swaps, and non-browser replays (curl, scripts).
- A mismatch revokes the refresh token in the DB and returns \`ErrInvalidRefreshToken\` so the user is forced to re-authenticate.
- Legacy rows with no stored UA (issued before this PR) accept any UA so the upgrade is non-breaking; the next rotation populates the binding.

Closes #57

## Test plan
- [x] \`cd backend && go test ./internal/service/auth/...\`
- [x] \`cd backend && go test ./...\`
- [ ] Log in via the app, copy the \`refresh_token\` cookie, and replay it via \`curl\` against \`/auth/refresh\` — confirm 401 and that the cookie is now revoked.
- [ ] Run an in-place Chrome auto-update against a logged-in tab, refresh, and confirm the session does **not** get logged out.