### PR TITLE
fix(infra): tighten resource management to prevent pool exhaustion

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -58,6 +58,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
+	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -172,6 +172,8 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -21,6 +21,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	_ "go.uber.org/automaxprocs"
 
 	"github.com/go-chi/chi/v5"
 
@@ -69,7 +70,36 @@ type App struct {
 }
 
 func New(ctx context.Context, cfg config.Config) (*App, error) {
-	pool, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	// Pool tuning rationale:
+	//   MaxConns=25 — TenantMiddleware holds 1 conn per HTTP request for the
+	//   full handler lifetime, plus background schedulers acquire conns per
+	//   tenant. Default of 4 (pgxpool's hardcoded default — NumCPU is NOT
+	//   consulted) drains immediately under any real traffic.
+	//   MaxConnLifetime=30m — recycle to prevent leaks from long-lived conns.
+	//   MaxConnIdleTime=5m  — release idle conns so we don't hold all 25 forever.
+	//   HealthCheckPeriod=1m — proactive ping catches network partitions.
+	// Override in production via DATABASE_URL ?pool_max_conns=N for tuning.
+	poolConfig, err := pgxpool.ParseConfig(cfg.DatabaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse pool config: %w", err)
+	}
+	if poolConfig.MaxConns < 25 {
+		poolConfig.MaxConns = 25
+	}
+	if poolConfig.MinConns < 2 {
+		poolConfig.MinConns = 2
+	}
+	if poolConfig.MaxConnLifetime == 0 {
+		poolConfig.MaxConnLifetime = 30 * time.Minute
+	}
+	if poolConfig.MaxConnIdleTime == 0 {
+		poolConfig.MaxConnIdleTime = 5 * time.Minute
+	}
+	if poolConfig.HealthCheckPeriod == 0 {
+		poolConfig.HealthCheckPeriod = 1 * time.Minute
+	}
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {
 		return nil, fmt.Errorf("create pgx pool: %w", err)
 	}
@@ -186,9 +216,9 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 
 	trackerReminderService := operationalservice.NewTrackerReminderService(trackerReminderRepository, notificationsRepository, whatsappService)
 	vpsService := operationalservice.NewVPSService(vpsRepository)
-	vpsMonitorService := operationalservice.NewVPSMonitorService(vpsRepository, notificationsRepository, authRepository)
+	vpsMonitorService := operationalservice.NewVPSMonitorService(vpsRepository, notificationsRepository, authRepository, pool)
 	domainService := operationalservice.NewDomainService(domainRepository)
-	domainMonitorService := operationalservice.NewDomainMonitorService(domainRepository, notificationsRepository, authRepository)
+	domainMonitorService := operationalservice.NewDomainMonitorService(domainRepository, notificationsRepository, authRepository, pool)
 
 	// Wire event triggers
 	kanbanService.SetTaskAssignNotifier(whatsappService)
@@ -472,6 +502,10 @@ func (a *App) buildRouter(
 func (a *App) startBackgroundJobs(authService *authservice.Service, subscriptionsService *hrisservice.SubscriptionsService, trackerService *operationalservice.TrackerService, trackerReminderService *operationalservice.TrackerReminderService, reimbursementsService *hrisservice.ReimbursementsService, whatsappService *waservice.Service, emailDeliveryService *notificationsservice.EmailDeliveryService, vpsMonitorService *operationalservice.VPSMonitorService, domainMonitorService *operationalservice.DomainMonitorService) {
 	ctx, cancel := context.WithCancel(context.Background())
 	a.backgroundCancel = cancel
+
+	// Permission cache otherwise leaks slowly via stale entries from users
+	// who never come back (TTL only deletes on access).
+	a.permissionCache.StartSweeper(ctx, 5*time.Minute)
 
 	runPerTenant := func(name string, fn func(ctx context.Context, t tenant.Info) error) {
 		if err := platformmiddleware.ForEachTenant(ctx, a.db, fn); err != nil {

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -139,3 +139,12 @@ func (s *statusRecorder) Write(b []byte) (int, error) {
 	}
 	return s.ResponseWriter.Write(b)
 }
+
+// Flush forwards to the wrapped writer when it supports streaming. Without
+// this, SSE handlers (notifications stream) fail their `http.Flusher` type
+// assert because *statusRecorder masks the Flusher interface.
+func (s *statusRecorder) Flush() {
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/backend/internal/middleware/tenant.go
+++ b/backend/internal/middleware/tenant.go
@@ -116,6 +116,35 @@ func WithScopedTenantConn[T any](ctx context.Context, fn func(context.Context) (
 	return fn(repository.WithConn(ctx, conn))
 }
 
+// AcquireTenantConn acquires a fresh tenant-scoped connection from the pool
+// with `app.current_tenant` set + role downgraded (if needed). Caller MUST
+// release via ReleaseTenantConn when done.
+//
+// Use this when you need a private conn for a unit of work that runs in
+// parallel with other workers (e.g. monitor probe workers) — sharing a
+// single pgxpool.Conn across goroutines is not safe.
+func AcquireTenantConn(ctx context.Context, pool *pgxpool.Pool, tenantID string) (*pgxpool.Conn, error) {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := setupTenantConn(ctx, conn, tenantID); err != nil {
+		conn.Release()
+		return nil, err
+	}
+	return conn, nil
+}
+
+// ReleaseTenantConn resets session state and returns the conn to the pool.
+// Always pair with AcquireTenantConn via defer.
+func ReleaseTenantConn(conn *pgxpool.Conn) {
+	if conn == nil {
+		return
+	}
+	_, _ = conn.Exec(context.Background(), "RESET ALL")
+	conn.Release()
+}
+
 // TenantMiddleware resolves the tenant from the Host header, acquires a
 // dedicated connection from the pool, and configures RLS by setting the
 // app.current_tenant GUC and (when superuser) downgrading to kantor_app.

--- a/backend/internal/rbac/cache.go
+++ b/backend/internal/rbac/cache.go
@@ -196,3 +196,36 @@ func (c *PermissionCache) InvalidateAll() {
 	c.store = make(map[string]*CachedPermissions)
 	c.mu.Unlock()
 }
+
+// StartSweeper spawns a background goroutine that periodically deletes
+// expired entries. Without this, stale entries from users who never come
+// back keep growing the cache map indefinitely (slow memory leak).
+//
+// Returns immediately. Stops when ctx is cancelled.
+func (c *PermissionCache) StartSweeper(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				c.sweep(time.Now())
+			}
+		}
+	}()
+}
+
+func (c *PermissionCache) sweep(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for key, entry := range c.store {
+		if entry == nil || now.Sub(entry.CachedAt) > entry.TTL {
+			delete(c.store, key)
+		}
+	}
+}

--- a/backend/internal/repository/operational/domain.go
+++ b/backend/internal/repository/operational/domain.go
@@ -318,7 +318,7 @@ func (r *DomainRepository) ListDueDNSChecks(ctx context.Context, now time.Time) 
 		WHERE dns_check_enabled = TRUE
 		  AND (
 		    dns_last_check_at IS NULL
-		    OR dns_last_check_at + (dns_check_interval_seconds * INTERVAL '1 second') <= $1
+		    OR dns_last_check_at + (dns_check_interval_seconds * INTERVAL '1 second') <= $1::timestamptz
 		  )
 	`, domainColumns)
 
@@ -347,7 +347,7 @@ func (r *DomainRepository) ListWhoisSyncDue(ctx context.Context, now time.Time) 
 	query := fmt.Sprintf(`
 		SELECT %s FROM domains
 		WHERE whois_sync_enabled = TRUE
-		  AND (whois_last_sync_at IS NULL OR whois_last_sync_at < $1 - INTERVAL '24 hours')
+		  AND (whois_last_sync_at IS NULL OR whois_last_sync_at < ($1::timestamptz - INTERVAL '24 hours'))
 	`, domainColumns)
 
 	rows, err := repository.DB(ctx, r.db).Query(ctx, query, now)

--- a/backend/internal/service/operational/domain_monitor.go
+++ b/backend/internal/service/operational/domain_monitor.go
@@ -9,12 +9,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/likexian/whois"
 	whoisparser "github.com/likexian/whois-parser"
 
 	"github.com/kana-consultant/kantor/backend/internal/model"
+	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
+	repository "github.com/kana-consultant/kantor/backend/internal/repository"
 	notificationsrepo "github.com/kana-consultant/kantor/backend/internal/repository/notifications"
 	operationalrepo "github.com/kana-consultant/kantor/backend/internal/repository/operational"
+	"github.com/kana-consultant/kantor/backend/internal/tenant"
 )
 
 // downBeforeDomainAlert is how many consecutive DNS failures must accumulate
@@ -31,13 +35,15 @@ type DomainMonitorService struct {
 	repo     domainRepository
 	notifs   vpsMonitorNotifications
 	authRepo vpsMonitorAuthLookup
+	pool     *pgxpool.Pool
 }
 
-func NewDomainMonitorService(repo domainRepository, notifs vpsMonitorNotifications, authRepo vpsMonitorAuthLookup) *DomainMonitorService {
+func NewDomainMonitorService(repo domainRepository, notifs vpsMonitorNotifications, authRepo vpsMonitorAuthLookup, pool *pgxpool.Pool) *DomainMonitorService {
 	return &DomainMonitorService{
 		repo:     repo,
 		notifs:   notifs,
 		authRepo: authRepo,
+		pool:     pool,
 	}
 }
 
@@ -59,6 +65,8 @@ func (s *DomainMonitorService) RunDueDNSChecks(ctx context.Context, now time.Tim
 	}
 	close(jobs)
 
+	tenantInfo, hasTenant := tenant.FromContext(ctx)
+
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
@@ -70,12 +78,29 @@ func (s *DomainMonitorService) RunDueDNSChecks(ctx context.Context, now time.Tim
 				}
 			}()
 			for d := range jobs {
-				s.processDNSCheck(ctx, d, time.Now().UTC())
+				s.runDNSWorker(ctx, tenantInfo.ID, hasTenant, d)
 			}
 		}()
 	}
 	wg.Wait()
 	return nil
+}
+
+// runDNSWorker wraps processDNSCheck with its own tenant-scoped pool conn so
+// concurrent workers do not share a single pgx conn.
+func (s *DomainMonitorService) runDNSWorker(ctx context.Context, tenantID string, hasTenant bool, d model.Domain) {
+	if !hasTenant || s.pool == nil {
+		s.processDNSCheck(ctx, d, time.Now().UTC())
+		return
+	}
+	conn, err := platformmiddleware.AcquireTenantConn(ctx, s.pool, tenantID)
+	if err != nil {
+		slog.WarnContext(ctx, "domain dns worker acquire conn failed", "domain_id", d.ID, "error", err)
+		return
+	}
+	defer platformmiddleware.ReleaseTenantConn(conn)
+	workerCtx := repository.WithConn(ctx, conn)
+	s.processDNSCheck(workerCtx, d, time.Now().UTC())
 }
 
 func (s *DomainMonitorService) processDNSCheck(ctx context.Context, d model.Domain, now time.Time) {
@@ -156,15 +181,60 @@ func domainCooldownExpired(lastSent *time.Time, now time.Time) bool {
 // SyncWhoisAll runs WHOIS lookups for domains due for sync (24h cadence).
 // Updates expiry_date when the registry returns one. Errors are recorded
 // per-domain but do not abort the loop.
+//
+// Uses a small worker pool so 50 domains × 5s WHOIS RTT does not block the
+// scheduler for minutes. Each worker uses its own DB connection so writes do
+// not serialize behind a single shared conn.
 func (s *DomainMonitorService) SyncWhoisAll(ctx context.Context, now time.Time) error {
 	domains, err := s.repo.ListWhoisSyncDue(ctx, now)
 	if err != nil {
 		return fmt.Errorf("list whois sync due: %w", err)
 	}
-	for _, d := range domains {
-		s.syncWhois(ctx, d)
+	if len(domains) == 0 {
+		return nil
 	}
+
+	const workers = 4
+	jobs := make(chan model.Domain, len(domains))
+	for _, d := range domains {
+		jobs <- d
+	}
+	close(jobs)
+
+	tenantInfo, hasTenant := tenant.FromContext(ctx)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.ErrorContext(ctx, "whois sync worker panic", "panic", r)
+				}
+			}()
+			for d := range jobs {
+				s.runWhoisWorker(ctx, tenantInfo.ID, hasTenant, d)
+			}
+		}()
+	}
+	wg.Wait()
 	return nil
+}
+
+func (s *DomainMonitorService) runWhoisWorker(ctx context.Context, tenantID string, hasTenant bool, d model.Domain) {
+	if !hasTenant || s.pool == nil {
+		s.syncWhois(ctx, d)
+		return
+	}
+	conn, err := platformmiddleware.AcquireTenantConn(ctx, s.pool, tenantID)
+	if err != nil {
+		slog.WarnContext(ctx, "whois worker acquire conn failed", "domain_id", d.ID, "error", err)
+		return
+	}
+	defer platformmiddleware.ReleaseTenantConn(conn)
+	workerCtx := repository.WithConn(ctx, conn)
+	s.syncWhois(workerCtx, d)
 }
 
 func (s *DomainMonitorService) syncWhois(ctx context.Context, d model.Domain) {

--- a/backend/internal/service/operational/vps_monitor.go
+++ b/backend/internal/service/operational/vps_monitor.go
@@ -11,9 +11,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/kana-consultant/kantor/backend/internal/model"
+	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
+	repository "github.com/kana-consultant/kantor/backend/internal/repository"
 	notificationsrepo "github.com/kana-consultant/kantor/backend/internal/repository/notifications"
 	operationalrepo "github.com/kana-consultant/kantor/backend/internal/repository/operational"
+	"github.com/kana-consultant/kantor/backend/internal/tenant"
 )
 
 // downBeforeAlert is how many consecutive failures must accumulate before
@@ -43,14 +48,16 @@ type VPSMonitorService struct {
 	repo       vpsRepository
 	notifs     vpsMonitorNotifications
 	authRepo   vpsMonitorAuthLookup
+	pool       *pgxpool.Pool
 	httpClient *http.Client
 }
 
-func NewVPSMonitorService(repo vpsRepository, notifs vpsMonitorNotifications, authRepo vpsMonitorAuthLookup) *VPSMonitorService {
+func NewVPSMonitorService(repo vpsRepository, notifs vpsMonitorNotifications, authRepo vpsMonitorAuthLookup, pool *pgxpool.Pool) *VPSMonitorService {
 	return &VPSMonitorService{
 		repo:     repo,
 		notifs:   notifs,
 		authRepo: authRepo,
+		pool:     pool,
 		// Single shared client; per-call timeout is set on the request itself.
 		// DisableKeepAlives keeps probe latency honest by not measuring a
 		// reused connection.
@@ -84,6 +91,12 @@ func (s *VPSMonitorService) RunDueChecks(ctx context.Context, now time.Time) err
 	}
 	close(jobs)
 
+	// Each worker acquires its own tenant-scoped DB connection. Sharing a
+	// single pgxpool.Conn across goroutines is not safe — pgx serializes at
+	// the connection level which both kills the parallelism the worker pool
+	// is meant to provide and risks panics on concurrent operations.
+	tenantInfo, hasTenant := tenant.FromContext(ctx)
+
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
 		wg.Add(1)
@@ -95,12 +108,31 @@ func (s *VPSMonitorService) RunDueChecks(ctx context.Context, now time.Time) err
 				}
 			}()
 			for c := range jobs {
-				s.processCheck(ctx, c, time.Now().UTC())
+				s.runWorker(ctx, tenantInfo.ID, hasTenant, c)
 			}
 		}()
 	}
 	wg.Wait()
 	return nil
+}
+
+// runWorker wraps processCheck with its own tenant-scoped pool connection so
+// concurrent workers do not share a single pgx conn.
+func (s *VPSMonitorService) runWorker(ctx context.Context, tenantID string, hasTenant bool, check model.VPSHealthCheck) {
+	if !hasTenant || s.pool == nil {
+		// Fallback to scheduler-provided conn (legacy path / tests). DB writes
+		// will serialize but it's the safer behavior than failing silently.
+		s.processCheck(ctx, check, time.Now().UTC())
+		return
+	}
+	conn, err := platformmiddleware.AcquireTenantConn(ctx, s.pool, tenantID)
+	if err != nil {
+		slog.WarnContext(ctx, "vps worker acquire conn failed", "check_id", check.ID, "error", err)
+		return
+	}
+	defer platformmiddleware.ReleaseTenantConn(conn)
+	workerCtx := repository.WithConn(ctx, conn)
+	s.processCheck(workerCtx, check, time.Now().UTC())
 }
 
 func (s *VPSMonitorService) processCheck(ctx context.Context, check model.VPSHealthCheck, now time.Time) {


### PR DESCRIPTION
## Summary

Server was reportedly going down under load. Audit found several compounding issues in resource management:

1. **DB pool not configured** — `pgxpool.New()` defaults to `MaxConns=4` (hardcoded, NumCPU is not consulted). With `TenantMiddleware` holding 1 conn per HTTP request lifetime + background schedulers grabbing conns per tenant, the pool drains under any real traffic.
2. **Monitor workers shared a single conn** — VPS + Domain monitor's worker pool of 8 goroutines all used the same tenant-scoped `pgxpool.Conn`, which is not safe for concurrent use. Operations serialized at the conn level, defeating parallelism, and risked panics on concurrent ops.
3. **WHOIS sync ran sequentially** — 50 domains × 5s WHOIS RTT held the tenant conn for ~4 minutes during the daily run.
4. **PermissionCache leaked slowly** — stale entries from churned users only deleted on access; map grew indefinitely.
5. **GOMAXPROCS unaware of cgroup CPU quota** — under Docker `--cpus=N` / k8s `cpu` limits, Go saw the host's full CPU count and oversized GOMAXPROCS, causing context-switch overhead.

## What changed

- `pgxpool.NewWithConfig` with `MaxConns=25`, `MinConns=2`, `MaxConnLifetime=30m`, `MaxConnIdleTime=5m`, `HealthCheckPeriod=1m`. Override via `DATABASE_URL ?pool_max_conns=N`.
- New helpers `AcquireTenantConn` / `ReleaseTenantConn` in `middleware/tenant.go`.
- VPS + Domain monitor workers now each acquire their own tenant-scoped conn.
- WHOIS sync runs in a worker pool of 4, each with its own conn.
- `PermissionCache.StartSweeper(ctx, 5*time.Minute)` purges expired entries periodically.
- `go.uber.org/automaxprocs` blank-imported in `app.go`.

## Drive-by bug fixes (surfaced during terminal verification)

- `ListWhoisSyncDue` + `ListDueDNSChecks`: explicit `::timestamptz` cast on placeholder. Postgres was rejecting `$1 - INTERVAL '24 hours'` with `operator does not exist: timestamp with time zone < interval` because the parser couldn't infer the placeholder type.
- `metrics.statusRecorder` now forwards `http.Flusher`. The wrapper was masking the interface, breaking SSE handlers — `/api/v1/notifications/stream` was returning 500 because the type-assert in `handler.Stream` was failing.

## Verification

- Backend tests: `go test -count=1 ./...` — all green
- Docker rebuild + restart, `automaxprocs: Leaving GOMAXPROCS=8: CPU quota undefined` log line confirms the lib is active
- WHOIS sync no longer logs the SQL operator error after restart
- Notifications SSE stream now connects without 500 (verified after metrics fix)

## Test plan

- [ ] After merge + deploy, verify `pg_stat_activity` shows the pool ramping up under traffic without saturating
- [ ] VPS / Domain monitor worker logs do not show `acquire conn failed`
- [ ] No more `operator does not exist: timestamp with time zone < interval` from `domain_whois_sync`
- [ ] SSE notifications stream stays connected (no 500 in access log)
- [ ] Memory of backend container stays flat over 24h (PermissionCache sweep working)