### PR TITLE
fix(ci): setup ssh aliases for private flake inputs + bump vendorHash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup SSH aliases for private flake inputs
+        env:
+          GH_FLAKE_A: ${{ secrets.GH_FLAKE_A }}
+          GH_FLAKE_B: ${{ secrets.GH_FLAKE_B }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          echo "$GH_FLAKE_A" > ~/.ssh/flake-a
+          echo "$GH_FLAKE_B" > ~/.ssh/flake-b
+          chmod 600 ~/.ssh/flake-a ~/.ssh/flake-b
+          GH_SCAN=$(ssh-keyscan github.com 2>/dev/null)
+          echo "$GH_SCAN" | sed 's/^github.com/github.com-flake-a/' >> ~/.ssh/known_hosts
+          echo "$GH_SCAN" | sed 's/^github.com/github.com-flake-b/' >> ~/.ssh/known_hosts
+          cat >> ~/.ssh/config <<EOF
+          Host github.com-flake-a
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/flake-a
+            IdentitiesOnly yes
+          Host github.com-flake-b
+            HostName github.com
+            User git
+            IdentityFile ~/.ssh/flake-b
+            IdentitiesOnly yes
+          EOF
+          chmod 600 ~/.ssh/config
+
       - uses: DeterminateSystems/nix-installer-action@main
         with:
           extra-conf: |

--- a/nix/backend.nix
+++ b/nix/backend.nix
@@ -6,7 +6,7 @@ buildGoModule {
 
   src = ../backend;
 
-  vendorHash = "sha256-9j/8xOA1ZvWNn/HMMWnkIwCPpA7j6/63IF+T1ApcpU8=";
+  vendorHash = "sha256-l7nHZg1E48sPRCE4javft1FyREMmHLm2fO6jnk/2nts=";
 
   subPackages = [ "cmd/server" ];
 


### PR DESCRIPTION
## Summary
- Two private flake inputs in nix-config are accessed via SSH host aliases. The CI runner had no SSH config for those aliases, so the deploy job failed at flake fetch.
- Add an alias-setup block before the nix-installer step using two repo secrets (\`GH_FLAKE_A\`, \`GH_FLAKE_B\`).
- Also refresh the \`kantor-backend\` \`vendorHash\` — go.mod gained prometheus + otel deps without bumping the FOD hash, so vendor/modules.txt drifted.

## Test plan
- [ ] CI build job reaches \`nix build\` step without ssh-fetch error
- [ ] kantor-backend builds with refreshed vendorHash
- [ ] After merge, deploy completes and pushes to cachix \`kantor-kana\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)