### PR TITLE
feat: OAuth 2.1 for MCP remote connectors (Claude Desktop)

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -171,6 +171,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	accessTokenBlacklist := backendauth.NewAccessTokenBlacklist(time.Minute)
 	authService := authservice.New(authRepository, employeesRepository, cfg, permissionCache, encrypter, accessTokenBlacklist)
 	patService := authservice.NewPATService(authRepository)
+	oauthService := authservice.NewOAuthService(authRepository, authService)
 
 	projectsRepository := operationalrepo.NewProjectsRepository(pool)
 	kanbanRepository := operationalrepo.NewKanbanRepository(pool)
@@ -244,6 +245,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		auditService,
 		authService,
 		patService,
+		oauthService,
 		adminhandler.NewAuditLogsHandler(auditService),
 		operationalhandler.NewOverviewHandler(operationalOverviewService),
 		operationalhandler.NewProjectsHandler(projectsService, kanbanService, projectsRepository, authRepository),
@@ -302,6 +304,7 @@ func (a *App) buildRouter(
 	auditService *auditservice.Service,
 	authService *authservice.Service,
 	patService *authservice.PATService,
+	oauthService *authservice.OAuthService,
 	auditLogsHandler *adminhandler.AuditLogsHandler,
 	operationalOverviewHandler *operationalhandler.OverviewHandler,
 	projectsHandler *operationalhandler.ProjectsHandler,
@@ -329,6 +332,7 @@ func (a *App) buildRouter(
 	router := chi.NewRouter()
 	authHandler := authhandler.New(authService, a.cfg)
 	patHandler := authhandler.NewPATHandler(patService)
+	oauthHandler := authhandler.NewOAuthHandler(oauthService)
 
 	clientIPMiddleware, err := platformmiddleware.NewClientIPMiddleware(a.cfg.TrustedProxyCIDRs)
 	if err != nil {
@@ -383,6 +387,14 @@ func (a *App) buildRouter(
 	// All API routes require tenant resolution from the Host header.
 	router.Group(func(tenanted chi.Router) {
 		tenanted.Use(platformmiddleware.TenantMiddleware(a.db, a.tenantResolver))
+
+		// OAuth 2.1 authorization server for MCP remote connectors (public).
+		tenanted.Get("/.well-known/oauth-authorization-server", oauthHandler.AuthorizationServerMetadata)
+		tenanted.Get("/.well-known/oauth-protected-resource", oauthHandler.ProtectedResourceMetadata)
+		tenanted.Post("/oauth/register", oauthHandler.Register)
+		tenanted.Get("/oauth/authorize", oauthHandler.Authorize)
+		tenanted.Post("/oauth/token", oauthHandler.Token)
+
 		tenanted.Route("/api/v1", func(r chi.Router) {
 			r.Route("/auth", authHandler.RegisterRoutes)
 			r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -408,6 +420,7 @@ func (a *App) buildRouter(
 				protected.Post("/auth/profile/avatar", authHandler.UploadProfileAvatar)
 				protected.Post("/auth/change-password", authHandler.ChangePassword)
 				protected.Route("/auth/pat", patHandler.RegisterRoutes)
+				protected.Post("/oauth/grant", oauthHandler.Grant)
 				protected.Get("/files/{type}/{id}/{filename}", filesHandler.Serve)
 				protected.With(platformmiddleware.RequireAnyPermission(
 					"admin:roles:view",
@@ -515,6 +528,13 @@ func (a *App) buildRouter(
 		return nil, fmt.Errorf("build mcp catalog: %w", err)
 	}
 	mcpServer := mcp.NewServer(mcpTools, mcp.InProcessExecutor{Handler: func() http.Handler { return a.router }}, "", mcpServerVersion)
+	mcpServer.SetAuthorizer(func(token string) bool {
+		if backendauth.IsPersonalAccessToken(token) {
+			return true
+		}
+		_, err := authService.ParseAccessToken(token)
+		return err == nil
+	})
 	router.Handle("/mcp", mcpServer.HTTPHandler())
 
 	return router, nil

--- a/backend/internal/handler/auth/oauth.go
+++ b/backend/internal/handler/auth/oauth.go
@@ -1,0 +1,198 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/kana-consultant/kantor/backend/internal/dto"
+	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
+	"github.com/kana-consultant/kantor/backend/internal/response"
+	authservice "github.com/kana-consultant/kantor/backend/internal/service/auth"
+)
+
+type OAuthHandler struct {
+	service *authservice.OAuthService
+}
+
+func NewOAuthHandler(service *authservice.OAuthService) *OAuthHandler {
+	return &OAuthHandler{service: service}
+}
+
+func (h *OAuthHandler) AuthorizationServerMetadata(w http.ResponseWriter, r *http.Request) {
+	base := requestPublicBaseURL(r, false)
+	writeRawJSON(w, http.StatusOK, map[string]interface{}{
+		"issuer":                                base,
+		"authorization_endpoint":                base + "/oauth/authorize",
+		"token_endpoint":                        base + "/oauth/token",
+		"registration_endpoint":                 base + "/oauth/register",
+		"response_types_supported":              []string{"code"},
+		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
+		"code_challenge_methods_supported":      []string{"S256"},
+		"token_endpoint_auth_methods_supported": []string{"none"},
+		"scopes_supported":                      []string{"mcp"},
+	})
+}
+
+func (h *OAuthHandler) ProtectedResourceMetadata(w http.ResponseWriter, r *http.Request) {
+	base := requestPublicBaseURL(r, false)
+	writeRawJSON(w, http.StatusOK, map[string]interface{}{
+		"resource":              base + "/mcp",
+		"authorization_servers": []string{base},
+	})
+}
+
+func (h *OAuthHandler) Register(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClientName   string   `json:"client_name"`
+		RedirectURIs []string `json:"redirect_uris"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "invalid request body")
+		return
+	}
+
+	result, err := h.service.RegisterClient(r.Context(), req.ClientName, req.RedirectURIs)
+	if err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", err.Error())
+		return
+	}
+
+	writeRawJSON(w, http.StatusCreated, map[string]interface{}{
+		"client_id":                  result.ClientID,
+		"client_name":                result.ClientName,
+		"redirect_uris":              result.RedirectURIs,
+		"token_endpoint_auth_method": "none",
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+	})
+}
+
+func (h *OAuthHandler) Authorize(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	if query.Get("response_type") != "code" {
+		http.Error(w, "unsupported_response_type", http.StatusBadRequest)
+		return
+	}
+
+	clientID := query.Get("client_id")
+	redirectURI := query.Get("redirect_uri")
+	if err := h.service.ValidateAuthorize(r.Context(), clientID, redirectURI); err != nil {
+		http.Error(w, "invalid client_id or redirect_uri", http.StatusBadRequest)
+		return
+	}
+
+	consent := url.Values{}
+	consent.Set("client_id", clientID)
+	consent.Set("redirect_uri", redirectURI)
+	consent.Set("code_challenge", query.Get("code_challenge"))
+	consent.Set("code_challenge_method", query.Get("code_challenge_method"))
+	consent.Set("state", query.Get("state"))
+	consent.Set("scope", query.Get("scope"))
+	http.Redirect(w, r, requestPublicBaseURL(r, false)+"/oauth/consent?"+consent.Encode(), http.StatusFound)
+}
+
+func (h *OAuthHandler) Token(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "could not parse request")
+		return
+	}
+
+	switch r.PostFormValue("grant_type") {
+	case "authorization_code":
+		tokens, err := h.service.ExchangeCode(
+			r.Context(),
+			r.PostFormValue("code"),
+			r.PostFormValue("client_id"),
+			r.PostFormValue("redirect_uri"),
+			r.PostFormValue("code_verifier"),
+			r.UserAgent(),
+			clientIP(r),
+			time.Now(),
+		)
+		if err != nil {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "authorization code is invalid or expired")
+			return
+		}
+		writeTokenResponse(w, tokens)
+	case "refresh_token":
+		tokens, err := h.service.RefreshGrant(r.Context(), r.PostFormValue("refresh_token"), r.UserAgent(), clientIP(r))
+		if err != nil {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token is invalid or expired")
+			return
+		}
+		writeTokenResponse(w, tokens)
+	default:
+		writeOAuthError(w, http.StatusBadRequest, "unsupported_grant_type", "grant_type not supported")
+	}
+}
+
+func (h *OAuthHandler) Grant(w http.ResponseWriter, r *http.Request) {
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+		return
+	}
+
+	var req struct {
+		ClientID            string `json:"client_id"`
+		RedirectURI         string `json:"redirect_uri"`
+		CodeChallenge       string `json:"code_challenge"`
+		CodeChallengeMethod string `json:"code_challenge_method"`
+		Scope               string `json:"scope"`
+		State               string `json:"state"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Invalid request body", nil)
+		return
+	}
+
+	code, err := h.service.Grant(r.Context(), authservice.GrantParams{
+		UserID:              principal.UserID,
+		ClientID:            req.ClientID,
+		RedirectURI:         req.RedirectURI,
+		CodeChallenge:       req.CodeChallenge,
+		CodeChallengeMethod: req.CodeChallengeMethod,
+		Scope:               req.Scope,
+	}, time.Now())
+	if err != nil {
+		response.WriteError(w, http.StatusBadRequest, "OAUTH_INVALID_REQUEST", "Permintaan OAuth tidak valid", nil)
+		return
+	}
+
+	redirect, err := url.Parse(req.RedirectURI)
+	if err != nil {
+		response.WriteError(w, http.StatusBadRequest, "OAUTH_INVALID_REQUEST", "Redirect URI tidak valid", nil)
+		return
+	}
+	query := redirect.Query()
+	query.Set("code", code)
+	if req.State != "" {
+		query.Set("state", req.State)
+	}
+	redirect.RawQuery = query.Encode()
+
+	response.WriteJSON(w, http.StatusOK, map[string]string{"redirect_uri": redirect.String()}, nil)
+}
+
+func writeRawJSON(w http.ResponseWriter, status int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeOAuthError(w http.ResponseWriter, status int, code string, description string) {
+	writeRawJSON(w, status, map[string]string{"error": code, "error_description": description})
+}
+
+func writeTokenResponse(w http.ResponseWriter, tokens dto.TokenPair) {
+	writeRawJSON(w, http.StatusOK, map[string]interface{}{
+		"access_token":  tokens.AccessToken,
+		"token_type":    "Bearer",
+		"expires_in":    tokens.ExpiresIn,
+		"refresh_token": tokens.RefreshToken,
+		"scope":         "mcp",
+	})
+}

--- a/backend/internal/mcp/catalog.go
+++ b/backend/internal/mcp/catalog.go
@@ -30,10 +30,11 @@ var excludedSuffixes = []string{
 	"/health",
 }
 
-// excludedContains drops credential self-management endpoints: an AI client must
-// not mint or revoke its own access tokens.
+// excludedContains drops credential and OAuth self-management endpoints: an AI
+// client must not mint or revoke its own tokens or approve OAuth grants.
 var excludedContains = []string{
 	"/auth/pat",
+	"/oauth",
 }
 
 // BuildCatalog derives the MCP tool surface from the live chi route table, so it

--- a/backend/internal/mcp/http.go
+++ b/backend/internal/mcp/http.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"io"
 	"net/http"
+	"strings"
 )
 
 const maxRequestBytes = 1 << 20
@@ -16,6 +17,16 @@ func (s *Server) HTTPHandler() http.Handler {
 			w.Header().Set("Allow", http.MethodPost)
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
+		}
+
+		if s.authorize != nil {
+			token := bearerToken(r.Header.Get("Authorization"))
+			if token == "" || !s.authorize(token) {
+				resourceMetadata := requestBaseURL(r) + "/.well-known/oauth-protected-resource"
+				w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+resourceMetadata+`"`)
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
 		}
 
 		raw, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBytes))
@@ -34,4 +45,20 @@ func (s *Server) HTTPHandler() http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(encoded)
 	})
+}
+
+func bearerToken(header string) string {
+	parts := strings.SplitN(strings.TrimSpace(header), " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+func requestBaseURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+		scheme = "https"
+	}
+	return scheme + "://" + r.Host
 }

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -8,11 +8,19 @@ import (
 const serverName = "kantor-mcp"
 
 type Server struct {
-	tools    []ToolSpec
-	byName   map[string]ToolSpec
-	executor Executor
-	baseURL  string
-	version  string
+	tools     []ToolSpec
+	byName    map[string]ToolSpec
+	executor  Executor
+	baseURL   string
+	version   string
+	authorize func(token string) bool
+}
+
+// SetAuthorizer registers a bearer-token validator. When set, the HTTP
+// transport replies 401 + WWW-Authenticate (triggering OAuth discovery) for
+// requests without a valid token.
+func (s *Server) SetAuthorizer(fn func(token string) bool) {
+	s.authorize = fn
 }
 
 func NewServer(tools []ToolSpec, executor Executor, baseURL string, version string) *Server {

--- a/backend/internal/mcp/server_test.go
+++ b/backend/internal/mcp/server_test.go
@@ -27,6 +27,7 @@ func TestBuildCatalogFiltersAndNames(t *testing.T) {
 		api.Post("/auth/pat", handler)
 		api.Delete("/auth/pat/{tokenID}", handler)
 		api.Post("/auth/change-password", handler)
+		api.Post("/oauth/grant", handler)
 	})
 	router.Get("/healthz", handler)
 
@@ -55,6 +56,7 @@ func TestBuildCatalogFiltersAndNames(t *testing.T) {
 		"post_auth_pat",
 		"delete_auth_pat_tokenid",
 		"post_auth_change_password",
+		"post_oauth_grant",
 		"get_healthz",
 	}
 	for _, name := range wantAbsent {

--- a/backend/internal/oauth/codes.go
+++ b/backend/internal/oauth/codes.go
@@ -1,0 +1,92 @@
+package oauth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
+	"sync"
+	"time"
+)
+
+const codeTTL = 2 * time.Minute
+
+type AuthCode struct {
+	UserID              string
+	ClientID            string
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Scope               string
+	ExpiresAt           time.Time
+}
+
+type CodeStore struct {
+	mu    sync.Mutex
+	codes map[string]AuthCode
+}
+
+func NewCodeStore() *CodeStore {
+	return &CodeStore{codes: make(map[string]AuthCode)}
+}
+
+func newRandomToken(byteLen int) (string, error) {
+	buffer := make([]byte, byteLen)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+// Issue stores a single-use authorization code and returns its value.
+func (s *CodeStore) Issue(code AuthCode, now time.Time) (string, error) {
+	value, err := newRandomToken(32)
+	if err != nil {
+		return "", err
+	}
+	code.ExpiresAt = now.Add(codeTTL)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for key, existing := range s.codes {
+		if now.After(existing.ExpiresAt) {
+			delete(s.codes, key)
+		}
+	}
+	s.codes[value] = code
+	return value, nil
+}
+
+// Consume returns and deletes the code. ok is false when missing or expired.
+func (s *CodeStore) Consume(value string, now time.Time) (AuthCode, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	code, ok := s.codes[value]
+	if !ok {
+		return AuthCode{}, false
+	}
+	delete(s.codes, value)
+	if now.After(code.ExpiresAt) {
+		return AuthCode{}, false
+	}
+	return code, true
+}
+
+// VerifyPKCE checks an S256 code_verifier against the stored code_challenge.
+func VerifyPKCE(method string, challenge string, verifier string) bool {
+	if method != "S256" {
+		return false
+	}
+	sum := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(sum[:])
+	return subtle.ConstantTimeCompare([]byte(computed), []byte(challenge)) == 1
+}
+
+// NewClientID mints a public client identifier for dynamic client registration.
+func NewClientID() (string, error) {
+	value, err := newRandomToken(24)
+	if err != nil {
+		return "", err
+	}
+	return "kantor_mcp_" + value, nil
+}

--- a/backend/internal/repository/auth/oauth_clients.go
+++ b/backend/internal/repository/auth/oauth_clients.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+
+	repository "github.com/kana-consultant/kantor/backend/internal/repository"
+)
+
+var ErrOAuthClientNotFound = errors.New("oauth client not found")
+
+type OAuthClient struct {
+	ClientID     string
+	ClientName   string
+	RedirectURIs []string
+}
+
+func (r *Repository) CreateOAuthClient(ctx context.Context, clientID string, clientName string, redirectURIs []string) error {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	raw, err := json.Marshal(redirectURIs)
+	if err != nil {
+		return err
+	}
+
+	_, err = repository.DB(ctx, r.db).Exec(ctx, `
+		INSERT INTO oauth_clients (client_id, client_name, redirect_uris)
+		VALUES ($1, $2, $3)
+	`, clientID, clientName, string(raw))
+	return err
+}
+
+func (r *Repository) GetOAuthClient(ctx context.Context, clientID string) (OAuthClient, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var client OAuthClient
+	var raw string
+	err := repository.DB(ctx, r.db).QueryRow(ctx, `
+		SELECT client_id, client_name, redirect_uris
+		FROM oauth_clients
+		WHERE client_id = $1
+	`, clientID).Scan(&client.ClientID, &client.ClientName, &raw)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return OAuthClient{}, ErrOAuthClientNotFound
+		}
+		return OAuthClient{}, err
+	}
+
+	if err := json.Unmarshal([]byte(raw), &client.RedirectURIs); err != nil {
+		return OAuthClient{}, err
+	}
+	return client, nil
+}

--- a/backend/internal/service/auth/oauth.go
+++ b/backend/internal/service/auth/oauth.go
@@ -1,0 +1,132 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/kana-consultant/kantor/backend/internal/dto"
+	"github.com/kana-consultant/kantor/backend/internal/oauth"
+	authrepo "github.com/kana-consultant/kantor/backend/internal/repository/auth"
+)
+
+var (
+	ErrOAuthInvalidClient   = errors.New("invalid client")
+	ErrOAuthInvalidRedirect = errors.New("invalid redirect uri")
+	ErrOAuthInvalidRequest  = errors.New("invalid request")
+	ErrOAuthInvalidGrant    = errors.New("invalid grant")
+)
+
+type oauthClientRepository interface {
+	CreateOAuthClient(ctx context.Context, clientID string, clientName string, redirectURIs []string) error
+	GetOAuthClient(ctx context.Context, clientID string) (authrepo.OAuthClient, error)
+}
+
+type OAuthService struct {
+	repo  oauthClientRepository
+	codes *oauth.CodeStore
+	auth  *Service
+}
+
+func NewOAuthService(repo oauthClientRepository, auth *Service) *OAuthService {
+	return &OAuthService{repo: repo, codes: oauth.NewCodeStore(), auth: auth}
+}
+
+type RegisterClientResult struct {
+	ClientID     string
+	ClientName   string
+	RedirectURIs []string
+}
+
+func (s *OAuthService) RegisterClient(ctx context.Context, clientName string, redirectURIs []string) (RegisterClientResult, error) {
+	if len(redirectURIs) == 0 {
+		return RegisterClientResult{}, ErrOAuthInvalidRequest
+	}
+	for _, uri := range redirectURIs {
+		parsed, err := url.Parse(uri)
+		if err != nil || parsed.Scheme == "" {
+			return RegisterClientResult{}, ErrOAuthInvalidRedirect
+		}
+	}
+
+	name := strings.TrimSpace(clientName)
+	if name == "" {
+		name = "MCP Client"
+	}
+
+	clientID, err := oauth.NewClientID()
+	if err != nil {
+		return RegisterClientResult{}, err
+	}
+	if err := s.repo.CreateOAuthClient(ctx, clientID, name, redirectURIs); err != nil {
+		return RegisterClientResult{}, err
+	}
+	return RegisterClientResult{ClientID: clientID, ClientName: name, RedirectURIs: redirectURIs}, nil
+}
+
+func (s *OAuthService) ValidateAuthorize(ctx context.Context, clientID string, redirectURI string) error {
+	client, err := s.repo.GetOAuthClient(ctx, clientID)
+	if err != nil {
+		return ErrOAuthInvalidClient
+	}
+	if !slices.Contains(client.RedirectURIs, redirectURI) {
+		return ErrOAuthInvalidRedirect
+	}
+	return nil
+}
+
+type GrantParams struct {
+	UserID              string
+	ClientID            string
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Scope               string
+}
+
+func (s *OAuthService) Grant(ctx context.Context, params GrantParams, now time.Time) (string, error) {
+	if err := s.ValidateAuthorize(ctx, params.ClientID, params.RedirectURI); err != nil {
+		return "", err
+	}
+	if params.CodeChallengeMethod != "S256" || strings.TrimSpace(params.CodeChallenge) == "" {
+		return "", ErrOAuthInvalidRequest
+	}
+	return s.codes.Issue(oauth.AuthCode{
+		UserID:              params.UserID,
+		ClientID:            params.ClientID,
+		RedirectURI:         params.RedirectURI,
+		CodeChallenge:       params.CodeChallenge,
+		CodeChallengeMethod: params.CodeChallengeMethod,
+		Scope:               params.Scope,
+	}, now)
+}
+
+func (s *OAuthService) ExchangeCode(ctx context.Context, code string, clientID string, redirectURI string, codeVerifier string, userAgent string, ipAddress string, now time.Time) (dto.TokenPair, error) {
+	stored, ok := s.codes.Consume(code, now)
+	if !ok {
+		return dto.TokenPair{}, ErrOAuthInvalidGrant
+	}
+	if stored.ClientID != clientID || stored.RedirectURI != redirectURI {
+		return dto.TokenPair{}, ErrOAuthInvalidGrant
+	}
+	if !oauth.VerifyPKCE(stored.CodeChallengeMethod, stored.CodeChallenge, codeVerifier) {
+		return dto.TokenPair{}, ErrOAuthInvalidGrant
+	}
+
+	result, err := s.auth.IssueTokensForUser(ctx, stored.UserID, userAgent, ipAddress)
+	if err != nil {
+		return dto.TokenPair{}, err
+	}
+	return result.Tokens, nil
+}
+
+func (s *OAuthService) RefreshGrant(ctx context.Context, refreshToken string, userAgent string, ipAddress string) (dto.TokenPair, error) {
+	result, err := s.auth.Refresh(ctx, refreshToken, userAgent, ipAddress)
+	if err != nil {
+		return dto.TokenPair{}, err
+	}
+	return result.Tokens, nil
+}

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -522,6 +522,17 @@ func (s *Service) ParseAccessToken(token string) (*backendauth.AccessClaims, err
 	return s.tokenManager.ParseAccessToken(token)
 }
 
+// IssueTokensForUser mints a fresh access + refresh token pair for a user
+// without a password, reusing the standard login token issuance. Used by the
+// OAuth authorization-code exchange once the user has approved a client.
+func (s *Service) IssueTokensForUser(ctx context.Context, userID string, userAgent string, ipAddress string) (AuthResult, error) {
+	user, err := s.repo.GetUserByID(ctx, userID)
+	if err != nil {
+		return AuthResult{}, err
+	}
+	return s.issueAuthResult(ctx, user, "", userAgent, ipAddress)
+}
+
 func (s *Service) GetSession(ctx context.Context, userID string) (AuthResult, error) {
 	user, err := s.repo.GetUserByID(ctx, userID)
 	if err != nil {

--- a/backend/migrations/20260629030000_oauth_clients.down.sql
+++ b/backend/migrations/20260629030000_oauth_clients.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS oauth_clients;

--- a/backend/migrations/20260629030000_oauth_clients.up.sql
+++ b/backend/migrations/20260629030000_oauth_clients.up.sql
@@ -1,0 +1,26 @@
+CREATE TABLE oauth_clients (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL DEFAULT current_setting('app.current_tenant')::uuid REFERENCES tenants(id) ON DELETE CASCADE,
+    client_id TEXT NOT NULL,
+    client_name TEXT NOT NULL,
+    redirect_uris TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_oauth_clients_client_id ON oauth_clients(client_id);
+
+ALTER TABLE oauth_clients ENABLE ROW LEVEL SECURITY;
+ALTER TABLE oauth_clients FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON oauth_clients
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+ALTER TABLE oauth_clients
+    ADD CONSTRAINT uq_oauth_clients_tenant_client UNIQUE (tenant_id, client_id);
+
+DO $$ BEGIN
+    IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'kantor_app') THEN
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON oauth_clients TO kantor_app';
+    END IF;
+END $$;

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -36,6 +36,22 @@ Authorization: Bearer kantor_pat_…
 Each request is a single JSON-RPC message; the response is a single JSON-RPC reply.
 The `Host` header selects the tenant, so use the tenant's own domain.
 
+### Claude Desktop custom connector (OAuth)
+
+Claude Desktop's **Settings → Connectors → Add custom connector** speaks OAuth, not
+static tokens. The backend is an OAuth 2.1 authorization server for exactly this:
+
+1. Name it anything; set **Remote MCP server URL** to `https://app.yourtenant.com/mcp`.
+2. Leave **OAuth Client ID / Secret** blank — the server supports Dynamic Client
+   Registration, so Claude registers itself.
+3. Click **Add**. Claude hits `/mcp`, gets `401` + `WWW-Authenticate`, discovers the
+   authorization server, and opens a browser to the Kantor consent page.
+4. Log in with your Kantor account and click **Izinkan** (Allow). Tokens map to your
+   user, so every tool call is enforced by your RBAC.
+
+Flow: Authorization Code + PKCE (S256). Endpoints: `/.well-known/oauth-authorization-server`,
+`/.well-known/oauth-protected-resource`, `/oauth/register`, `/oauth/authorize`, `/oauth/token`.
+
 ## Transport B — Local stdio (`kantor-mcp`)
 
 For clients that speak stdio (e.g. Claude Desktop), run the bundled binary, which

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -19,6 +19,15 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
+  location /mcp {
+    proxy_pass http://backend:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -28,6 +28,32 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
+  # OAuth endpoints to the backend; the consent page stays on the SPA.
+  location = /oauth/consent {
+    try_files $uri /index.html;
+  }
+
+  location /oauth/ {
+    proxy_pass http://backend:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location = /.well-known/oauth-authorization-server {
+    proxy_pass http://backend:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
+  location = /.well-known/oauth-protected-resource {
+    proxy_pass http://backend:8080;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   location / {
     try_files $uri $uri/ /index.html;
   }

--- a/frontend/src/components/personal-access-tokens/token-manager-card.tsx
+++ b/frontend/src/components/personal-access-tokens/token-manager-card.tsx
@@ -151,7 +151,28 @@ export function TokenManagerCard() {
 
               <div className="space-y-2">
                 <p className="font-semibold text-text-primary">
-                  Cara pasang (config file)
+                  Cara A — Connectors (remote, paling gampang)
+                </p>
+                <ol className="list-decimal space-y-1 pl-5">
+                  <li>
+                    Claude Desktop → Settings → Connectors → Add custom
+                    connector.
+                  </li>
+                  <li>
+                    Remote MCP server URL ={" "}
+                    <code className="font-mono">{mcp.mcpUrl}</code> → Add.
+                  </li>
+                  <li>
+                    Browser kebuka → login KANTOR → klik{" "}
+                    <strong>Izinkan</strong>. OAuth Client ID/Secret biarkan
+                    kosong.
+                  </li>
+                </ol>
+              </div>
+
+              <div className="space-y-2">
+                <p className="font-semibold text-text-primary">
+                  Cara B — Config file (stdio, pakai PAT)
                 </p>
                 <ol className="list-decimal space-y-1 pl-5">
                   <li>Buat token di kartu ini, lalu salin.</li>
@@ -187,12 +208,11 @@ export function TokenManagerCard() {
                 <p>Restart Claude Desktop → tools KANTOR muncul.</p>
               </div>
 
-              <div className="rounded-md border border-warning/40 bg-warning-light p-3 text-text-primary">
+              <div className="rounded-md border border-border bg-surface-muted/40 p-3 text-text-primary">
                 <p className="font-semibold">OAuth Client ID / Secret?</p>
                 <p className="mt-1 text-text-secondary">
-                  Tidak ada. Auth server ini Personal Access Token, jadi menu
-                  "Connectors" (remote/OAuth) di Claude Desktop belum didukung —
-                  pakai cara config file di atas.
+                  Kosongkan saja — KANTOR pakai Dynamic Client Registration, jadi
+                  Claude mendaftar sendiri otomatis.
                 </p>
               </div>
             </div>

--- a/frontend/src/components/personal-access-tokens/token-manager-card.tsx
+++ b/frontend/src/components/personal-access-tokens/token-manager-card.tsx
@@ -1,10 +1,19 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Copy, KeyRound, Plus, Trash2 } from "lucide-react";
+import { Copy, Info, KeyRound, Plus, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { env } from "@/lib/env";
 import {
   createPersonalAccessToken,
   listPersonalAccessTokens,
@@ -12,6 +21,14 @@ import {
   revokePersonalAccessToken,
 } from "@/services/personal-access-tokens";
 import { toast } from "@/stores/toast-store";
+
+function resolveMcpConfig() {
+  const apiBase = env.VITE_API_BASE_URL;
+  const origin = apiBase.startsWith("/")
+    ? window.location.origin
+    : apiBase.replace(/\/api\/v1\/?$/, "");
+  return { mcpUrl: `${origin}/mcp`, baseUrl: origin, host: new URL(origin).host };
+}
 
 function formatTimestamp(value?: string | null) {
   if (!value) {
@@ -29,6 +46,8 @@ export function TokenManagerCard() {
   const [name, setName] = useState("");
   const [expiresInDays, setExpiresInDays] = useState("");
   const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [isInfoOpen, setIsInfoOpen] = useState(false);
+  const mcp = resolveMcpConfig();
 
   const tokensQuery = useQuery({
     queryKey: personalAccessTokenKeys.list(),
@@ -88,20 +107,98 @@ export function TokenManagerCard() {
 
   return (
     <Card className="space-y-5 p-6 xl:col-span-2">
-      <div className="flex items-start gap-3">
-        <div className="rounded-md bg-error-light p-3 text-error">
-          <KeyRound className="h-5 w-5" />
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <div className="rounded-md bg-error-light p-3 text-error">
+            <KeyRound className="h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="font-display text-[18px] font-[700] text-text-primary">
+              Access Token (MCP)
+            </h2>
+            <p className="mt-1 text-sm text-text-secondary">
+              Buat personal access token untuk binding KANTOR ke Claude / Hermes
+              via MCP. Token mewarisi permission akun Anda.
+            </p>
+          </div>
         </div>
-        <div>
-          <h2 className="font-display text-[18px] font-[700] text-text-primary">
-            Access Token (MCP)
-          </h2>
-          <p className="mt-1 text-sm text-text-secondary">
-            Buat personal access token untuk binding KANTOR ke Claude / Hermes
-            via MCP. Token mewarisi permission akun Anda.
-          </p>
-        </div>
+        <button
+          aria-label="Cara hubungkan ke Claude Desktop"
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border text-text-secondary transition hover:bg-surface-muted hover:text-text-primary"
+          onClick={() => setIsInfoOpen(true)}
+          type="button"
+        >
+          <Info className="h-4.5 w-4.5" />
+        </button>
       </div>
+
+      <Dialog onOpenChange={setIsInfoOpen} open={isInfoOpen}>
+        <DialogContent size="lg">
+          <DialogHeader>
+            <DialogTitle>Hubungkan ke Claude Desktop</DialogTitle>
+            <DialogDescription>
+              Server MCP ini memakai Personal Access Token (Bearer), bukan OAuth.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogBody>
+            <div className="space-y-4 text-sm text-text-secondary">
+              <div>
+                <p className="font-semibold text-text-primary">Endpoint MCP</p>
+                <code className="mt-1 block overflow-x-auto rounded-md bg-surface-muted px-3 py-2 font-mono text-[13px] text-text-primary">
+                  {mcp.mcpUrl}
+                </code>
+              </div>
+
+              <div className="space-y-2">
+                <p className="font-semibold text-text-primary">
+                  Cara pasang (config file)
+                </p>
+                <ol className="list-decimal space-y-1 pl-5">
+                  <li>Buat token di kartu ini, lalu salin.</li>
+                  <li>
+                    Build binary:{" "}
+                    <code className="font-mono">
+                      go build -o kantor-mcp ./backend/cmd/mcp
+                    </code>
+                  </li>
+                  <li>Claude Desktop → Settings → Developer → Edit Config.</li>
+                  <li>
+                    Tempel ke{" "}
+                    <code className="font-mono">
+                      claude_desktop_config.json
+                    </code>
+                    :
+                  </li>
+                </ol>
+                <pre className="overflow-x-auto rounded-md bg-surface-muted px-3 py-3 font-mono text-[12px] leading-relaxed text-text-primary">
+                  {`{
+  "mcpServers": {
+    "kantor": {
+      "command": "/path/ke/kantor-mcp",
+      "env": {
+        "KANTOR_BASE_URL": "${mcp.baseUrl}",
+        "KANTOR_PAT": "kantor_pat_...",
+        "KANTOR_TENANT_HOST": "${mcp.host}"
+      }
+    }
+  }
+}`}
+                </pre>
+                <p>Restart Claude Desktop → tools KANTOR muncul.</p>
+              </div>
+
+              <div className="rounded-md border border-warning/40 bg-warning-light p-3 text-text-primary">
+                <p className="font-semibold">OAuth Client ID / Secret?</p>
+                <p className="mt-1 text-text-secondary">
+                  Tidak ada. Auth server ini Personal Access Token, jadi menu
+                  "Connectors" (remote/OAuth) di Claude Desktop belum didukung —
+                  pakai cara config file di atas.
+                </p>
+              </div>
+            </div>
+          </DialogBody>
+        </DialogContent>
+      </Dialog>
 
       {createdToken ? (
         <div className="space-y-2 rounded-md border border-warning/40 bg-warning-light p-4">

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as OauthConsentRouteImport } from './routes/oauth/consent'
 import { Route as AuthenticatedProfileRouteImport } from './routes/_authenticated/profile'
 import { Route as AuthenticatedForbiddenRouteImport } from './routes/_authenticated/forbidden'
 import { Route as AuthenticatedOperationalIndexRouteImport } from './routes/_authenticated/operational/index'
@@ -75,6 +76,11 @@ const AuthenticatedRoute = AuthenticatedRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OauthConsentRoute = OauthConsentRouteImport.update({
+  id: '/oauth/consent',
+  path: '/oauth/consent',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedProfileRoute = AuthenticatedProfileRouteImport.update({
@@ -273,6 +279,7 @@ export interface FileRoutesByFullPath {
   '/reset-password': typeof ResetPasswordRoute
   '/forbidden': typeof AuthenticatedForbiddenRoute
   '/profile': typeof AuthenticatedProfileRoute
+  '/oauth/consent': typeof OauthConsentRoute
   '/admin/audit-logs': typeof AuthenticatedAdminAuditLogsRoute
   '/admin/registration': typeof AuthenticatedAdminRegistrationRoute
   '/admin/roles': typeof AuthenticatedAdminRolesRoute
@@ -312,6 +319,7 @@ export interface FileRoutesByTo {
   '/reset-password': typeof ResetPasswordRoute
   '/forbidden': typeof AuthenticatedForbiddenRoute
   '/profile': typeof AuthenticatedProfileRoute
+  '/oauth/consent': typeof OauthConsentRoute
   '/admin/audit-logs': typeof AuthenticatedAdminAuditLogsRoute
   '/admin/registration': typeof AuthenticatedAdminRegistrationRoute
   '/admin/roles': typeof AuthenticatedAdminRolesRoute
@@ -353,6 +361,7 @@ export interface FileRoutesById {
   '/reset-password': typeof ResetPasswordRoute
   '/_authenticated/forbidden': typeof AuthenticatedForbiddenRoute
   '/_authenticated/profile': typeof AuthenticatedProfileRoute
+  '/oauth/consent': typeof OauthConsentRoute
   '/_authenticated/admin/audit-logs': typeof AuthenticatedAdminAuditLogsRoute
   '/_authenticated/admin/registration': typeof AuthenticatedAdminRegistrationRoute
   '/_authenticated/admin/roles': typeof AuthenticatedAdminRolesRoute
@@ -394,6 +403,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/forbidden'
     | '/profile'
+    | '/oauth/consent'
     | '/admin/audit-logs'
     | '/admin/registration'
     | '/admin/roles'
@@ -433,6 +443,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/forbidden'
     | '/profile'
+    | '/oauth/consent'
     | '/admin/audit-logs'
     | '/admin/registration'
     | '/admin/roles'
@@ -473,6 +484,7 @@ export interface FileRouteTypes {
     | '/reset-password'
     | '/_authenticated/forbidden'
     | '/_authenticated/profile'
+    | '/oauth/consent'
     | '/_authenticated/admin/audit-logs'
     | '/_authenticated/admin/registration'
     | '/_authenticated/admin/roles'
@@ -512,6 +524,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   RegisterRoute: typeof RegisterRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
+  OauthConsentRoute: typeof OauthConsentRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -556,6 +569,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/oauth/consent': {
+      id: '/oauth/consent'
+      path: '/oauth/consent'
+      fullPath: '/oauth/consent'
+      preLoaderRoute: typeof OauthConsentRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated/profile': {
@@ -874,6 +894,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   RegisterRoute: RegisterRoute,
   ResetPasswordRoute: ResetPasswordRoute,
+  OauthConsentRoute: OauthConsentRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -20,6 +20,12 @@ const loginSchema = z.object({
 type LoginFormValues = z.infer<typeof loginSchema>;
 
 export const Route = createFileRoute("/login")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    redirect:
+      typeof search.redirect === "string" && search.redirect.startsWith("/")
+        ? search.redirect
+        : undefined,
+  }),
   beforeLoad: async () => {
     const session = getValidStoredSession();
     if (session?.tokens.access_token) {
@@ -32,6 +38,7 @@ export const Route = createFileRoute("/login")({
 });
 
 function LoginPage() {
+  const search = Route.useSearch();
   const setSession = useAuthStore((state) => state.setSession);
   const authPublicOptionsQuery = useQuery({
     queryKey: ["auth", "public-options"],
@@ -55,7 +62,9 @@ function LoginPage() {
     mutationFn: login,
     onSuccess: (session) => {
       setSession(session);
-      window.location.replace(getDefaultAuthorizedPath(session));
+      window.location.replace(
+        search.redirect ?? getDefaultAuthorizedPath(session),
+      );
     },
   });
 

--- a/frontend/src/routes/oauth/consent.tsx
+++ b/frontend/src/routes/oauth/consent.tsx
@@ -1,0 +1,123 @@
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { ensureAuthenticated } from "@/services/auth";
+import { approveOAuthGrant } from "@/services/oauth";
+import { useAuthStore } from "@/stores/auth-store";
+
+type ConsentSearch = {
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  state: string;
+  scope: string;
+};
+
+export const Route = createFileRoute("/oauth/consent")({
+  validateSearch: (search: Record<string, unknown>): ConsentSearch => ({
+    client_id: String(search.client_id ?? ""),
+    redirect_uri: String(search.redirect_uri ?? ""),
+    code_challenge: String(search.code_challenge ?? ""),
+    code_challenge_method: String(search.code_challenge_method ?? "S256"),
+    state: String(search.state ?? ""),
+    scope: String(search.scope ?? ""),
+  }),
+  beforeLoad: async () => {
+    const session = await ensureAuthenticated();
+    if (!session) {
+      throw redirect({
+        to: "/login",
+        search: { redirect: window.location.pathname + window.location.search },
+      });
+    }
+  },
+  component: ConsentPage,
+});
+
+function ConsentPage() {
+  const search = Route.useSearch();
+  const session = useAuthStore((state) => state.session);
+
+  const approveMutation = useMutation({
+    mutationFn: approveOAuthGrant,
+    onSuccess: (result) => {
+      window.location.href = result.redirect_uri;
+    },
+  });
+
+  const onApprove = () => {
+    approveMutation.mutate({
+      client_id: search.client_id,
+      redirect_uri: search.redirect_uri,
+      code_challenge: search.code_challenge,
+      code_challenge_method: search.code_challenge_method,
+      scope: search.scope || undefined,
+      state: search.state || undefined,
+    });
+  };
+
+  const onDeny = () => {
+    const url = new URL(search.redirect_uri);
+    url.searchParams.set("error", "access_denied");
+    if (search.state) {
+      url.searchParams.set("state", search.state);
+    }
+    window.location.href = url.toString();
+  };
+
+  const incomplete =
+    !search.client_id || !search.redirect_uri || !search.code_challenge;
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-surface-muted p-4">
+      <Card className="w-full max-w-md space-y-6 p-8">
+        <div className="flex items-start gap-3">
+          <div className="rounded-md bg-error-light p-3 text-error">
+            <ShieldCheck className="h-6 w-6" />
+          </div>
+          <div>
+            <h1 className="font-display text-[22px] font-[700] text-text-primary">
+              Izinkan akses MCP?
+            </h1>
+            <p className="mt-1 text-sm leading-6 text-text-secondary">
+              Aplikasi meminta akses ke KANTOR sebagai{" "}
+              <strong className="text-text-primary">
+                {session?.user.email}
+              </strong>{" "}
+              lewat MCP. Token mewarisi permission akun Anda.
+            </p>
+          </div>
+        </div>
+
+        {approveMutation.isError ? (
+          <p className="text-sm text-error">
+            Gagal memproses persetujuan. Coba lagi.
+          </p>
+        ) : null}
+
+        {incomplete ? (
+          <p className="text-sm text-error">
+            Permintaan OAuth tidak lengkap atau tidak valid.
+          </p>
+        ) : (
+          <div className="flex justify-end gap-3">
+            <Button onClick={onDeny} type="button" variant="outline">
+              Tolak
+            </Button>
+            <Button
+              disabled={approveMutation.isPending}
+              onClick={onApprove}
+              type="button"
+            >
+              Izinkan
+            </Button>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/services/oauth.ts
+++ b/frontend/src/services/oauth.ts
@@ -1,0 +1,20 @@
+import { authRequestJSON } from "@/lib/api-client";
+
+export type OAuthGrantPayload = {
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  code_challenge_method: string;
+  scope?: string;
+  state?: string;
+};
+
+export function approveOAuthGrant(
+  payload: OAuthGrantPayload,
+): Promise<{ redirect_uri: string }> {
+  return authRequestJSON<{ redirect_uri: string }>("/oauth/grant", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+}

--- a/module.nix
+++ b/module.nix
@@ -241,6 +241,40 @@ in
           '';
         };
 
+        # OAuth authorization-server endpoints live on the backend; the consent
+        # page is served by the SPA. /.well-known is matched exactly so the ACME
+        # challenge path is left untouched.
+        locations."/oauth/" = {
+          proxyPass = "http://127.0.0.1:${toString cfg.port}";
+          extraConfig = ''
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          '';
+        };
+
+        locations."= /oauth/consent" = {
+          tryFiles = "$uri /index.html";
+        };
+
+        locations."= /.well-known/oauth-authorization-server" = {
+          proxyPass = "http://127.0.0.1:${toString cfg.port}";
+          extraConfig = ''
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          '';
+        };
+
+        locations."= /.well-known/oauth-protected-resource" = {
+          proxyPass = "http://127.0.0.1:${toString cfg.port}";
+          extraConfig = ''
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          '';
+        };
+
         locations."/assets/" = {
           root = "${frontend}";
           extraConfig = ''

--- a/module.nix
+++ b/module.nix
@@ -232,6 +232,15 @@ in
           '';
         };
 
+        locations."/mcp" = {
+          proxyPass = "http://127.0.0.1:${toString cfg.port}";
+          extraConfig = ''
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+          '';
+        };
+
         locations."/assets/" = {
           root = "${frontend}";
           extraConfig = ''


### PR DESCRIPTION
> **Note:** retargeted to `main`. Besides the OAuth work, this PR also lands two commits that trailed #124's squash and never reached `main`: the nginx **`/mcp` proxy** (required for the remote connector to reach the backend) and the **access-token card setup guide**. All five commits are absent from `main`.

## Summary

Makes the MCP server usable from **Claude Desktop's "Add custom connector"** (remote URL) by implementing the **MCP Authorization spec (OAuth 2.1)**. Kantor is the authorization server itself — users log in with their Kantor account, and tokens carry their RBAC.

Stacked on #124 (MCP server). Base is `feat/mcp-compensation-policy`.

## Flow
1. Connector URL = `https://<host>/mcp`, OAuth Client ID/Secret left blank.
2. `/mcp` replies `401 + WWW-Authenticate` → Claude discovers the authorization server.
3. **Dynamic Client Registration** (`/oauth/register`) — Claude registers itself, no manual client id/secret.
4. `/oauth/authorize` redirects to the SPA consent page → user logs in + clicks **Allow**.
5. `/oauth/token` exchanges the code (**Authorization Code + PKCE S256**) for an access + refresh token.
6. Tool calls use the access token; RBAC is enforced per user.

## Backend
- `internal/oauth` (in-memory PKCE code store), `oauth_clients` table (migration, RLS), `OAuthService`, handler (metadata / register / authorize / token / authenticated grant).
- Access tokens reuse the existing JWT + refresh issuance (`IssueTokensForUser`), so they validate through the normal auth middleware and map to the user.
- `/mcp` 401 discovery; PAT access still works; the OAuth grant route is excluded from the MCP tool surface.
- **No new Go modules** — `vendor/`/`vendorHash` unaffected.

## Frontend
- `/oauth/consent` route (login-gated, returns after login), `services/oauth.ts`, and an updated access-token card guide.

## Deploy
- nginx (NixOS module + Docker) proxies `/oauth/*` and the two `/.well-known/oauth-*` paths to the backend; `/.well-known` is matched exactly so ACME is untouched; the consent page stays on the SPA.

## Verification (live, curl)
- `/mcp` no-token → `401` + `WWW-Authenticate` ✓
- DCR → `token_endpoint_auth_method: none` ✓
- grant → code (+state) → token (PKCE-verified access JWT + refresh) ✓
- OAuth token → `/mcp` `tools/call` → real data, RBAC enforced ✓
- replay code → `invalid_grant` ✓
- `tools/list` excludes the OAuth grant route ✓
- `go build/vet/test ./...` green, gofmt clean; frontend `eslint` + `build` green.

