### PR TITLE
fix: tracker time integrity, scoped extension PAT, MCP query enrichment

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -565,6 +565,31 @@ func (a *App) startBackgroundJobs(authService *authservice.Service, subscription
 		}()
 	}
 
+	// runPerTenantTicker runs fn for every tenant on an interval (optionally once
+	// immediately at startup), passing the tick time as the job's "now".
+	runPerTenantTicker := func(name string, interval time.Duration, runImmediately bool, fn func(ctx context.Context, t tenant.Info, now time.Time) error) {
+		runBackground(name, func() {
+			tick := func(now time.Time) {
+				runPerTenant(name, func(tCtx context.Context, t tenant.Info) error {
+					return fn(tCtx, t, now)
+				})
+			}
+			if runImmediately {
+				tick(time.Now())
+			}
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case tickAt := <-ticker.C:
+					tick(tickAt)
+				}
+			}
+		})
+	}
+
 	runBackground("background_scheduler", func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -647,138 +672,39 @@ func (a *App) startBackgroundJobs(authService *authservice.Service, subscription
 		}
 	})
 
-	runBackground("domain_monitor_scheduler", func() {
-		// Tick every 5 min — DNS check interval is configurable per-domain
-		// (default 1 hour). 5 min is fine since ListDueDNSChecks filters.
-		ticker := time.NewTicker(5 * time.Minute)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case tickAt := <-ticker.C:
-				runPerTenant("domain_dns_run_due", func(tCtx context.Context, t tenant.Info) error {
-					return domainMonitorService.RunDueDNSChecks(tCtx, tickAt)
-				})
-			}
-		}
+	// DNS check interval is per-domain (default 1h); 5 min tick is fine because
+	// RunDueDNSChecks filters by what's due.
+	runPerTenantTicker("domain_dns_run_due", 5*time.Minute, false, func(tCtx context.Context, t tenant.Info, now time.Time) error {
+		return domainMonitorService.RunDueDNSChecks(tCtx, now)
 	})
 
-	runBackground("vps_monitor_scheduler", func() {
-		// Tick every 30s — finer than that wastes CPU since the smallest
-		// configurable check interval is 30s. ListDueChecks filters by
-		// last_check_at + interval so this loop is cheap when no checks
-		// are due.
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case tickAt := <-ticker.C:
-				runPerTenant("vps_monitor_run_due", func(tCtx context.Context, t tenant.Info) error {
-					return vpsMonitorService.RunDueChecks(tCtx, tickAt)
-				})
-			}
-		}
+	// 30s tick — the smallest configurable VPS check interval; RunDueChecks
+	// filters so the loop is cheap when nothing is due.
+	runPerTenantTicker("vps_monitor_run_due", 30*time.Second, false, func(tCtx context.Context, t tenant.Info, now time.Time) error {
+		return vpsMonitorService.RunDueChecks(tCtx, now)
 	})
 
-	runBackground("wa_scheduler", func() {
-		runPerTenant("wa_scheduler", func(tCtx context.Context, t tenant.Info) error {
-			return whatsappService.RunCronJobs(tCtx, time.Now())
-		})
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case tickAt := <-ticker.C:
-				runPerTenant("wa_scheduler", func(tCtx context.Context, t tenant.Info) error {
-					return whatsappService.RunCronJobs(tCtx, tickAt)
-				})
-			}
-		}
+	runPerTenantTicker("wa_scheduler", time.Minute, true, func(tCtx context.Context, t tenant.Info, now time.Time) error {
+		return whatsappService.RunCronJobs(tCtx, now)
 	})
 
-	runBackground("email_scheduler", func() {
-		runPerTenant("email_scheduler", func(tCtx context.Context, t tenant.Info) error {
-			return emailDeliveryService.RunCronJobs(tCtx, time.Now())
-		})
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case tickAt := <-ticker.C:
-				runPerTenant("email_scheduler", func(tCtx context.Context, t tenant.Info) error {
-					return emailDeliveryService.RunCronJobs(tCtx, tickAt)
-				})
-			}
-		}
+	runPerTenantTicker("email_scheduler", time.Minute, true, func(tCtx context.Context, t tenant.Info, now time.Time) error {
+		return emailDeliveryService.RunCronJobs(tCtx, now)
 	})
 
-	runBackground("reimbursement_reminder_scheduler", func() {
-		runPerTenant("reimbursement_reminder_scheduler", func(tCtx context.Context, t tenant.Info) error {
-			return reimbursementsService.RunReminderJobs(tCtx, time.Now())
-		})
-
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case tickAt := <-ticker.C:
-				runPerTenant("reimbursement_reminder_scheduler", func(tCtx context.Context, t tenant.Info) error {
-					return reimbursementsService.RunReminderJobs(tCtx, tickAt)
-				})
-			}
-		}
+	runPerTenantTicker("reimbursement_reminder_scheduler", time.Minute, true, func(tCtx context.Context, t tenant.Info, now time.Time) error {
+		return reimbursementsService.RunReminderJobs(tCtx, now)
 	})
 
-	runBackground("tracker_reminder_scheduler", func() {
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case tickAt := <-ticker.C:
-				runPerTenant("tracker_reminder_scheduler", func(tCtx context.Context, t tenant.Info) error {
-					return trackerReminderService.RunReminderJobs(tCtx, tickAt)
-				})
-			}
-		}
+	runPerTenantTicker("tracker_reminder_scheduler", time.Minute, false, func(tCtx context.Context, t tenant.Info, now time.Time) error {
+		return trackerReminderService.RunReminderJobs(tCtx, now)
 	})
 
-	runBackground("tracker_stale_session_sweeper", func() {
-		// Close sessions orphaned by crashed/disconnected extensions so a later
-		// heartbeat or StartSession cannot resurrect a stale session and
-		// back-fill the offline gap as active time.
-		ticker := time.NewTicker(5 * time.Minute)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case tickAt := <-ticker.C:
-				runPerTenant("tracker_stale_sessions", func(tCtx context.Context, t tenant.Info) error {
-					_, err := trackerService.EndStaleSessions(tCtx, tickAt)
-					return err
-				})
-			}
-		}
+	// Close sessions orphaned by crashed/disconnected extensions so a later
+	// heartbeat cannot resurrect a stale session and back-fill the offline gap.
+	runPerTenantTicker("tracker_stale_sessions", 5*time.Minute, false, func(tCtx context.Context, t tenant.Info, now time.Time) error {
+		_, err := trackerService.EndStaleSessions(tCtx, now)
+		return err
 	})
 }
 

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -760,6 +760,26 @@ func (a *App) startBackgroundJobs(authService *authservice.Service, subscription
 			}
 		}
 	})
