### PR TITLE
fix(operational): block SSRF-prone VPS health-check targets

### DIFF
--- a/backend/internal/service/operational/vps.go
+++ b/backend/internal/service/operational/vps.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/netip"
+	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,6 +24,11 @@ var (
 	ErrVPSCheckOnOther  = errors.New("vps app cannot link to a check on a different vps")
 	ErrInvalidVPSCheck  = errors.New("invalid vps health check")
 )
+
+var blockedProbeCIDRs = []netip.Prefix{
+	netip.MustParsePrefix("100.64.0.0/10"), // CGNAT
+	netip.MustParsePrefix("198.18.0.0/15"), // benchmark/testing range
+}
 
 type vpsRepository interface {
 	CreateVPS(ctx context.Context, p operationalrepo.CreateVPSParams) (model.VPSServer, error)
@@ -142,11 +151,11 @@ func (s *VPSService) ListVPS(ctx context.Context, p operationalrepo.ListVPSParam
 // VPSDetail bundles a server with its checks, apps, and recent events for the
 // detail page. The handler renders this directly as JSON.
 type VPSDetail struct {
-	Server  model.VPSServer               `json:"server"`
-	Checks  []model.VPSHealthCheck        `json:"checks"`
-	Apps    []model.VPSApp                `json:"apps"`
-	Events  []model.VPSHealthEvent        `json:"events"`
-	Daily   []model.VPSHealthDailySummary `json:"daily"`
+	Server model.VPSServer               `json:"server"`
+	Checks []model.VPSHealthCheck        `json:"checks"`
+	Apps   []model.VPSApp                `json:"apps"`
+	Events []model.VPSHealthEvent        `json:"events"`
+	Daily  []model.VPSHealthDailySummary `json:"daily"`
 }
 
 func (s *VPSService) GetVPSDetail(ctx context.Context, vpsID string) (VPSDetail, error) {
@@ -325,20 +334,94 @@ func validateCheckTarget(checkType string, target string) error {
 		if target == "" {
 			return fmt.Errorf("%w: icmp target (host or IP) is required", ErrInvalidVPSCheck)
 		}
+		if err := validateProbeHost(target); err != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidVPSCheck, err)
+		}
 	case "tcp":
-		// expect host:port
-		idx := strings.LastIndex(target, ":")
-		if idx <= 0 || idx == len(target)-1 {
+		host, port, err := net.SplitHostPort(target)
+		if err != nil {
 			return fmt.Errorf("%w: tcp target must be host:port", ErrInvalidVPSCheck)
 		}
+		p, err := strconv.Atoi(port)
+		if err != nil || p < 1 || p > 65535 {
+			return fmt.Errorf("%w: tcp target must use numeric port", ErrInvalidVPSCheck)
+		}
+		if err := validateProbeHost(host); err != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidVPSCheck, err)
+		}
 	case "http", "https":
-		if !strings.HasPrefix(target, "http://") && !strings.HasPrefix(target, "https://") {
+		parsed, err := url.ParseRequestURI(target)
+		if err != nil || !parsed.IsAbs() || parsed.Hostname() == "" {
 			return fmt.Errorf("%w: http/https target must be a full URL", ErrInvalidVPSCheck)
+		}
+		if parsed.User != nil {
+			return fmt.Errorf("%w: URL credentials are not allowed", ErrInvalidVPSCheck)
+		}
+		if parsed.Scheme != checkType {
+			return fmt.Errorf("%w: %s checks must use %s:// target", ErrInvalidVPSCheck, checkType, checkType)
+		}
+		if parsed.Port() != "" {
+			p, err := strconv.Atoi(parsed.Port())
+			if err != nil || p < 1 || p > 65535 {
+				return fmt.Errorf("%w: URL port must be numeric", ErrInvalidVPSCheck)
+			}
+		}
+		if err := validateProbeHost(parsed.Hostname()); err != nil {
+			return fmt.Errorf("%w: %v", ErrInvalidVPSCheck, err)
 		}
 	default:
 		return fmt.Errorf("%w: unknown check type %q", ErrInvalidVPSCheck, checkType)
 	}
 	return nil
+}
+
+func validateProbeHost(rawHost string) error {
+	host := strings.TrimSpace(rawHost)
+	if host == "" {
+		return errors.New("target host is required")
+	}
+	if strings.EqualFold(host, "localhost") || strings.HasSuffix(strings.ToLower(host), ".localhost") {
+		return errors.New("localhost targets are not allowed")
+	}
+
+	ip, ok := parseLiteralIP(host)
+	if !ok {
+		return nil
+	}
+	if isBlockedProbeIP(ip) {
+		return fmt.Errorf("target IP %s is not allowed", ip.String())
+	}
+	return nil
+}
+
+func parseLiteralIP(raw string) (netip.Addr, bool) {
+	trimmed := strings.TrimSpace(strings.Trim(raw, "[]"))
+	if zone := strings.Index(trimmed, "%"); zone > 0 {
+		trimmed = trimmed[:zone]
+	}
+	addr, err := netip.ParseAddr(trimmed)
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return addr.Unmap(), true
+}
+
+func isBlockedProbeIP(addr netip.Addr) bool {
+	if !addr.IsValid() {
+		return true
+	}
+	if addr.IsLoopback() || addr.IsPrivate() || addr.IsMulticast() || addr.IsUnspecified() {
+		return true
+	}
+	if addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() || addr.IsInterfaceLocalMulticast() {
+		return true
+	}
+	for _, cidr := range blockedProbeCIDRs {
+		if cidr.Contains(addr) {
+			return true
+		}
+	}
+	return false
 }
 
 func mapVPSError(err error) error {

--- a/backend/internal/service/operational/vps_monitor.go
+++ b/backend/internal/service/operational/vps_monitor.go
@@ -40,9 +40,9 @@ type vpsMonitorAuthLookup interface {
 // alerts on transition. It is invoked from the per-tenant background
 // scheduler in app.go.
 type VPSMonitorService struct {
-	repo     vpsRepository
-	notifs   vpsMonitorNotifications
-	authRepo vpsMonitorAuthLookup
+	repo       vpsRepository
+	notifs     vpsMonitorNotifications
+	authRepo   vpsMonitorAuthLookup
 	httpClient *http.Client
 }
 
@@ -223,6 +223,14 @@ func (s *VPSMonitorService) probe(ctx context.Context, c model.VPSHealthCheck) o
 }
 
 func probeTCP(ctx context.Context, target string, timeout time.Duration) operationalrepo.CheckResult {
+	host, _, err := net.SplitHostPort(target)
+	if err != nil {
+		return operationalrepo.CheckResult{Status: "down", ErrorMessage: "invalid tcp target: " + err.Error()}
+	}
+	if err := ensureProbeHostIsPublic(ctx, host, timeout); err != nil {
+		return operationalrepo.CheckResult{Status: "down", ErrorMessage: err.Error()}
+	}
+
 	dialer := &net.Dialer{Timeout: timeout}
 	dialCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -242,9 +250,14 @@ func probeHTTP(ctx context.Context, client *http.Client, target string, timeout 
 	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	if _, err := url.Parse(target); err != nil {
+	parsed, err := url.Parse(target)
+	if err != nil {
 		return operationalrepo.CheckResult{Status: "down", ErrorMessage: "invalid url: " + err.Error()}
 	}
+	if err := ensureProbeHostIsPublic(reqCtx, parsed.Hostname(), timeout); err != nil {
+		return operationalrepo.CheckResult{Status: "down", ErrorMessage: err.Error()}
+	}
+
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, target, nil)
 	if err != nil {
 		return operationalrepo.CheckResult{Status: "down", ErrorMessage: "request build: " + err.Error()}
@@ -281,6 +294,30 @@ func probeHTTP(ctx context.Context, client *http.Client, target string, timeout 
 		}
 	}
 	return res
+}
+
+func ensureProbeHostIsPublic(ctx context.Context, host string, timeout time.Duration) error {
+	if err := validateProbeHost(host); err != nil {
+		return err
+	}
+	if _, isLiteral := parseLiteralIP(host); isLiteral {
+		return nil
+	}
+
+	resolveCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ips, err := net.DefaultResolver.LookupNetIP(resolveCtx, "ip", host)
+	if err != nil {
+		// Let the probe attempt continue and report the dial/request failure.
+		return nil
+	}
+	for _, ip := range ips {
+		if isBlockedProbeIP(ip.Unmap()) {
+			return fmt.Errorf("target host resolves to non-public IP %s", ip.String())
+		}
+	}
+	return nil
 }
 
 func trimCertIssuer(s string) string {
@@ -444,4 +481,3 @@ func (s *VPSMonitorService) RollupYesterday(ctx context.Context, now time.Time) 
 	yesterday := now.AddDate(0, 0, -1)
 	return s.repo.RollupDailySummary(ctx, yesterday)
 }
-

--- a/backend/internal/service/operational/vps_security_test.go
+++ b/backend/internal/service/operational/vps_security_test.go
@@ -1,0 +1,103 @@
+package operational
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func TestValidateCheckTarget(t *testing.T) {
+	tests := []struct {
+		name      string
+		checkType string
+		target    string
+		wantErr   bool
+	}{
+		{
+			name:      "http accepts public hostname",
+			checkType: "http",
+			target:    "http://example.com/healthz",
+		},
+		{
+			name:      "http rejects scheme mismatch",
+			checkType: "http",
+			target:    "https://example.com",
+			wantErr:   true,
+		},
+		{
+			name:      "https rejects localhost",
+			checkType: "https",
+			target:    "https://localhost",
+			wantErr:   true,
+		},
+		{
+			name:      "https rejects loopback literal",
+			checkType: "https",
+			target:    "https://127.0.0.1",
+			wantErr:   true,
+		},
+		{
+			name:      "tcp rejects private literal",
+			checkType: "tcp",
+			target:    "10.1.2.3:443",
+			wantErr:   true,
+		},
+		{
+			name:      "tcp accepts public literal",
+			checkType: "tcp",
+			target:    "8.8.8.8:53",
+		},
+		{
+			name:      "tcp rejects non-numeric port",
+			checkType: "tcp",
+			target:    "example.com:https",
+			wantErr:   true,
+		},
+		{
+			name:      "icmp rejects localhost",
+			checkType: "icmp",
+			target:    "localhost",
+			wantErr:   true,
+		},
+		{
+			name:      "icmp accepts hostname",
+			checkType: "icmp",
+			target:    "example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCheckTarget(tc.checkType, tc.target)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected nil, got error: %v", err)
+			}
+		})
+	}
+}
+
+func TestIsBlockedProbeIP(t *testing.T) {
+	tests := []struct {
+		addr    string
+		blocked bool
+	}{
+		{addr: "127.0.0.1", blocked: true},
+		{addr: "10.0.0.1", blocked: true},
+		{addr: "169.254.1.1", blocked: true},
+		{addr: "100.64.1.1", blocked: true},
+		{addr: "198.18.0.1", blocked: true},
+		{addr: "8.8.8.8", blocked: false},
+		{addr: "1.1.1.1", blocked: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.addr, func(t *testing.T) {
+			addr := netip.MustParseAddr(tc.addr)
+			if got := isBlockedProbeIP(addr); got != tc.blocked {
+				t.Fatalf("isBlockedProbeIP(%s) = %v, want %v", tc.addr, got, tc.blocked)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This PR hardens Operational VPS health checks against SSRF-style target abuse.

## Why this change?
VPS health check targets are user-configurable. Without strict validation, a malicious/compromised admin session could point checks to local/internal addresses and make the monitor probe sensitive network surfaces.

## What changed
- Tightened check target validation for `icmp`, `tcp`, `http`, and `https`.
- Enforced stronger URL/target rules:
  - scheme must match check type (`http` vs `https`),
  - numeric port validation (`1-65535`),
  - reject URL credentials,
  - reject localhost and non-public IP ranges.
- Added blocked network coverage for loopback/private/link-local/multicast plus CGNAT and benchmarking ranges.
- Added runtime DNS safety checks in probe execution:
  - if hostname resolves to blocked/internal IPs, probe is rejected before dial/request.

## Security impact
- Prevents monitor workers from being used as an internal network pivot.
- Significantly reduces SSRF risk in the operational checks subsystem.

## Testing
- Added new security-focused test coverage for target validation and blocked IP logic.
- Ran targeted operational service test suite.

## Notes
This is a defensive hardening PR. The monitor remains fully functional for legitimate public targets while rejecting unsafe internal destinations.
