### PR TITLE
fix(security): trust client IP headers only from configured proxy CIDRs

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -15,18 +15,17 @@ import (
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/go-chi/chi/v5"
 
 	backendauth "github.com/kana-consultant/kantor/backend/internal/auth"
 	"github.com/kana-consultant/kantor/backend/internal/config"
-	"github.com/kana-consultant/kantor/backend/internal/metrics"
 	adminhandler "github.com/kana-consultant/kantor/backend/internal/handler/admin"
 	authhandler "github.com/kana-consultant/kantor/backend/internal/handler/auth"
 	fileshandler "github.com/kana-consultant/kantor/backend/internal/handler/files"
@@ -35,6 +34,7 @@ import (
 	notificationshandler "github.com/kana-consultant/kantor/backend/internal/handler/notifications"
 	operationalhandler "github.com/kana-consultant/kantor/backend/internal/handler/operational"
 	wahandler "github.com/kana-consultant/kantor/backend/internal/handler/whatsapp"
+	"github.com/kana-consultant/kantor/backend/internal/metrics"
 	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
 	"github.com/kana-consultant/kantor/backend/internal/rbac"
 	auditrepo "github.com/kana-consultant/kantor/backend/internal/repository/audit"
@@ -206,7 +206,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		metrics:              metrics.NewRegistry(),
 		accessTokenBlacklist: accessTokenBlacklist,
 	}
-	application.router = application.buildRouter(
+	router, err := application.buildRouter(
 		auditService,
 		authService,
 		adminhandler.NewAuditLogsHandler(auditService),
@@ -232,6 +232,11 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		fileshandler.New(filesService),
 		wahandler.New(whatsappService),
 	)
+	if err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("build router: %w", err)
+	}
+	application.router = router
 	application.startBackgroundJobs(authService, subscriptionsService, trackerService, trackerReminderService, reimbursementsService, whatsappService, emailDeliveryService, vpsMonitorService, domainMonitorService)
 
 	return application, nil
@@ -282,12 +287,17 @@ func (a *App) buildRouter(
 	notificationsHandler *notificationshandler.Handler,
 	filesHandler *fileshandler.Handler,
 	waHandler *wahandler.Handler,
-) http.Handler {
+) (http.Handler, error) {
 	router := chi.NewRouter()
 	authHandler := authhandler.New(authService, a.cfg)
 
+	clientIPMiddleware, err := platformmiddleware.NewClientIPMiddleware(a.cfg.TrustedProxyCIDRs)
+	if err != nil {
+		return nil, err
+	}
+
 	router.Use(chimiddleware.RequestID)
-	router.Use(chimiddleware.RealIP)
+	router.Use(clientIPMiddleware)
 	// otelhttp opens a server span for every request and stitches it into
 	// the W3C traceparent context propagated by upstream callers.
 	router.Use(func(next http.Handler) http.Handler {
@@ -456,7 +466,7 @@ func (a *App) buildRouter(
 		})
 	})
 
-	return router
+	return router, nil
 }
 
 func (a *App) startBackgroundJobs(authService *authservice.Service, subscriptionsService *hrisservice.SubscriptionsService, trackerService *operationalservice.TrackerService, trackerReminderService *operationalservice.TrackerReminderService, reimbursementsService *hrisservice.ReimbursementsService, whatsappService *waservice.Service, emailDeliveryService *notificationsservice.EmailDeliveryService, vpsMonitorService *operationalservice.VPSMonitorService, domainMonitorService *operationalservice.DomainMonitorService) {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	JWTAccessExpiry           time.Duration
 	JWTRefreshExpiry          time.Duration
 	CORSOrigins               []string
+	TrustedProxyCIDRs         []string
 	TrackerRetentionDays      int
 	AppURL                    string
 	Tenants                   []TenantConfig
@@ -85,10 +86,12 @@ func Load() (Config, error) {
 		JWTAccessExpiry:           accessExpiry,
 		JWTRefreshExpiry:          refreshExpiry,
 		CORSOrigins:               splitCSV(getEnv("CORS_ORIGINS", "http://localhost:3000")),
-		TrackerRetentionDays:      parseIntEnv("TRACKER_RETENTION_DAYS", 90),
-		AppURL:                    getEnv("APP_URL", "http://localhost:3000"),
-		Tenants:                   parseTenants(getEnv("TENANTS", "Default|default|localhost")),
-		WAHADefaults:              wahaDefaults,
+		TrustedProxyCIDRs: splitCSV(getEnv("TRUSTED_PROXY_CIDRS",
+			"127.0.0.1/32,::1/128,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,169.254.0.0/16,fc00::/7,fe80::/10")),
+		TrackerRetentionDays: parseIntEnv("TRACKER_RETENTION_DAYS", 90),
+		AppURL:               getEnv("APP_URL", "http://localhost:3000"),
+		Tenants:              parseTenants(getEnv("TENANTS", "Default|default|localhost")),
+		WAHADefaults:         wahaDefaults,
 	}
 
 	if cfg.DatabaseURL == "" {

--- a/backend/internal/handler/auth/handler.go
+++ b/backend/internal/handler/auth/handler.go
@@ -478,6 +478,10 @@ func hasCSRFHeader(r *http.Request) bool {
 }
 
 func clientIP(r *http.Request) string {
+	if forwarded := strings.TrimSpace(platformmiddleware.ClientIPFromContext(r.Context())); forwarded != "" {
+		return forwarded
+	}
+
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err == nil {
 		return host

--- a/backend/internal/middleware/audit.go
+++ b/backend/internal/middleware/audit.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"net"
 	"net/http"
 
 	auditservice "github.com/kana-consultant/kantor/backend/internal/service/audit"
@@ -16,7 +15,7 @@ const (
 func AuditMiddleware(svc *auditservice.Service) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip := extractIP(r)
+			ip := ClientIPFromRequest(r)
 			ctx := context.WithValue(r.Context(), auditServiceKey, svc)
 			ctx = context.WithValue(ctx, clientIPKey, ip)
 			next.ServeHTTP(w, r.WithContext(ctx))
@@ -72,14 +71,4 @@ func AuditLogWithUser(ctx context.Context, userID, action, module, resource, res
 		NewValue:   newValue,
 		IPAddress:  ClientIPFromContext(ctx),
 	})
-}
-
-func extractIP(r *http.Request) string {
-	// chi's RealIP middleware sets RemoteAddr from X-Forwarded-For / X-Real-IP,
-	// so r.RemoteAddr already reflects the real client IP in most setups.
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		return r.RemoteAddr
-	}
-	return host
 }

--- a/backend/internal/middleware/client_ip.go
+++ b/backend/internal/middleware/client_ip.go
@@ -1,0 +1,146 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+type clientIPContextKey struct{}
+
+var defaultTrustedProxyCIDRs = []string{
+	"127.0.0.1/32",
+	"::1/128",
+	"10.0.0.0/8",
+	"172.16.0.0/12",
+	"192.168.0.0/16",
+	"169.254.0.0/16",
+	"fc00::/7",
+	"fe80::/10",
+}
+
+type clientIPResolver struct {
+	trustedProxyNets []*net.IPNet
+}
+
+func NewClientIPMiddleware(trustedProxyCIDRs []string) (func(http.Handler) http.Handler, error) {
+	resolver, err := newClientIPResolver(trustedProxyCIDRs)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			clientIP := resolver.Resolve(r)
+			ctx := context.WithValue(r.Context(), clientIPContextKey{}, clientIP)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}, nil
+}
+
+func ClientIPFromRequest(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+
+	if ip, ok := r.Context().Value(clientIPContextKey{}).(string); ok && strings.TrimSpace(ip) != "" {
+		return ip
+	}
+
+	return parseRemoteIP(r.RemoteAddr)
+}
+
+func newClientIPResolver(trustedProxyCIDRs []string) (*clientIPResolver, error) {
+	cidrs := trustedProxyCIDRs
+	if len(cidrs) == 0 {
+		cidrs = defaultTrustedProxyCIDRs
+	}
+
+	trustedProxyNets := make([]*net.IPNet, 0, len(cidrs))
+	for _, item := range cidrs {
+		cidr := strings.TrimSpace(item)
+		if cidr == "" {
+			continue
+		}
+
+		_, network, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return nil, fmt.Errorf("parse trusted proxy cidr %q: %w", cidr, err)
+		}
+		trustedProxyNets = append(trustedProxyNets, network)
+	}
+
+	return &clientIPResolver{trustedProxyNets: trustedProxyNets}, nil
+}
+
+func (r *clientIPResolver) Resolve(req *http.Request) string {
+	remoteIP := parseRemoteIP(req.RemoteAddr)
+	if remoteIP == "" {
+		return ""
+	}
+
+	parsedRemote := net.ParseIP(remoteIP)
+	if parsedRemote == nil || !r.isTrustedProxy(parsedRemote) {
+		return remoteIP
+	}
+
+	candidates := forwardedCandidates(req)
+	for idx := len(candidates) - 1; idx >= 0; idx-- {
+		candidateIP := net.ParseIP(candidates[idx])
+		if candidateIP == nil {
+			continue
+		}
+		if !r.isTrustedProxy(candidateIP) {
+			return candidateIP.String()
+		}
+	}
+
+	return remoteIP
+}
+
+func (r *clientIPResolver) isTrustedProxy(ip net.IP) bool {
+	for _, network := range r.trustedProxyNets {
+		if network.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func forwardedCandidates(req *http.Request) []string {
+	values := req.Header.Values("X-Forwarded-For")
+	if len(values) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		parts := strings.Split(value, ",")
+		for _, part := range parts {
+			if ip := strings.TrimSpace(part); ip != "" {
+				out = append(out, ip)
+			}
+		}
+	}
+
+	return out
+}
+
+func parseRemoteIP(remoteAddr string) string {
+	trimmed := strings.TrimSpace(remoteAddr)
+	if trimmed == "" {
+		return ""
+	}
+
+	if host, _, err := net.SplitHostPort(trimmed); err == nil {
+		return host
+	}
+
+	if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+		return strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]")
+	}
+
+	return trimmed
+}