+
+	runBackground("tracker_stale_session_sweeper", func() {
+		// Close sessions orphaned by crashed/disconnected extensions so a later
+		// heartbeat or StartSession cannot resurrect a stale session and
+		// back-fill the offline gap as active time.
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case tickAt := <-ticker.C:
+				runPerTenant("tracker_stale_sessions", func(tCtx context.Context, t tenant.Info) error {
+					_, err := trackerService.EndStaleSessions(tCtx, tickAt)
+					return err
+				})
+			}
+		}
+	})
 }
 
 func runMigrations(databaseURL string) error {

--- a/backend/internal/dto/operational/tracker.go
+++ b/backend/internal/dto/operational/tracker.go
@@ -22,7 +22,7 @@ type TrackerHeartbeatRequest struct {
 }
 
 type TrackerBatchEntriesRequest struct {
-	Entries []TrackerHeartbeatRequest `json:"entries" validate:"required,min=1,dive"`
+	Entries []TrackerHeartbeatRequest `json:"entries" validate:"required,min=1,max=500,dive"`
 }
 
 type TrackerConsentRequest struct{}
@@ -32,7 +32,7 @@ type TrackerEndSessionRequest struct {
 }
 
 type DomainCategoryRequest struct {
-	DomainPattern string `json:"domain_pattern" validate:"required,max=255"`
+	DomainPattern string `json:"domain_pattern" validate:"required,max=255,excludesall=%_"`
 	Category      string `json:"category" validate:"required,oneof=work communication social_media entertainment development design documentation other uncategorized"`
 	IsProductive  bool   `json:"is_productive"`
 }

--- a/backend/internal/dto/personal_access_token.go
+++ b/backend/internal/dto/personal_access_token.go
@@ -1,14 +1,16 @@
 package dto
 
 type CreatePersonalAccessTokenRequest struct {
-	Name          string `json:"name" validate:"required,min=1,max=120"`
-	ExpiresInDays *int   `json:"expires_in_days,omitempty" validate:"omitempty,min=1,max=365"`
+	Name          string  `json:"name" validate:"required,min=1,max=120"`
+	ExpiresInDays *int    `json:"expires_in_days,omitempty" validate:"omitempty,min=1,max=365"`
+	Scope         *string `json:"scope,omitempty" validate:"omitempty,oneof=tracker"`
 }
 
 type PersonalAccessTokenResponse struct {
 	ID          string  `json:"id"`
 	Name        string  `json:"name"`
 	TokenPrefix string  `json:"token_prefix"`
+	Scope       *string `json:"scope,omitempty"`
 	LastUsedAt  *string `json:"last_used_at,omitempty"`
 	ExpiresAt   *string `json:"expires_at,omitempty"`
 	CreatedAt   string  `json:"created_at"`

--- a/backend/internal/handler/auth/personal_access_token.go
+++ b/backend/internal/handler/auth/personal_access_token.go
@@ -47,7 +47,7 @@ func (h *PATHandler) create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, item, err := h.service.Issue(r.Context(), principal.UserID, req.Name, req.ExpiresInDays, time.Now())
+	token, item, err := h.service.Issue(r.Context(), principal.UserID, req.Name, req.ExpiresInDays, req.Scope, time.Now())
 	if err != nil {
 		platformmiddleware.LoggerFromContext(r.Context()).Error("create personal access token failed", "error", err, "user_id", principal.UserID)
 		response.WriteInternalError(r.Context(), w, err, "Failed to create access token")
@@ -107,6 +107,7 @@ func toPATResponse(item model.PersonalAccessToken) dto.PersonalAccessTokenRespon
 		ID:          item.ID,
 		Name:        item.Name,
 		TokenPrefix: item.TokenPrefix,
+		Scope:       item.Scope,
 		CreatedAt:   item.CreatedAt.Format(time.RFC3339),
 	}
 	if item.LastUsedAt != nil {

--- a/backend/internal/handler/operational/tracker.go
+++ b/backend/internal/handler/operational/tracker.go
@@ -165,7 +165,7 @@ func (h *TrackerHandler) heartbeat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entry, session, err := h.service.RecordHeartbeat(r.Context(), principal.UserID, request)
+	entry, session, err := h.service.RecordHeartbeat(r.Context(), principal.UserID, request, time.Now())
 	if err != nil {
 		h.writeError(r.Context(), w, err)
 		return
@@ -189,7 +189,7 @@ func (h *TrackerHandler) batchEntries(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.service.RecordBatch(r.Context(), principal.UserID, request)
+	result, err := h.service.RecordBatch(r.Context(), principal.UserID, request, time.Now())
 	if err != nil {
 		h.writeError(r.Context(), w, err)
 		return
@@ -411,4 +411,3 @@ func parseDateRange(w http.ResponseWriter, r *http.Request) (time.Time, time.Tim
 	}
 	return dateFrom, dateTo, true
 }
-

--- a/backend/internal/mcp/annotations.go
+++ b/backend/internal/mcp/annotations.go
@@ -1,12 +1,7 @@
 package mcp
 
-// endpointAnnotations curates query/pagination metadata for the data-heavy
-// list & query endpoints. The tool surface is still derived 1:1 from the live
-// route table (catalog.go); this only ENRICHES matching routes so AI clients can
-// discover the real filters and page through all results. Routes without an
-// entry fall back to the generic opaque-query schema. Keyed by "METHOD path".
-//
-// When you add/rename a list endpoint or its filters, add/update the entry here.
+// endpointAnnotations enriches data-heavy list/query routes with their real
+// filters + pagination. Keyed by "METHOD path"; unlisted routes stay generic.
 var endpointAnnotations = map[string]EndpointMeta{
 	// ---- HRIS ----
 	"GET /api/v1/hris/employees": {

--- a/backend/internal/mcp/annotations.go
+++ b/backend/internal/mcp/annotations.go
@@ -1,0 +1,246 @@
+package mcp
+
+// endpointAnnotations curates query/pagination metadata for the data-heavy
+// list & query endpoints. The tool surface is still derived 1:1 from the live
+// route table (catalog.go); this only ENRICHES matching routes so AI clients can
+// discover the real filters and page through all results. Routes without an
+// entry fall back to the generic opaque-query schema. Keyed by "METHOD path".
+//
+// When you add/rename a list endpoint or its filters, add/update the entry here.
+var endpointAnnotations = map[string]EndpointMeta{
+	// ---- HRIS ----
+	"GET /api/v1/hris/employees": {
+		Description: "List employees with search and filters",
+		Paginated:   true, PerPageDefault: 10, PerPageMax: 100,
+		Query: []QueryParam{
+			qs("search", "Free-text search over name/email."),
+			qs("department", "Filter by department name."),
+			qe("status", "Employment status filter.", "active", "probation", "resigned", "terminated"),
+		},
+	},
+	"GET /api/v1/hris/salary-safety": {
+		Description: "Salary-safety (min-hours compliance) per employee for a period",
+		Query: []QueryParam{
+			qi("year", "Period year (default current year)."),
+			qi("month", "Period month 1-12 (default current month)."),
+			qs("employee_id", "Restrict to a single employee (UUID)."),
+		},
+	},
+	"GET /api/v1/hris/finance/records": {
+		Description: "List finance records with filters",
+		Paginated:   true, PerPageDefault: 20, PerPageMax: 100,
+		Query: []QueryParam{
+			qs("type", "Record type filter (e.g. income/expense)."),
+			qs("category", "Category filter."),
+			qs("status", "Status filter."),
+			qi("month", "Month 1-12."),
+			qi("year", "Year."),
+		},
+	},
+	"GET /api/v1/hris/finance/categories": {
+		Description: "List finance categories",
+		Query:       []QueryParam{qs("type", "Filter by category type.")},
+	},
+	"GET /api/v1/hris/finance/summary": {
+		Description: "Finance summary totals for a year",
+		Query:       []QueryParam{qi("year", "Year (default current year).")},
+	},
+	"GET /api/v1/hris/reimbursements": {
+		Description: "List reimbursements with filters and sorting",
+		Paginated:   true, PerPageDefault: 20, PerPageMax: 100,
+		Query: []QueryParam{
+			qs("status", "Status filter."),
+			qs("employee", "Filter by employee."),
+			qs("sort_by", "Field to sort by."),
+			qe("sort_order", "Sort direction.", "asc", "desc"),
+			qi("month", "Month 1-12."),
+			qi("year", "Year."),
+		},
+	},
+	"GET /api/v1/hris/reimbursements/summary": {
+		Description: "Reimbursement summary for a period",
+		Query:       []QueryParam{qi("month", "Month 1-12."), qi("year", "Year.")},
+	},
+
+	// ---- Marketing ----
+	"GET /api/v1/marketing/campaigns": {
+		Description: "List marketing campaigns with filters",
+		Paginated:   true, PerPageDefault: 12, PerPageMax: 100,
+		Query: []QueryParam{
+			qs("search", "Free-text search."),
+			qs("channel", "Channel filter."),
+			qs("status", "Status filter."),
+			qs("pic", "Person-in-charge filter."),
+			qs("date_from", "On/after this date (YYYY-MM-DD)."),
+			qs("date_to", "On/before this date (YYYY-MM-DD)."),
+		},
+	},
+	"GET /api/v1/marketing/ads-metrics": {
+		Description: "List ads metrics with filters",
+		Paginated:   true, PerPageDefault: 20, PerPageMax: 100,
+		Query: []QueryParam{
+			qs("campaign_id", "Filter by campaign (UUID)."),
+			qs("platform", "Ad platform filter."),
+			qs("date_from", "On/after this date (YYYY-MM-DD)."),
+			qs("date_to", "On/before this date (YYYY-MM-DD)."),
+		},
+	},
+	"GET /api/v1/marketing/ads-metrics/summary": {
+		Description: "Aggregated ads metrics summary",
+		Query: []QueryParam{
+			qs("group_by", "Grouping dimension."),
+			qs("date_from", "On/after this date (YYYY-MM-DD)."),
+			qs("date_to", "On/before this date (YYYY-MM-DD)."),
+		},
+	},
+	"GET /api/v1/marketing/leads": {
+		Description: "List leads with pipeline filters",
+		Paginated:   true, PerPageDefault: 20, PerPageMax: 100,
+		Query: []QueryParam{
+			qs("pipeline_status", "Pipeline stage filter."),
+			qs("source_channel", "Acquisition channel filter."),
+			qs("campaign_id", "Filter by campaign (UUID)."),
+			qs("assigned_to", "Filter by assignee."),
+			qs("search", "Free-text search."),
+			qs("date_from", "On/after this date (YYYY-MM-DD)."),
+			qs("date_to", "On/before this date (YYYY-MM-DD)."),
+		},
+	},
+
+	// ---- Operational ----
+	"GET /api/v1/operational/projects": {
+		Description: "List projects with filters",
+		Paginated:   true, PerPageDefault: 10, PerPageMax: 100,
+		Query: []QueryParam{
+			qs("search", "Free-text search."),
+			qs("status", "Status filter."),
+			qs("priority", "Priority filter."),
+		},
+	},
+	"GET /api/v1/operational/vps": {
+		Description: "List VPS inventory (returns all matching rows)",
+		Query: []QueryParam{
+			qs("status", "Status filter."),
+			qs("provider", "Provider filter."),
+			qs("tag", "Tag filter."),
+			qs("search", "Free-text search."),
+		},
+	},
+	"GET /api/v1/operational/domains": {
+		Description: "List domain inventory (returns all matching rows)",
+		Query: []QueryParam{
+			qs("status", "Status filter."),
+			qs("registrar", "Registrar filter."),
+			qs("tag", "Tag filter."),
+			qs("search", "Free-text search."),
+		},
+	},
+
+	// ---- Tracker ----
+	"GET /api/v1/tracker/my-activity": {
+		Description: "Your activity-tracker overview for a date range",
+		Query:       []QueryParam{qs("date_from", "Start date (YYYY-MM-DD)."), qs("date_to", "End date (YYYY-MM-DD).")},
+	},
+	"GET /api/v1/tracker/team-activity": {
+		Description: "Team activity-tracker overview for a date range",
+		Query: []QueryParam{
+			qs("date_from", "Start date (YYYY-MM-DD)."),
+			qs("date_to", "End date (YYYY-MM-DD)."),
+			qs("user_id", "Restrict to a single user (UUID)."),
+		},
+	},
+	"GET /api/v1/tracker/activity/{userID}": {
+		Description: "A specific user's activity-tracker overview",
+		Query:       []QueryParam{qs("date_from", "Start date (YYYY-MM-DD)."), qs("date_to", "End date (YYYY-MM-DD).")},
+	},
+	"GET /api/v1/tracker/summary": {
+		Description: "Daily tracker summary",
+		Query:       []QueryParam{qs("date", "Day (YYYY-MM-DD, default today).")},
+	},
+
+	// ---- WhatsApp ----
+	"GET /api/v1/wa/templates": {
+		Description: "List WA message templates",
+		Query:       []QueryParam{qs("category", "Category filter."), qs("trigger_type", "Trigger type filter.")},
+	},
+	"GET /api/v1/wa/logs": {
+		Description: "List WA broadcast logs",
+		Paginated:   true, PerPageDefault: 20,
+		Query: []QueryParam{
+			qs("schedule_id", "Filter by schedule (UUID)."),
+			qs("trigger_type", "Trigger type filter."),
+			qs("template_slug", "Template slug filter."),
+			qs("status", "Delivery status filter."),
+			qs("search", "Free-text search."),
+			qs("date_from", "On/after this date (YYYY-MM-DD)."),
+			qs("date_to", "On/before this date (YYYY-MM-DD)."),
+		},
+	},
+
+	// ---- Notifications ----
+	"GET /api/v1/notifications": {
+		Description: "List your notifications",
+		Paginated:   true, PerPageDefault: 20, PerPageMax: 100,
+		Query: []QueryParam{qb("read", "Filter by read/unread state.")},
+	},
+
+	// ---- Admin ----
+	"GET /api/v1/admin/audit-logs": {
+		Description: "Search the audit log",
+		Paginated:   true, PerPageDefault: 20,
+		Query: []QueryParam{
+			qs("module", "Module filter."),
+			qs("action", "Action filter."),
+			qs("user_id", "Actor user (UUID)."),
+			qs("resource", "Resource type filter."),
+			qs("resource_id", "Resource id filter."),
+			qs("search", "Free-text search."),
+			qs("date_from", "On/after this date (YYYY-MM-DD)."),
+			qs("date_to", "On/before this date (YYYY-MM-DD)."),
+		},
+	},
+	"GET /api/v1/admin/audit-logs/users": {
+		Description: "List users that appear in the audit log",
+		Query:       []QueryParam{qs("search", "Free-text search.")},
+	},
+	"GET /api/v1/admin/roles": {
+		Description: "List roles (returns the full filtered list)",
+		Query: []QueryParam{
+			qs("search", "Free-text search over name/slug."),
+			qb("is_system", "Filter system vs custom roles."),
+			qb("is_active", "Filter active/inactive roles."),
+		},
+	},
+	"GET /api/v1/admin/users": {
+		Description: "List users with filters",
+		Paginated:   true, PerPageDefault: 20,
+		Query: []QueryParam{
+			qs("search", "Free-text search over name/email."),
+			qs("module", "Filter by assigned module."),
+			qs("role", "Filter by assigned role (UUID)."),
+			qb("super_admin", "Filter super admins."),
+		},
+	},
+}
+
+// annotationFor returns the curated metadata for a route, if any.
+func annotationFor(method string, route string) *EndpointMeta {
+	if meta, ok := endpointAnnotations[method+" "+route]; ok {
+		copy := meta
+		return &copy
+	}
+	return nil
+}
+
+func qs(name, desc string) QueryParam {
+	return QueryParam{Name: name, Type: "string", Description: desc}
+}
+func qi(name, desc string) QueryParam {
+	return QueryParam{Name: name, Type: "integer", Description: desc}
+}
+func qb(name, desc string) QueryParam {
+	return QueryParam{Name: name, Type: "boolean", Description: desc}
+}
+func qe(name, desc string, enum ...string) QueryParam {
+	return QueryParam{Name: name, Type: "string", Description: desc, Enum: enum}
+}

--- a/backend/internal/mcp/annotations_test.go
+++ b/backend/internal/mcp/annotations_test.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestAnnotatedToolExposesFiltersAndPagination(t *testing.T) {
+	tool := ToolSpec{
+		Name:         "get_hris_employees",
+		Method:       http.MethodGet,
+		PathTemplate: "/api/v1/hris/employees",
+		Meta:         annotationFor(http.MethodGet, "/api/v1/hris/employees"),
+	}
+	if tool.Meta == nil {
+		t.Fatal("expected annotation for GET /api/v1/hris/employees")
+	}
+
+	query, ok := tool.inputSchema()["properties"].(map[string]interface{})["query"].(map[string]interface{})
+	if !ok {
+		t.Fatal("query schema missing")
+	}
+	props, ok := query["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected named query properties, got opaque object")
+	}
+	for _, want := range []string{"search", "department", "status", "page", "per_page"} {
+		if _, ok := props[want]; !ok {
+			t.Errorf("query schema missing %q", want)
+		}
+	}
+
+	// read-only hint should be set for a GET tool
+	ann := tool.descriptor()["annotations"].(map[string]interface{})
+	if ann["readOnlyHint"] != true {
+		t.Errorf("GET tool should be readOnlyHint=true, got %v", ann["readOnlyHint"])
+	}
+}
+
+func TestUnannotatedToolFallsBackToOpaqueQuery(t *testing.T) {
+	tool := ToolSpec{Name: "get_unknown", Method: http.MethodGet, PathTemplate: "/api/v1/unknown/thing"}
+	query := tool.inputSchema()["properties"].(map[string]interface{})["query"].(map[string]interface{})
+	if _, hasProps := query["properties"]; hasProps {
+		t.Error("unannotated tool should keep the opaque query object (no properties)")
+	}
+}
+
+func TestBuildRequestEncodesNumbersAndArrays(t *testing.T) {
+	tool := ToolSpec{Name: "get_x", Method: http.MethodGet, PathTemplate: "/api/v1/x"}
+	args := map[string]json.RawMessage{
+		"query": json.RawMessage(`{"per_page": 1000000, "tag": ["a","b"], "read": true}`),
+	}
+	req, err := tool.buildRequest(context.Background(), "", args, "", "")
+	if err != nil {
+		t.Fatalf("buildRequest: %v", err)
+	}
+	q := req.URL.Query()
+	if got := q.Get("per_page"); got != "1000000" {
+		t.Errorf("integer query mangled: per_page=%q (want 1000000)", got)
+	}
+	if got := q["tag"]; len(got) != 2 || got[0] != "a" || got[1] != "b" {
+		t.Errorf("array query not expanded to repeated keys: %v", got)
+	}
+	if got := q.Get("read"); got != "true" {
+		t.Errorf("bool query mangled: read=%q", got)
+	}
+}
+
+func TestAnnotationKeysAreWellFormed(t *testing.T) {
+	methods := map[string]bool{"GET": true, "POST": true, "PUT": true, "PATCH": true, "DELETE": true}
+	for key := range endpointAnnotations {
+		parts := strings.SplitN(key, " ", 2)
+		if len(parts) != 2 || !methods[parts[0]] || !strings.HasPrefix(parts[1], "/api/v1/") {
+			t.Errorf("malformed annotation key %q (want 'METHOD /api/v1/...')", key)
+		}
+	}
+}

--- a/backend/internal/mcp/catalog.go
+++ b/backend/internal/mcp/catalog.go
@@ -62,6 +62,7 @@ func BuildCatalog(router chi.Routes) ([]ToolSpec, error) {
 			Method:       method,
 			PathTemplate: route,
 			PathParams:   pathParams(route),
+			Meta:         annotationFor(method, route),
 		})
 		return nil
 	})

--- a/backend/internal/mcp/dispatch.go
+++ b/backend/internal/mcp/dispatch.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -73,7 +75,7 @@ func (t ToolSpec) buildRequest(ctx context.Context, baseURL string, args map[str
 			return nil, fmt.Errorf("query must be an object")
 		}
 		for key, value := range parsed {
-			query.Set(key, fmt.Sprintf("%v", value))
+			addQueryValue(query, key, value)
 		}
 	}
 
@@ -106,4 +108,31 @@ func (t ToolSpec) buildRequest(ctx context.Context, baseURL string, args map[str
 	}
 	req.Header.Set("Accept", "application/json")
 	return req, nil
+}
+
+// addQueryValue encodes a JSON query value into url.Values. JSON numbers decode
+// as float64, so integers must render without scientific notation/decimals, and
+// arrays become repeated keys (?k=a&k=b). fmt.Sprintf("%v") mangled all of these
+// (e.g. a large per_page -> "1e+06", an array -> "[a b]"), corrupting filters.
+func addQueryValue(query url.Values, key string, value interface{}) {
+	switch v := value.(type) {
+	case nil:
+		return
+	case string:
+		query.Add(key, v)
+	case bool:
+		query.Add(key, strconv.FormatBool(v))
+	case float64:
+		if !math.IsInf(v, 0) && !math.IsNaN(v) && v == math.Trunc(v) {
+			query.Add(key, strconv.FormatInt(int64(v), 10))
+		} else {
+			query.Add(key, strconv.FormatFloat(v, 'f', -1, 64))
+		}
+	case []interface{}:
+		for _, item := range v {
+			addQueryValue(query, key, item)
+		}
+	default:
+		query.Add(key, fmt.Sprintf("%v", v))
+	}
 }

--- a/backend/internal/mcp/tool.go
+++ b/backend/internal/mcp/tool.go
@@ -1,6 +1,9 @@
 package mcp
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 type ToolSpec struct {
 	Name         string
@@ -8,6 +11,27 @@ type ToolSpec struct {
 	Method       string
 	PathTemplate string
 	PathParams   []string
+	// Meta carries curated query/pagination metadata so AI clients can discover
+	// filters and page through all data. Nil for endpoints without an annotation
+	// (they fall back to the generic opaque query schema).
+	Meta *EndpointMeta
+}
+
+// QueryParam describes one real query-string parameter of an endpoint.
+type QueryParam struct {
+	Name        string
+	Type        string // "string", "integer", "boolean"
+	Description string
+	Enum        []string
+}
+
+// EndpointMeta is the curated annotation for an endpoint.
+type EndpointMeta struct {
+	Description    string
+	Query          []QueryParam
+	Paginated      bool
+	PerPageDefault int
+	PerPageMax     int // 0 = no enforced cap
 }
 
 func (t ToolSpec) hasBody() bool {
@@ -26,10 +50,7 @@ func (t ToolSpec) inputSchema() map[string]interface{} {
 		required = append(required, param)
 	}
 
-	properties["query"] = map[string]interface{}{
-		"type":        "object",
-		"description": "Optional query-string parameters as key/value pairs.",
-	}
+	properties["query"] = t.querySchema()
 
 	if t.hasBody() {
 		properties["body"] = map[string]interface{}{
@@ -48,10 +69,67 @@ func (t ToolSpec) inputSchema() map[string]interface{} {
 	return schema
 }
 
+// querySchema renders the query object. With a curated EndpointMeta it exposes
+// each real filter as a typed, described property and surfaces page/per_page
+// (with defaults and caps) so the client knows to paginate through ALL results.
+// Without metadata it falls back to a free-form key/value object.
+func (t ToolSpec) querySchema() map[string]interface{} {
+	if t.Meta == nil || (len(t.Meta.Query) == 0 && !t.Meta.Paginated) {
+		return map[string]interface{}{
+			"type":        "object",
+			"description": "Optional query-string parameters as key/value pairs.",
+		}
+	}
+
+	props := map[string]interface{}{}
+	for _, param := range t.Meta.Query {
+		prop := map[string]interface{}{"type": param.Type}
+		if param.Description != "" {
+			prop["description"] = param.Description
+		}
+		if len(param.Enum) > 0 {
+			prop["enum"] = param.Enum
+		}
+		props[param.Name] = prop
+	}
+
+	if t.Meta.Paginated {
+		props["page"] = map[string]interface{}{
+			"type":        "integer",
+			"minimum":     1,
+			"description": "1-based page number (default 1).",
+		}
+		perPage := map[string]interface{}{"type": "integer", "minimum": 1}
+		desc := fmt.Sprintf("Items per page (default %d", t.Meta.PerPageDefault)
+		if t.Meta.PerPageMax > 0 {
+			desc += fmt.Sprintf(", max %d", t.Meta.PerPageMax)
+			perPage["maximum"] = t.Meta.PerPageMax
+		}
+		desc += "). The response is paginated — page through every page to retrieve all data."
+		perPage["description"] = desc
+		props["per_page"] = perPage
+	}
+
+	return map[string]interface{}{
+		"type":        "object",
+		"description": "Query-string filters and pagination.",
+		"properties":  props,
+	}
+}
+
 func (t ToolSpec) descriptor() map[string]interface{} {
+	description := t.Description
+	if t.Meta != nil && t.Meta.Description != "" {
+		description = t.Meta.Description + " (" + t.Method + " " + t.PathTemplate + ")"
+	}
 	return map[string]interface{}{
 		"name":        t.Name,
-		"description": t.Description,
+		"description": description,
 		"inputSchema": t.inputSchema(),
+		"annotations": map[string]interface{}{
+			"readOnlyHint":    t.Method == http.MethodGet,
+			"destructiveHint": t.Method == http.MethodDelete,
+			"idempotentHint":  t.Method == http.MethodGet || t.Method == http.MethodPut || t.Method == http.MethodDelete,
+		},
 	}
 }

--- a/backend/internal/mcp/tool.go
+++ b/backend/internal/mcp/tool.go
@@ -11,9 +11,7 @@ type ToolSpec struct {
 	Method       string
 	PathTemplate string
 	PathParams   []string
-	// Meta carries curated query/pagination metadata so AI clients can discover
-	// filters and page through all data. Nil for endpoints without an annotation
-	// (they fall back to the generic opaque query schema).
+	// Meta enriches the query schema; nil endpoints keep the generic one.
 	Meta *EndpointMeta
 }
 
@@ -69,10 +67,8 @@ func (t ToolSpec) inputSchema() map[string]interface{} {
 	return schema
 }
 
-// querySchema renders the query object. With a curated EndpointMeta it exposes
-// each real filter as a typed, described property and surfaces page/per_page
-// (with defaults and caps) so the client knows to paginate through ALL results.
-// Without metadata it falls back to a free-form key/value object.
+// querySchema renders named filter + pagination properties when metadata exists,
+// else a free-form query object.
 func (t ToolSpec) querySchema() map[string]interface{} {
 	if t.Meta == nil || (len(t.Meta.Query) == 0 && !t.Meta.Paginated) {
 		return map[string]interface{}{

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -27,13 +27,29 @@ const principalContextKey contextKey = "principal"
 type patIdentity struct {
 	userID   string
 	tenantID string
+	scope    *string
+}
+
+type patScopeDef struct {
+	permissionPrefixes []string
+	modules            []string
+}
+
+// patScopeDefs maps a PAT scope to the permissions and modules it may exercise.
+// A scoped token can ONLY reach endpoints under these prefixes/modules and never
+// receives the super-admin bypass — limiting the blast radius if it leaks.
+var patScopeDefs = map[string]patScopeDef{
+	"tracker": {
+		permissionPrefixes: []string{"operational:tracker:"},
+		modules:            []string{rbac.ModuleOperational},
+	},
 }
 
 func AuthMiddleware(
 	parseToken func(string) (*backendauth.AccessClaims, error),
 	loadPermissions func(context.Context, string) (*rbac.CachedPermissions, error),
 	blacklist *backendauth.AccessTokenBlacklist,
-	authenticatePAT func(context.Context, string) (string, string, error),
+	authenticatePAT func(context.Context, string) (string, string, *string, error),
 ) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -52,20 +68,21 @@ func AuthMiddleware(
 			rawToken := parts[1]
 
 			var userID, tenantID string
+			var patScope *string
 			if backendauth.IsPersonalAccessToken(rawToken) {
 				if authenticatePAT == nil {
 					response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Access token is invalid or expired", nil)
 					return
 				}
 				identity, err := WithScopedTenantConn(r.Context(), func(ctx context.Context) (patIdentity, error) {
-					uid, tid, authErr := authenticatePAT(ctx, rawToken)
-					return patIdentity{userID: uid, tenantID: tid}, authErr
+					uid, tid, scope, authErr := authenticatePAT(ctx, rawToken)
+					return patIdentity{userID: uid, tenantID: tid, scope: scope}, authErr
 				})
 				if err != nil {
 					response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Access token is invalid or expired", nil)
 					return
 				}
-				userID, tenantID = identity.userID, identity.tenantID
+				userID, tenantID, patScope = identity.userID, identity.tenantID, identity.scope
 			} else {
 				claims, err := parseToken(rawToken)
 				if err != nil {
@@ -89,6 +106,15 @@ func AuthMiddleware(
 			if !cachedPermissions.IsActive {
 				response.WriteError(w, http.StatusForbidden, "INACTIVE_USER", "akun pengguna sedang tidak aktif", nil)
 				return
+			}
+
+			if patScope != nil {
+				def, ok := patScopeDefs[*patScope]
+				if !ok {
+					response.WriteError(w, http.StatusForbidden, "FORBIDDEN", "token scope is not permitted", nil)
+					return
+				}
+				cachedPermissions = restrictCachedPermissions(cachedPermissions, def)
 			}
 
 			roles := make([]string, 0, len(cachedPermissions.ModuleRoles)+1)
@@ -118,4 +144,52 @@ func AuthMiddleware(
 func PrincipalFromContext(ctx context.Context) (Principal, bool) {
 	principal, ok := ctx.Value(principalContextKey).(Principal)
 	return principal, ok
+}
+
+// restrictCachedPermissions returns a scoped COPY of the loaded permissions:
+// only permissions under the scope's prefixes survive, the super-admin bypass is
+// dropped, and for a super admin (who normally carries no explicit permissions)
+// the scope's full permission + module set is synthesized so the token still
+// works. The source is never mutated — it is shared from the permission cache.
+func restrictCachedPermissions(src *rbac.CachedPermissions, def patScopeDef) *rbac.CachedPermissions {
+	filtered := make(map[string]bool)
+	if src.IsSuperAdmin {
+		for _, permission := range rbac.DefaultPermissions() {
+			if hasAnyPrefix(permission.ID, def.permissionPrefixes) {
+				filtered[permission.ID] = true
+			}
+		}
+	} else {
+		for permission := range src.Permissions {
+			if hasAnyPrefix(permission, def.permissionPrefixes) {
+				filtered[permission] = true
+			}
+		}
+	}
+
+	moduleRoles := src.ModuleRoles
+	if src.IsSuperAdmin {
+		moduleRoles = make(map[string]rbac.ModuleRole, len(def.modules))
+		for _, moduleID := range def.modules {
+			moduleRoles[moduleID] = rbac.ModuleRole{}
+		}
+	}
+
+	return &rbac.CachedPermissions{
+		IsActive:     src.IsActive,
+		IsSuperAdmin: false,
+		ModuleRoles:  moduleRoles,
+		Permissions:  filtered,
+		CachedAt:     src.CachedAt,
+		TTL:          src.TTL,
+	}
+}
+
+func hasAnyPrefix(value string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(value, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/model/personal_access_token.go
+++ b/backend/internal/model/personal_access_token.go
@@ -6,6 +6,7 @@ type PersonalAccessToken struct {
 	ID          string     `json:"id"`
 	Name        string     `json:"name"`
 	TokenPrefix string     `json:"token_prefix"`
+	Scope       *string    `json:"scope,omitempty"`
 	LastUsedAt  *time.Time `json:"last_used_at,omitempty"`
 	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 	CreatedAt   time.Time  `json:"created_at"`

--- a/backend/internal/repository/auth/personal_access_token.go
+++ b/backend/internal/repository/auth/personal_access_token.go
@@ -20,6 +20,7 @@ type CreatePersonalAccessTokenParams struct {
 	TokenHash   string
 	TokenPrefix string
 	ExpiresAt   *time.Time
+	Scope       *string
 }
 
 func (r *Repository) CreatePersonalAccessToken(ctx context.Context, params CreatePersonalAccessTokenParams) (model.PersonalAccessToken, error) {
@@ -28,17 +29,21 @@ func (r *Repository) CreatePersonalAccessToken(ctx context.Context, params Creat
 
 	var token model.PersonalAccessToken
 	var lastUsedAt, expiresAt sql.NullTime
+	var scope sql.NullString
 	err := repository.DB(ctx, r.db).QueryRow(ctx, `
-		INSERT INTO personal_access_tokens (user_id, name, token_hash, token_prefix, expires_at)
-		VALUES ($1::uuid, $2, $3, $4, $5)
-		RETURNING id::text, name, token_prefix, last_used_at, expires_at, created_at
-	`, params.UserID, params.Name, params.TokenHash, params.TokenPrefix, params.ExpiresAt).Scan(
-		&token.ID, &token.Name, &token.TokenPrefix, &lastUsedAt, &expiresAt, &token.CreatedAt,
+		INSERT INTO personal_access_tokens (user_id, name, token_hash, token_prefix, expires_at, scope)
+		VALUES ($1::uuid, $2, $3, $4, $5, $6)
+		RETURNING id::text, name, token_prefix, scope, last_used_at, expires_at, created_at
+	`, params.UserID, params.Name, params.TokenHash, params.TokenPrefix, params.ExpiresAt, params.Scope).Scan(
+		&token.ID, &token.Name, &token.TokenPrefix, &scope, &lastUsedAt, &expiresAt, &token.CreatedAt,
 	)
 	if err != nil {
 		return model.PersonalAccessToken{}, err
 	}
 
+	if scope.Valid {
+		token.Scope = &scope.String
+	}
 	token.LastUsedAt = authNullTimePointer(lastUsedAt)
 	token.ExpiresAt = authNullTimePointer(expiresAt)
 	return token, nil
@@ -49,7 +54,7 @@ func (r *Repository) ListPersonalAccessTokens(ctx context.Context, userID string
 	defer cancel()
 
 	rows, err := repository.DB(ctx, r.db).Query(ctx, `
-		SELECT id::text, name, token_prefix, last_used_at, expires_at, created_at
+		SELECT id::text, name, token_prefix, scope, last_used_at, expires_at, created_at
 		FROM personal_access_tokens
 		WHERE user_id = $1::uuid AND revoked_at IS NULL
 		ORDER BY created_at DESC
@@ -63,8 +68,12 @@ func (r *Repository) ListPersonalAccessTokens(ctx context.Context, userID string
 	for rows.Next() {
 		var token model.PersonalAccessToken
 		var lastUsedAt, expiresAt sql.NullTime
-		if err := rows.Scan(&token.ID, &token.Name, &token.TokenPrefix, &lastUsedAt, &expiresAt, &token.CreatedAt); err != nil {
+		var scope sql.NullString
+		if err := rows.Scan(&token.ID, &token.Name, &token.TokenPrefix, &scope, &lastUsedAt, &expiresAt, &token.CreatedAt); err != nil {
 			return nil, err
+		}
+		if scope.Valid {
+			token.Scope = &scope.String
 		}
 		token.LastUsedAt = authNullTimePointer(lastUsedAt)
 		token.ExpiresAt = authNullTimePointer(expiresAt)
@@ -73,24 +82,28 @@ func (r *Repository) ListPersonalAccessTokens(ctx context.Context, userID string
 	return out, rows.Err()
 }
 
-func (r *Repository) GetActivePersonalAccessTokenByHash(ctx context.Context, tokenHash string) (userID string, tenantID string, err error) {
+func (r *Repository) GetActivePersonalAccessTokenByHash(ctx context.Context, tokenHash string) (userID string, tenantID string, scope *string, err error) {
 	ctx, cancel := repository.QueryContext(ctx)
 	defer cancel()
 
+	var scopeValue sql.NullString
 	err = repository.DB(ctx, r.db).QueryRow(ctx, `
-		SELECT user_id::text, tenant_id::text
+		SELECT user_id::text, tenant_id::text, scope
 		FROM personal_access_tokens
 		WHERE token_hash = $1
 		  AND revoked_at IS NULL
 		  AND (expires_at IS NULL OR expires_at > NOW())
-	`, tokenHash).Scan(&userID, &tenantID)
+	`, tokenHash).Scan(&userID, &tenantID, &scopeValue)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return "", "", ErrPersonalAccessTokenNotFound
+			return "", "", nil, ErrPersonalAccessTokenNotFound
 		}
-		return "", "", err
+		return "", "", nil, err
 	}
-	return userID, tenantID, nil
+	if scopeValue.Valid {
+		scope = &scopeValue.String
+	}
+	return userID, tenantID, scope, nil
 }
 
 func (r *Repository) TouchPersonalAccessToken(ctx context.Context, tokenHash string) error {

--- a/backend/internal/repository/operational/tracker.go
+++ b/backend/internal/repository/operational/tracker.go
@@ -295,6 +295,13 @@ func (r *TrackerRepository) RecordHeartbeat(ctx context.Context, params TrackerH
 		}
 	}()
 
+	// Serialize per-user session creation with StartSession so the stale/rotation
+	// recreate path below cannot race a concurrent StartSession into a duplicate
+	// active session (which the one-active unique index would reject with a 500).
+	if _, err = tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, params.UserID); err != nil {
+		return model.ActivityEntry{}, model.ActivitySession{}, err
+	}
+
 	session, err := r.getSessionForUpdate(ctx, tx, params.UserID, params.SessionID)
 	if err != nil {
 		return model.ActivityEntry{}, model.ActivitySession{}, err

--- a/backend/internal/repository/operational/tracker.go
+++ b/backend/internal/repository/operational/tracker.go
@@ -23,6 +23,18 @@ var (
 const (
 	trackerMinTimezoneOffsetMinutes = -720
 	trackerMaxTimezoneOffsetMinutes = 840
+
+	// trackerMaxHeartbeatGapSeconds caps how much active time a single heartbeat
+	// may credit. The extension beats every ~30s; beyond a few intervals the gap
+	// is not trustworthy continuous activity. Capping the per-heartbeat delta is
+	// what stops a long offline gap from being back-filled as active time.
+	trackerMaxHeartbeatGapSeconds = 120
+
+	// trackerStaleSessionGapSeconds is the gap beyond which the active session is
+	// considered abandoned (extension crashed / browser closed). Instead of
+	// crediting the whole offline gap, we close the old session at its last-seen
+	// time and start a fresh one — no back-fill.
+	trackerStaleSessionGapSeconds = 15 * 60
 )
 
 type TrackerStartSessionParams struct {
@@ -33,13 +45,17 @@ type TrackerStartSessionParams struct {
 }
 
 type TrackerHeartbeatParams struct {
-	SessionID             string
-	UserID                string
-	URL                   string
-	Domain                string
-	PageTitle             *string
-	IsIdle                bool
-	Timestamp             time.Time
+	SessionID string
+	UserID    string
+	URL       string
+	Domain    string
+	PageTitle *string
+	IsIdle    bool
+	Timestamp time.Time
+	// Now is the server's authoritative receive time. The client-supplied
+	// Timestamp is clamped to [session.start, Now] so future-dated or skewed
+	// client clocks cannot inflate or corrupt recorded time.
+	Now                   time.Time
 	TimezoneOffsetMinutes int
 	TimezoneName          *string
 	ExtensionVersion      *string
@@ -171,6 +187,12 @@ func (r *TrackerRepository) StartSession(ctx context.Context, userID string, par
 		}
 	}()
 
+	// Serialize session creation per user so two concurrent StartSession calls
+	// cannot both miss the active-session check and insert duplicates.
+	if _, err = tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, userID); err != nil {
+		return model.ActivitySession{}, err
+	}
+
 	userContext, timezoneOffsetMinutes, timezoneName, err := r.resolveEffectiveTrackerOffset(ctx, tx, userID, startedAt, params.TimezoneName, params.TimezoneOffsetMinutes)
 	if err != nil {
 		return model.ActivitySession{}, err
@@ -228,9 +250,13 @@ func (r *TrackerRepository) EndSession(ctx context.Context, userID string, sessi
 	defer cancel()
 
 	var session model.ActivitySession
+	// Clamp the client-supplied end time to [start_time, now] so a user cannot
+	// write an arbitrary end_time (past start or far in the future).
 	err := repository.DB(ctx, r.db).QueryRow(ctx, `
 		UPDATE activity_sessions
-		SET end_time = $3, is_active = FALSE, updated_at = $3
+		SET end_time = LEAST(GREATEST($3, start_time), NOW()),
+			is_active = FALSE,
+			updated_at = LEAST(GREATEST($3, start_time), NOW())
 		WHERE id = $1::uuid AND user_id = $2::uuid
 		RETURNING id::text, user_id::text, date, timezone_offset_minutes, start_time, end_time, total_active_seconds, total_idle_seconds, is_active, created_at, updated_at
 	`, sessionID, userID, endedAt.UTC()).Scan(
@@ -280,9 +306,26 @@ func (r *TrackerRepository) RecordHeartbeat(ctx context.Context, params TrackerH
 
 	params.Domain = strings.ToLower(strings.TrimSpace(params.Domain))
 
+	now := params.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	// Clamp the client-supplied timestamp into a trustworthy window:
+	//   - never in the future (a future value poisons updated_at and silently
+	//     zeroes all later activity, and inflates active time),
+	//   - never before the session start,
+	//   - never before the last heartbeat (monotonic: a stale/replayed beat must
+	//     not reopen an already-counted interval and double-count).
 	timestamp := params.Timestamp.UTC()
+	if timestamp.After(now) {
+		timestamp = now
+	}
 	if timestamp.Before(session.StartTime) {
 		timestamp = session.StartTime
+	}
+	if timestamp.Before(session.UpdatedAt) {
+		timestamp = session.UpdatedAt
 	}
 
 	userContext, timezoneOffsetMinutes, timezoneName, err := r.resolveEffectiveTrackerOffset(ctx, tx, params.UserID, timestamp, params.TimezoneName, params.TimezoneOffsetMinutes)
@@ -296,6 +339,24 @@ func (r *TrackerRepository) RecordHeartbeat(ctx context.Context, params TrackerH
 		}
 	}
 
+	// Abandoned session: a gap larger than the stale threshold means the
+	// extension was offline (crash/close/sleep). Close the old session at its
+	// last-seen time and start a fresh one rather than back-filling the whole
+	// offline gap as active time (the 22h/100% exploit).
+	if int(timestamp.Sub(session.UpdatedAt).Seconds()) > trackerStaleSessionGapSeconds {
+		if _, err = r.closeSessionAt(ctx, tx, session.ID, session.UserID, session.UpdatedAt); err != nil {
+			return model.ActivityEntry{}, model.ActivitySession{}, err
+		}
+		freshSession, createErr := r.createSession(ctx, tx, session.UserID, timestamp, session.TimezoneOffsetMinutes)
+		if createErr != nil {
+			return model.ActivityEntry{}, model.ActivitySession{}, createErr
+		}
+		if err = tx.Commit(ctx); err != nil {
+			return model.ActivityEntry{}, model.ActivitySession{}, err
+		}
+		return model.ActivityEntry{}, freshSession, nil
+	}
+
 	category := "uncategorized"
 	productive := false
 	if !params.IsIdle {
@@ -306,16 +367,13 @@ func (r *TrackerRepository) RecordHeartbeat(ctx context.Context, params TrackerH
 	}
 
 	var entry model.ActivityEntry
-	if shouldRotateTrackerSession(session, timestamp, params.TimezoneOffsetMinutes) {
+	if shouldRotateTrackerSession(session, timestamp) {
 		entry, session, err = r.recordHeartbeatAcrossSessionBoundary(ctx, tx, session, params, timestamp, category, productive)
 		if err != nil {
 			return model.ActivityEntry{}, model.ActivitySession{}, err
 		}
 	} else {
-		deltaSeconds := int(timestamp.Sub(session.UpdatedAt).Seconds())
-		if deltaSeconds < 0 {
-			deltaSeconds = 0
-		}
+		deltaSeconds := cappedHeartbeatDelta(session.UpdatedAt, timestamp)
 
 		if !params.IsIdle && deltaSeconds > 0 {
 			params.SessionID = session.ID
@@ -844,6 +902,42 @@ func (r *TrackerRepository) PurgeOldSessions(ctx context.Context, cutoff time.Ti
 	return tag.RowsAffected(), nil
 }
 
+// EndActiveSessions closes every still-active session for a user at its last-seen
+// time. Used when consent is revoked so no further time is credited and a later
+// re-grant cannot resume a stale session.
+func (r *TrackerRepository) EndActiveSessions(ctx context.Context, userID string) (int64, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	tag, err := repository.DB(ctx, r.db).Exec(ctx, `
+		UPDATE activity_sessions
+		SET is_active = FALSE, end_time = updated_at
+		WHERE user_id = $1::uuid AND is_active = TRUE
+	`, userID)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
+// EndStaleSessions closes active sessions whose last heartbeat predates cutoff —
+// orphaned by crashed/disconnected clients. Closing at updated_at adds no
+// phantom active time and stops StartSession from resurrecting a stale session.
+func (r *TrackerRepository) EndStaleSessions(ctx context.Context, cutoff time.Time) (int64, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	tag, err := repository.DB(ctx, r.db).Exec(ctx, `
+		UPDATE activity_sessions
+		SET is_active = FALSE, end_time = updated_at
+		WHERE is_active = TRUE AND updated_at < $1
+	`, cutoff.UTC())
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
 func (r *TrackerRepository) getSessionForUpdate(ctx context.Context, tx pgx.Tx, userID string, sessionID string) (model.ActivitySession, error) {
 	var session model.ActivitySession
 	err := tx.QueryRow(ctx, `
@@ -920,16 +1014,13 @@ func (r *TrackerRepository) closeSessionAt(ctx context.Context, tx pgx.Tx, sessi
 }
 
 func (r *TrackerRepository) recordHeartbeatAcrossSessionBoundary(ctx context.Context, tx pgx.Tx, session model.ActivitySession, params TrackerHeartbeatParams, timestamp time.Time, category string, isProductive bool) (model.ActivityEntry, model.ActivitySession, error) {
-	boundary := trackerSessionBoundaryUTC(session, timestamp, params.TimezoneOffsetMinutes)
+	boundary := trackerSessionBoundaryUTC(session, timestamp, session.TimezoneOffsetMinutes)
 	if boundary.Before(session.UpdatedAt) || boundary.After(timestamp) {
 		boundary = timestamp
 	}
 
 	var entry model.ActivityEntry
-	oldDeltaSeconds := int(boundary.Sub(session.UpdatedAt).Seconds())
-	if oldDeltaSeconds < 0 {
-		oldDeltaSeconds = 0
-	}
+	oldDeltaSeconds := cappedHeartbeatDelta(session.UpdatedAt, boundary)
 	if !params.IsIdle && oldDeltaSeconds > 0 {
 		oldParams := params
 		oldParams.SessionID = session.ID
@@ -949,15 +1040,12 @@ func (r *TrackerRepository) recordHeartbeatAcrossSessionBoundary(ctx context.Con
 		return model.ActivityEntry{}, model.ActivitySession{}, err
 	}
 
-	nextSession, err := r.createSession(ctx, tx, updatedSession.UserID, boundary, params.TimezoneOffsetMinutes)
+	nextSession, err := r.createSession(ctx, tx, updatedSession.UserID, boundary, session.TimezoneOffsetMinutes)
 	if err != nil {
 		return model.ActivityEntry{}, model.ActivitySession{}, err
 	}
 
-	remainingDeltaSeconds := int(timestamp.Sub(nextSession.UpdatedAt).Seconds())
-	if remainingDeltaSeconds < 0 {
-		remainingDeltaSeconds = 0
-	}
+	remainingDeltaSeconds := cappedHeartbeatDelta(nextSession.UpdatedAt, timestamp)
 	if !params.IsIdle && remainingDeltaSeconds > 0 {
 		nextParams := params
 		nextParams.SessionID = nextSession.ID
@@ -1125,11 +1213,26 @@ func trackerSessionBoundaryUTC(session model.ActivitySession, timestamp time.Tim
 	return currentLocalDate.Add(time.Duration(timezoneOffsetMinutes) * time.Minute)
 }
 
-func shouldRotateTrackerSession(session model.ActivitySession, timestamp time.Time, timezoneOffsetMinutes int) bool {
-	if session.TimezoneOffsetMinutes != timezoneOffsetMinutes {
-		return true
+func shouldRotateTrackerSession(session model.ActivitySession, timestamp time.Time) bool {
+	// Timezone is pinned at session start: rotate only when the local calendar
+	// date advances, computed with the session's own offset. This stops a
+	// per-heartbeat timezone change from forcing rotations or redistributing
+	// activity across date buckets.
+	return session.Date.Format("2006-01-02") != trackerLocalDateString(timestamp, session.TimezoneOffsetMinutes)
+}
+
+// cappedHeartbeatDelta is the active/idle seconds a single heartbeat may credit:
+// the gap since the last heartbeat, floored at 0 and capped at
+// trackerMaxHeartbeatGapSeconds so a missed-beat gap is never back-filled.
+func cappedHeartbeatDelta(lastSeen time.Time, timestamp time.Time) int {
+	delta := int(timestamp.Sub(lastSeen).Seconds())
+	if delta < 0 {
+		return 0
 	}
-	return session.Date.Format("2006-01-02") != trackerLocalDateString(timestamp, timezoneOffsetMinutes)
+	if delta > trackerMaxHeartbeatGapSeconds {
+		return trackerMaxHeartbeatGapSeconds
+	}
+	return delta
 }
 func (r *TrackerRepository) resolveDomainCategory(ctx context.Context, tx pgx.Tx, domain string) (string, bool, error) {
 	var (
@@ -1232,8 +1335,8 @@ func (r *TrackerRepository) updateSessionAfterHeartbeat(ctx context.Context, tx 
 		SET
 			total_active_seconds = total_active_seconds + $3,
 			total_idle_seconds = total_idle_seconds + $4,
-			end_time = $5,
-			updated_at = $5
+			end_time = GREATEST(end_time, $5),
+			updated_at = GREATEST(updated_at, $5)
 		WHERE id = $1::uuid AND user_id = $2::uuid
 		RETURNING id::text, user_id::text, date, timezone_offset_minutes, start_time, end_time, total_active_seconds, total_idle_seconds, is_active, created_at, updated_at
 	`
@@ -1548,4 +1651,3 @@ func nullStringPointer(value sql.NullString) *string {
 	result := strings.TrimSpace(value.String)
 	return &result
 }
-

--- a/backend/internal/service/auth/personal_access_token.go
+++ b/backend/internal/service/auth/personal_access_token.go
@@ -16,7 +16,7 @@ var ErrInvalidPersonalAccessToken = errors.New("invalid personal access token")
 type patRepository interface {
 	CreatePersonalAccessToken(ctx context.Context, params authrepo.CreatePersonalAccessTokenParams) (model.PersonalAccessToken, error)
 	ListPersonalAccessTokens(ctx context.Context, userID string) ([]model.PersonalAccessToken, error)
-	GetActivePersonalAccessTokenByHash(ctx context.Context, tokenHash string) (string, string, error)
+	GetActivePersonalAccessTokenByHash(ctx context.Context, tokenHash string) (string, string, *string, error)
 	TouchPersonalAccessToken(ctx context.Context, tokenHash string) error
 	RevokePersonalAccessToken(ctx context.Context, userID string, tokenID string) error
 }
@@ -29,7 +29,7 @@ func NewPATService(repo patRepository) *PATService {
 	return &PATService{repo: repo}
 }
 
-func (s *PATService) Issue(ctx context.Context, userID string, name string, expiresInDays *int, now time.Time) (string, model.PersonalAccessToken, error) {
+func (s *PATService) Issue(ctx context.Context, userID string, name string, expiresInDays *int, scope *string, now time.Time) (string, model.PersonalAccessToken, error) {
 	token, hash, prefix, err := backendauth.GeneratePersonalAccessToken()
 	if err != nil {
 		return "", model.PersonalAccessToken{}, err
@@ -47,6 +47,7 @@ func (s *PATService) Issue(ctx context.Context, userID string, name string, expi
 		TokenHash:   hash,
 		TokenPrefix: prefix,
 		ExpiresAt:   expiresAt,
+		Scope:       scope,
 	})
 	if err != nil {
 		return "", model.PersonalAccessToken{}, err
@@ -65,19 +66,19 @@ func (s *PATService) Revoke(ctx context.Context, userID string, tokenID string) 
 // Authenticate resolves a personal access token to its owning user and tenant.
 // It runs under the request's tenant-scoped connection, so RLS guarantees a
 // token only resolves within the tenant it was issued for.
-func (s *PATService) Authenticate(ctx context.Context, token string) (userID string, tenantID string, err error) {
+func (s *PATService) Authenticate(ctx context.Context, token string) (userID string, tenantID string, scope *string, err error) {
 	if !backendauth.IsPersonalAccessToken(token) {
-		return "", "", ErrInvalidPersonalAccessToken
+		return "", "", nil, ErrInvalidPersonalAccessToken
 	}
 
 	hash := backendauth.HashRefreshToken(token)
-	userID, tenantID, err = s.repo.GetActivePersonalAccessTokenByHash(ctx, hash)
+	userID, tenantID, scope, err = s.repo.GetActivePersonalAccessTokenByHash(ctx, hash)
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 
 	if touchErr := s.repo.TouchPersonalAccessToken(ctx, hash); touchErr != nil {
 		slog.WarnContext(ctx, "failed to touch personal access token last_used_at", "error", touchErr)
 	}
-	return userID, tenantID, nil
+	return userID, tenantID, scope, nil
 }

--- a/backend/internal/service/operational/tracker.go
+++ b/backend/internal/service/operational/tracker.go
@@ -93,6 +93,11 @@ func (s *TrackerService) StartSession(ctx context.Context, userID string, reques
 	if request.Timestamp != nil {
 		startedAt = *request.Timestamp
 	}
+	// Never let a client start a session dated in the future (skewed clock or
+	// abuse) — it would bucket activity into a future date.
+	if startedAt.After(now) {
+		startedAt = now
+	}
 
 	return s.repo.StartSession(ctx, userID, operationalrepo.TrackerStartSessionParams{
 		StartedAt:             startedAt,
@@ -143,10 +148,21 @@ func (s *TrackerService) RecordBatch(ctx context.Context, userID string, request
 	sortHeartbeats(entries)
 
 	result := TrackerBatchResult{}
+	var currentSessionID string
 	for _, entry := range entries {
-		if _, _, err := s.RecordHeartbeat(ctx, userID, entry, now); err != nil {
+		// If an earlier entry's session was rotated/recreated server-side (e.g. a
+		// stale-gap close), route the remaining replayed beats to the new session
+		// instead of the now-closed original so post-gap activity is not dropped.
+		if currentSessionID != "" {
+			entry.SessionID = currentSessionID
+		}
+		_, session, err := s.RecordHeartbeat(ctx, userID, entry, now)
+		if err != nil {
 			result.Skipped++
 			continue
+		}
+		if session.ID != "" {
+			currentSessionID = session.ID
 		}
 		result.Processed++
 	}

--- a/backend/internal/service/operational/tracker.go
+++ b/backend/internal/service/operational/tracker.go
@@ -35,6 +35,8 @@ type trackerRepository interface {
 	BulkClassifyObservedDomains(ctx context.Context, domains []string, isProductive bool, category *string) (model.BulkClassifyDomainsResult, error)
 	DeleteDomainCategory(ctx context.Context, domainID string) error
 	PurgeOldSessions(ctx context.Context, cutoff time.Time) (int64, error)
+	EndActiveSessions(ctx context.Context, userID string) (int64, error)
+	EndStaleSessions(ctx context.Context, cutoff time.Time) (int64, error)
 }
 
 type TrackerService struct {
@@ -70,7 +72,16 @@ func (s *TrackerService) GiveConsent(ctx context.Context, userID string, ipAddre
 }
 
 func (s *TrackerService) RevokeConsent(ctx context.Context, userID string, ipAddress string, now time.Time) (model.ActivityConsent, error) {
-	return s.repo.UpsertConsent(ctx, userID, false, ipAddress, now)
+	consent, err := s.repo.UpsertConsent(ctx, userID, false, ipAddress, now)
+	if err != nil {
+		return model.ActivityConsent{}, err
+	}
+	// Close any open sessions so no further time is credited after consent is
+	// withdrawn and a later re-grant cannot resume a stale (back-fillable) one.
+	if _, err := s.repo.EndActiveSessions(ctx, userID); err != nil {
+		return model.ActivityConsent{}, err
+	}
+	return consent, nil
 }
 
 func (s *TrackerService) StartSession(ctx context.Context, userID string, request operationaldto.TrackerStartSessionRequest, now time.Time) (model.ActivitySession, error) {
@@ -99,7 +110,7 @@ func (s *TrackerService) EndSession(ctx context.Context, userID string, sessionI
 	return session, err
 }
 
-func (s *TrackerService) RecordHeartbeat(ctx context.Context, userID string, request operationaldto.TrackerHeartbeatRequest) (model.ActivityEntry, model.ActivitySession, error) {
+func (s *TrackerService) RecordHeartbeat(ctx context.Context, userID string, request operationaldto.TrackerHeartbeatRequest, now time.Time) (model.ActivityEntry, model.ActivitySession, error) {
 	if err := s.requireConsent(ctx, userID); err != nil {
 		return model.ActivityEntry{}, model.ActivitySession{}, err
 	}
@@ -112,6 +123,7 @@ func (s *TrackerService) RecordHeartbeat(ctx context.Context, userID string, req
 		PageTitle:             request.PageTitle,
 		IsIdle:                request.IsIdle,
 		Timestamp:             request.Timestamp,
+		Now:                   now,
 		TimezoneOffsetMinutes: request.TimezoneOffsetMinutes,
 		TimezoneName:          request.TimezoneName,
 		ExtensionVersion:      request.ExtensionVersion,
@@ -122,7 +134,7 @@ func (s *TrackerService) RecordHeartbeat(ctx context.Context, userID string, req
 	return entry, session, err
 }
 
-func (s *TrackerService) RecordBatch(ctx context.Context, userID string, request operationaldto.TrackerBatchEntriesRequest) (TrackerBatchResult, error) {
+func (s *TrackerService) RecordBatch(ctx context.Context, userID string, request operationaldto.TrackerBatchEntriesRequest, now time.Time) (TrackerBatchResult, error) {
 	if err := s.requireConsent(ctx, userID); err != nil {
 		return TrackerBatchResult{}, err
 	}
@@ -132,7 +144,7 @@ func (s *TrackerService) RecordBatch(ctx context.Context, userID string, request
 
 	result := TrackerBatchResult{}
 	for _, entry := range entries {
-		if _, _, err := s.RecordHeartbeat(ctx, userID, entry); err != nil {
+		if _, _, err := s.RecordHeartbeat(ctx, userID, entry, now); err != nil {
 			result.Skipped++
 			continue
 		}
@@ -203,8 +215,21 @@ func (s *TrackerService) DeleteDomainCategory(ctx context.Context, domainID stri
 }
 
 func (s *TrackerService) PurgeOldData(ctx context.Context, now time.Time) (int64, error) {
-	cutoff := now.AddDate(0, 0, -s.retentionDays)
+	// Sessions store a LOCAL date but the cutoff derives from UTC now; keep one
+	// extra day of slack so a timezone offset can never purge data still inside
+	// the retention window.
+	cutoff := now.AddDate(0, 0, -(s.retentionDays + 1))
 	return s.repo.PurgeOldSessions(ctx, cutoff)
+}
+
+// trackerStaleSessionThreshold is how long a session may go without a heartbeat
+// before the sweeper closes it as abandoned (matches the in-request stale gap).
+const trackerStaleSessionThreshold = 15 * time.Minute
+
+// EndStaleSessions closes sessions orphaned by crashed/disconnected clients so a
+// later heartbeat or StartSession cannot resurrect them and back-fill the gap.
+func (s *TrackerService) EndStaleSessions(ctx context.Context, now time.Time) (int64, error) {
+	return s.repo.EndStaleSessions(ctx, now.Add(-trackerStaleSessionThreshold))
 }
 
 func (s *TrackerService) requireConsent(ctx context.Context, userID string) error {

--- a/backend/migrations/20260630010000_tracker_active_session_unique.down.sql
+++ b/backend/migrations/20260630010000_tracker_active_session_unique.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS uq_activity_sessions_one_active;

--- a/backend/migrations/20260630010000_tracker_active_session_unique.up.sql
+++ b/backend/migrations/20260630010000_tracker_active_session_unique.up.sql
@@ -2,15 +2,31 @@
 -- sessions (left by the pre-fix StartSession race or never-ended sessions) are
 -- closed at their last-seen time, keeping the most recent per user, so the
 -- unique index can be created.
-UPDATE activity_sessions
-SET is_active = FALSE, end_time = updated_at
-WHERE is_active
-  AND id NOT IN (
-    SELECT DISTINCT ON (tenant_id, user_id) id
-    FROM activity_sessions
+--
+-- activity_sessions has FORCE ROW LEVEL SECURITY, and migrations run without an
+-- app.current_tenant set (and in production as a non-superuser owner), so a
+-- plain UPDATE would be filtered to zero rows by the tenant_isolation policy and
+-- the dedup would silently do nothing — making CREATE UNIQUE INDEX abort on any
+-- instance that actually has duplicates. Loop per tenant and set the GUC, as
+-- 20260413093000_operational_kanban_column_type.up.sql does.
+DO $$
+DECLARE
+  current_tenant_id UUID;
+BEGIN
+  FOR current_tenant_id IN SELECT id FROM tenants LOOP
+    PERFORM set_config('app.current_tenant', current_tenant_id::text, true);
+    UPDATE activity_sessions
+    SET is_active = FALSE, end_time = updated_at
     WHERE is_active
-    ORDER BY tenant_id, user_id, start_time DESC
-  );
+      AND tenant_id = current_tenant_id
+      AND id NOT IN (
+        SELECT DISTINCT ON (user_id) id
+        FROM activity_sessions
+        WHERE is_active AND tenant_id = current_tenant_id
+        ORDER BY user_id, start_time DESC
+      );
+  END LOOP;
+END $$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_activity_sessions_one_active
   ON activity_sessions (tenant_id, user_id)

--- a/backend/migrations/20260630010000_tracker_active_session_unique.up.sql
+++ b/backend/migrations/20260630010000_tracker_active_session_unique.up.sql
@@ -1,0 +1,17 @@
+-- Enforce one active activity_session per user. Existing duplicate active
+-- sessions (left by the pre-fix StartSession race or never-ended sessions) are
+-- closed at their last-seen time, keeping the most recent per user, so the
+-- unique index can be created.
+UPDATE activity_sessions
+SET is_active = FALSE, end_time = updated_at
+WHERE is_active
+  AND id NOT IN (
+    SELECT DISTINCT ON (tenant_id, user_id) id
+    FROM activity_sessions
+    WHERE is_active
+    ORDER BY tenant_id, user_id, start_time DESC
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_activity_sessions_one_active
+  ON activity_sessions (tenant_id, user_id)
+  WHERE is_active;

--- a/backend/migrations/20260630020000_pat_scope.down.sql
+++ b/backend/migrations/20260630020000_pat_scope.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE personal_access_tokens DROP COLUMN IF EXISTS scope;

--- a/backend/migrations/20260630020000_pat_scope.up.sql
+++ b/backend/migrations/20260630020000_pat_scope.up.sql
@@ -1,0 +1,4 @@
+-- Optional scope on a personal access token. NULL = full access (inherits the
+-- user's permissions, current behaviour). 'tracker' = restricted to the activity
+-- tracker endpoints, used by the browser extension token.
+ALTER TABLE personal_access_tokens ADD COLUMN IF NOT EXISTS scope TEXT;

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -90,5 +90,14 @@ arguments; pass query parameters under `query` (object) and request bodies under
 `body` (object). The API validates everything and returns the standard response
 envelope as the tool result; a non-2xx status sets `isError: true`.
 
+Data-heavy list/query tools carry an enriched `inputSchema`: their real filters
+are exposed as named, typed, described `query` properties (with enums where
+applicable), and paginated endpoints surface `page`/`per_page` with their
+defaults and caps — so a client can discover the available filters and page
+through **all** rows instead of taking only the default first page. Tools also
+expose MCP `annotations` (`readOnlyHint`/`destructiveHint`/`idempotentHint`)
+derived from the HTTP method. Endpoints without a curated annotation keep the
+generic free-form `query` object.
+
 Excluded from the surface: superadmin endpoints (toggle super admin, registration
 settings) and public auth flows (login, register, password reset).

--- a/frontend/src/routes/_authenticated/operational/tracker.tsx
+++ b/frontend/src/routes/_authenticated/operational/tracker.tsx
@@ -111,6 +111,7 @@ async function issueExtensionToken(): Promise<string> {
   const created = await createPersonalAccessToken({
     name: EXTENSION_PAT_NAME,
     expires_in_days: 365,
+    scope: "tracker",
   });
   return created.token;
 }

--- a/frontend/src/services/personal-access-tokens.ts
+++ b/frontend/src/services/personal-access-tokens.ts
@@ -4,6 +4,7 @@ export type PersonalAccessToken = {
   id: string;
   name: string;
   token_prefix: string;
+  scope?: string | null;
   last_used_at?: string | null;
   expires_at?: string | null;
   created_at: string;
@@ -12,6 +13,7 @@ export type PersonalAccessToken = {
 export type CreatePersonalAccessTokenPayload = {
   name: string;
   expires_in_days?: number;
+  scope?: string;
 };
 
 export type PersonalAccessTokenCreated = {


### PR DESCRIPTION
Three related fixes in one PR.

**1. Tracker time integrity (server-side, no extension reinstall)** — closes the time-faking exploit (on at start, off, on at end → 22h/100% productive):
- clamp client heartbeat/start timestamps to [session start, now]; cap per-heartbeat credit at 120s
- auto-close sessions abandoned >15min (in-request + 5-min sweeper) instead of back-filling the gap; monotonic updated_at; end sessions on consent revoke; clamp end_time
- one-active-session partial unique index + per-user advisory lock; pin timezone at session start; batch cap; retention slack
- RLS-safe dedup migration (per-tenant set_config)

**2. Scoped extension PAT** — optional `scope` on PATs; the dashboard issues the extension token `tracker`-scoped → limited to `operational:tracker:*`, super-admin bypass dropped.

**3. MCP query enrichment** — list/query tools now expose their real filters as named typed query properties and surface page/per_page with defaults/caps, so AI clients can discover filters and page through all data (fixes 'banyak data gak ke query'). Also fixes dispatch query encoding (integers/arrays) and adds tool annotations.

Runtime-verified: migrations apply on real data, 3h gap not back-filled, 5-min gap capped at 120s, scoped token blocked from /hris & /admin, MCP schema renders filters + pagination.

Follow-ups: extension-side fixes + Firefox (#130, #129); tracker-scoped token can still touch its own /wa/phone (self-service).