### PR TITLE
fix(upload): enforce strict multipart size caps and consistent 413 responses

### DIFF
--- a/backend/internal/handler/auth/profile.go
+++ b/backend/internal/handler/auth/profile.go
@@ -19,6 +19,8 @@ import (
 	"github.com/kana-consultant/kantor/backend/internal/uploads"
 )
 
+const maxProfileAvatarMultipartMaxBytes = 6 << 20
+
 func (h *Handler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
 	if !ok {
@@ -96,7 +98,12 @@ func (h *Handler) UploadProfileAvatar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxProfileAvatarMultipartMaxBytes)
 	if err := r.ParseMultipartForm(5 << 20); err != nil {
+		if platformmiddleware.IsBodyTooLargeError(err) {
+			platformmiddleware.WriteBodyTooLargeError(w)
+			return
+		}
 		response.WriteError(w, http.StatusBadRequest, "INVALID_MULTIPART", "Upload harus menggunakan multipart form data", nil)
 		return
 	}

--- a/backend/internal/handler/hris/employees.go
+++ b/backend/internal/handler/hris/employees.go
@@ -32,6 +32,8 @@ type EmployeesHandler struct {
 	uploadsDir   string
 }
 
+const maxEmployeeAvatarMultipartMaxBytes = 6 << 20
+
 func NewEmployeesHandler(
 	service *hrisservice.EmployeesService,
 	compensation *hrisservice.CompensationService,
@@ -138,7 +140,12 @@ func (h *EmployeesHandler) updateEmployee(w http.ResponseWriter, r *http.Request
 }
 
 func (h *EmployeesHandler) uploadAvatar(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxEmployeeAvatarMultipartMaxBytes)
 	if err := r.ParseMultipartForm(5 << 20); err != nil {
+		if platformmiddleware.IsBodyTooLargeError(err) {
+			platformmiddleware.WriteBodyTooLargeError(w)
+			return
+		}
 		response.WriteError(w, http.StatusBadRequest, "INVALID_MULTIPART", "Avatar upload must use multipart form data", nil)
 		return
 	}

--- a/backend/internal/handler/hris/reimbursements.go
+++ b/backend/internal/handler/hris/reimbursements.go
@@ -179,7 +179,12 @@ func (h *ReimbursementsHandler) uploadAttachments(w http.ResponseWriter, r *http
 		return
 	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, maxReimbursementMultipartMaxBytes)
 	if err := r.ParseMultipartForm(maxReimbursementMultipartMaxBytes); err != nil {
+		if platformmiddleware.IsBodyTooLargeError(err) {
+			platformmiddleware.WriteBodyTooLargeError(w)
+			return
+		}
 		response.WriteError(w, http.StatusBadRequest, "INVALID_MULTIPART", "Attachment upload must use multipart form data", nil)
 		return
 	}

--- a/backend/internal/handler/marketing/campaigns.go
+++ b/backend/internal/handler/marketing/campaigns.go
@@ -33,6 +33,11 @@ type CampaignsHandler struct {
 	uploadsDir string
 }
 
+const (
+	maxCampaignAttachmentMultipartMaxBytes = 50 << 20
+	maxCampaignAttachmentFiles             = 10
+)
+
 func NewCampaignsHandler(service *marketingservice.CampaignsService, uploadsDir string, users exportutil.UserLookup) *CampaignsHandler {
 	return &CampaignsHandler{
 		service:    service,
@@ -211,7 +216,12 @@ func (h *CampaignsHandler) uploadAttachment(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if err := r.ParseMultipartForm(50 << 20); err != nil {
+	r.Body = http.MaxBytesReader(w, r.Body, maxCampaignAttachmentMultipartMaxBytes)
+	if err := r.ParseMultipartForm(maxCampaignAttachmentMultipartMaxBytes); err != nil {
+		if platformmiddleware.IsBodyTooLargeError(err) {
+			platformmiddleware.WriteBodyTooLargeError(w)
+			return
+		}
 		response.WriteError(w, http.StatusBadRequest, "INVALID_MULTIPART", "Attachment upload must use multipart form data", nil)
 		return
 	}
@@ -222,6 +232,10 @@ func (h *CampaignsHandler) uploadAttachment(w http.ResponseWriter, r *http.Reque
 	}
 	if len(files) == 0 {
 		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "At least one file is required", map[string]string{"files": "required"})
+		return
+	}
+	if len(files) > maxCampaignAttachmentFiles {
+		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", fmt.Sprintf("Maximum %d files can be uploaded at once", maxCampaignAttachmentFiles), map[string]string{"files": "too_many_files"})
 		return
 	}
 

--- a/backend/internal/handler/marketing/leads.go
+++ b/backend/internal/handler/marketing/leads.go
@@ -23,6 +23,8 @@ type LeadsHandler struct {
 	validator *validator.Validate
 }
 
+const maxLeadImportMultipartMaxBytes = 10 << 20
+
 func NewLeadsHandler(service *marketingservice.LeadsService, users exportutil.UserLookup) *LeadsHandler {
 	return &LeadsHandler{
 		service:   service,
@@ -198,7 +200,12 @@ func (h *LeadsHandler) importCSV(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := r.ParseMultipartForm(10 << 20); err != nil {
+	r.Body = http.MaxBytesReader(w, r.Body, maxLeadImportMultipartMaxBytes)
+	if err := r.ParseMultipartForm(maxLeadImportMultipartMaxBytes); err != nil {
+		if platformmiddleware.IsBodyTooLargeError(err) {
+			platformmiddleware.WriteBodyTooLargeError(w)
+			return
+		}
 		response.WriteError(w, http.StatusBadRequest, "INVALID_MULTIPART", "Lead import must use multipart form data", nil)
 		return
 	}

--- a/backend/internal/middleware/bodysize.go
+++ b/backend/internal/middleware/bodysize.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -27,4 +28,18 @@ func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
 // Handlers that decode JSON should check for http.MaxBytesError and call this.
 func WriteBodyTooLargeError(w http.ResponseWriter) {
 	response.WriteError(w, http.StatusRequestEntityTooLarge, "BODY_TOO_LARGE", "Request body exceeds the maximum allowed size", nil)
+}
+
+// IsBodyTooLargeError detects body-size violations produced by http.MaxBytesReader.
+func IsBodyTooLargeError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		return true
+	}
+
+	return strings.Contains(strings.ToLower(err.Error()), "request body too large")
 }

--- a/backend/internal/middleware/bodysize_test.go
+++ b/backend/internal/middleware/bodysize_test.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestIsBodyTooLargeError_WithMaxBytesError(t *testing.T) {
+	err := &http.MaxBytesError{Limit: 1024}
+	if !IsBodyTooLargeError(err) {
+		t.Fatal("expected max bytes error to be detected")
+	}
+}
+
+func TestIsBodyTooLargeError_WithGenericError(t *testing.T) {
+	if IsBodyTooLargeError(errors.New("invalid multipart")) {
+		t.Fatal("did not expect generic multipart error to be treated as body too large")
+	}
+}


### PR DESCRIPTION
## Summary
This PR strengthens multipart upload handling by enforcing strict request-size boundaries and consistent `413 Payload Too Large` behavior across upload-heavy endpoints.

## Why this change?
Some endpoints relied on multipart parsing without a hard reader cap at the request layer. That increases risk of oversized payload abuse (memory/CPU pressure and unnecessary resource usage), especially on file-upload routes.

## What changed
- Added explicit `http.MaxBytesReader` enforcement before multipart parsing on key endpoints.
- Standardized oversized-body detection with helper logic so over-limit requests fail fast with clean `413` responses.
- Applied/updated multipart limits on:
  - profile avatar upload,
  - employee avatar upload,
  - reimbursement attachments,
  - marketing campaign attachments,
  - lead import.
- Added guardrail for campaign attachment count to avoid excessive multi-file submissions.

## Security impact
- Reduces DoS surface from large multipart payloads.
- Improves operational stability by failing early and consistently under abusive input.

## Testing
- Added focused tests for body-size error classification.
- Ran targeted tests for middleware and affected handler packages.

## Notes
This change is intentionally strict on oversized payloads, but non-breaking for legitimate clients already within documented limits.
