### PR TITLE
fix(auth): send bearer access token on logout

### DIFF
--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -86,10 +86,11 @@ export function getAuthPublicOptions() {
   return getJSON<AuthPublicOptions>("/auth/public-options");
 }
 
-export function revokeRefreshToken() {
+export function revokeRefreshToken(accessToken?: string) {
   return postJSON<{ revoked: boolean }, Record<string, never>>(
     "/auth/logout",
     {},
+    accessToken,
   );
 }
 
@@ -118,8 +119,9 @@ export async function logout() {
   const store = useAuthStore.getState();
 
   try {
+    const accessToken = store.session?.tokens.access_token;
     if (store.session) {
-      await revokeRefreshToken();
+      await revokeRefreshToken(accessToken);
     }
   } finally {
     store.clearSession();


### PR DESCRIPTION
## Summary

This PR updates the frontend logout flow so it sends the current access token as a Bearer token when calling `POST /auth/logout`.

## Why?

The backend logout endpoint already supports best-effort access token revocation (blacklisting) when an `Authorization` header is present.  
Before this change, the frontend only relied on the refresh-token cookie and did not send the access token, so the current access token could remain usable until it expired.

## Changes

- Updated `revokeRefreshToken` to accept an optional `accessToken` argument and forward it to `postJSON`.
- Updated `logout()` to read the active session access token and pass it to `revokeRefreshToken(accessToken)`.
- Kept existing behavior of always clearing local session state in `finally`.

File changed:
- `frontend/src/services/auth.ts`

## Impact

- Improves sign-out security by allowing immediate revocation of the current access token.
- No backend changes required.
- No user-facing UI changes.

## Testing

Manual verification:
1. Login and capture current access token.
2. Trigger logout from the app.
3. Try using the old token on a protected endpoint.
4. Expected result: request is rejected (token revoked), and refresh cookie is cleared.

## Notes

I couldn’t run frontend lint in this environment because local frontend dependencies (`eslint` from `node_modules`) are not installed yet.