--- a/backend/internal/middleware/client_ip_test.go
+++ b/backend/internal/middleware/client_ip_test.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientIPResolver_UntrustedRemoteIgnoresForwardedHeader(t *testing.T) {
+	resolver, err := newClientIPResolver([]string{"10.0.0.0/8"})
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.10:44321"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7")
+
+	if got := resolver.Resolve(req); got != "203.0.113.10" {
+		t.Fatalf("expected direct client ip, got %q", got)
+	}
+}
+
+func TestClientIPResolver_TrustedRemoteUsesFirstUntrustedFromRight(t *testing.T) {
+	resolver, err := newClientIPResolver([]string{"10.0.0.0/8", "192.168.0.0/16"})
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.5:44321"
+	req.Header.Set("X-Forwarded-For", "198.51.100.99, 192.168.0.20")
+
+	if got := resolver.Resolve(req); got != "198.51.100.99" {
+		t.Fatalf("expected forwarded client ip, got %q", got)
+	}
+}
+
+func TestClientIPResolver_AllForwardedTrustedFallsBackToRemote(t *testing.T) {
+	resolver, err := newClientIPResolver([]string{"10.0.0.0/8", "192.168.0.0/16"})
+	if err != nil {
+		t.Fatalf("new resolver: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.5:44321"
+	req.Header.Set("X-Forwarded-For", "10.1.2.3, 192.168.0.20")
+
+	if got := resolver.Resolve(req); got != "10.0.0.5" {
+		t.Fatalf("expected remote ip fallback, got %q", got)
+	}
+}

--- a/backend/internal/middleware/logging.go
+++ b/backend/internal/middleware/logging.go
@@ -59,7 +59,7 @@ func AccessLogger(next http.Handler) http.Handler {
 				slog.Int("status", status),
 				slog.Int("bytes", ww.BytesWritten()),
 				slog.Int64("latency_ms", latency.Milliseconds()),
-				slog.String("remote_ip", r.RemoteAddr),
+				slog.String("remote_ip", ClientIPFromRequest(r)),
 			}
 			if reqID := chimiddleware.GetReqID(r.Context()); reqID != "" {
 				attrs = append(attrs, slog.String("request_id", reqID))

--- a/backend/internal/middleware/rate_limit.go
+++ b/backend/internal/middleware/rate_limit.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"math"
-	"net"
 	"net/http"
 	"strconv"
 	"sync"
@@ -110,14 +109,8 @@ func (l *ipRateLimiter) retryAfter(key string, now time.Time) time.Duration {
 	return 0
 }
 
-// clientIPFromRequest returns the client IP from r.RemoteAddr.
-// Assumes chi's RealIP middleware has already rewritten RemoteAddr
-// from X-Real-IP / X-Forwarded-For when behind a reverse proxy.
+// clientIPFromRequest resolves client IP from the trusted-proxy aware
+// middleware context and falls back to the direct RemoteAddr when needed.
 func clientIPFromRequest(r *http.Request) string {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err == nil {
-		return host
-	}
-
-	return r.RemoteAddr
+	return ClientIPFromRequest(r)
 }


### PR DESCRIPTION
## Summary
This PR hardens how client IP addresses are resolved when the app is running behind reverse proxies.

## Why this change?
Previously, request IP handling could trust forwarded headers too broadly. In practice, that can allow spoofed client IPs, which affects:
- audit log accuracy,
- rate-limit fairness/effectiveness,
- and auth telemetry quality.

## What changed
- Added a dedicated trusted-proxy-aware client IP middleware.
- Replaced generic RealIP behavior in router setup with the new middleware.
- Introduced `TRUSTED_PROXY_CIDRS` config support (with safe defaults for local/private proxy ranges).
- Updated downstream consumers (audit, logging, rate limiting, auth handler client IP reads) to use the resolved trusted client IP from request context.

## Security impact
- Prevents untrusted peers from forging client identity through `X-Forwarded-For` / `X-Real-IP`.
- Keeps security controls and logs anchored to trusted network boundaries.

## Testing
- Added focused middleware tests for client IP resolution behavior.
- Ran targeted tests for affected auth/middleware paths.

## Notes
This is backward-compatible by default and only tightens trust boundaries. Existing deployments can still customize proxy trust explicitly via environment configuration.
