### PR TITLE
fix(oauth): enforce rate limit and restrict redirect URI schemes on client registration

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -391,9 +391,15 @@ func (a *App) buildRouter(
 		// OAuth 2.1 authorization server for MCP remote connectors (public).
 		tenanted.Get("/.well-known/oauth-authorization-server", oauthHandler.AuthorizationServerMetadata)
 		tenanted.Get("/.well-known/oauth-protected-resource", oauthHandler.ProtectedResourceMetadata)
-		tenanted.Post("/oauth/register", oauthHandler.Register)
-		tenanted.Get("/oauth/authorize", oauthHandler.Authorize)
-		tenanted.Post("/oauth/token", oauthHandler.Token)
+		tenanted.With(platformmiddleware.NewIPRateLimit(10, time.Minute,
+			"RATE_LIMITED", "Too many client registration attempts. Try again later.",
+		)).Post("/oauth/register", oauthHandler.Register)
+		tenanted.With(platformmiddleware.NewIPRateLimit(20, time.Minute,
+			"RATE_LIMITED", "Too many authorization requests. Try again later.",
+		)).Get("/oauth/authorize", oauthHandler.Authorize)
+		tenanted.With(platformmiddleware.NewIPRateLimit(20, time.Minute,
+			"RATE_LIMITED", "Too many token requests. Try again later.",
+		)).Post("/oauth/token", oauthHandler.Token)
 
 		tenanted.Route("/api/v1", func(r chi.Router) {
 			r.Route("/auth", authHandler.RegisterRoutes)

--- a/backend/internal/oauth/redirect.go
+++ b/backend/internal/oauth/redirect.go
@@ -1,0 +1,36 @@
+package oauth
+
+import (
+	"errors"
+	"net/url"
+)
+
+// ErrInvalidRedirectURI is returned when a redirect URI does not satisfy the
+// allowlist. Only https:// URIs and http://localhost (or 127.0.0.1 / ::1) are
+// accepted. The localhost exception covers development MCP clients that run on
+// the local machine.
+var ErrInvalidRedirectURI = errors.New("redirect URI must use https or http://localhost")
+
+// ValidateRedirectURI checks that uri is safe to use as an OAuth 2.x redirect
+// target. It rejects javascript:, data:, file:, and any other non-http(s)
+// scheme that could be exploited to redirect authorization codes to
+// attacker-controlled locations.
+func ValidateRedirectURI(uri string) error {
+	parsed, err := url.Parse(uri)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ErrInvalidRedirectURI
+	}
+
+	switch parsed.Scheme {
+	case "https":
+		return nil
+	case "http":
+		host := parsed.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return nil
+		}
+		return ErrInvalidRedirectURI
+	default:
+		return ErrInvalidRedirectURI
+	}
+}

--- a/backend/internal/oauth/redirect_test.go
+++ b/backend/internal/oauth/redirect_test.go
@@ -1,0 +1,43 @@
+package oauth
+
+import "testing"
+
+func TestValidateRedirectURI(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr bool
+	}{
+		// Accepted URIs.
+		{name: "https external", uri: "https://example.com/callback", wantErr: false},
+		{name: "https with path and query", uri: "https://app.example.com/oauth/callback?foo=bar", wantErr: false},
+		{name: "http localhost by name", uri: "http://localhost/callback", wantErr: false},
+		{name: "http localhost with port", uri: "http://localhost:8080/callback", wantErr: false},
+		{name: "http 127.0.0.1", uri: "http://127.0.0.1/callback", wantErr: false},
+		{name: "http 127.0.0.1 with port", uri: "http://127.0.0.1:3000/callback", wantErr: false},
+		{name: "http ::1 IPv6", uri: "http://[::1]:9000/callback", wantErr: false},
+
+		// Rejected URIs — dangerous or non-https schemes.
+		{name: "javascript scheme", uri: "javascript:alert(1)", wantErr: true},
+		{name: "data scheme", uri: "data:text/html,<script>alert(1)</script>", wantErr: true},
+		{name: "file scheme", uri: "file:///etc/passwd", wantErr: true},
+		{name: "http non-localhost", uri: "http://evil.com/callback", wantErr: true},
+		{name: "http non-loopback IP", uri: "http://192.168.1.1/callback", wantErr: true},
+		{name: "no scheme", uri: "example.com/callback", wantErr: true},
+		{name: "empty string", uri: "", wantErr: true},
+		{name: "scheme only", uri: "https://", wantErr: true},
+		{name: "custom deep-link scheme", uri: "myapp://callback", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRedirectURI(tc.uri)
+			if tc.wantErr && err == nil {
+				t.Errorf("ValidateRedirectURI(%q) = nil, want error", tc.uri)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("ValidateRedirectURI(%q) = %v, want nil", tc.uri, err)
+			}
+		})
+	}
+}

--- a/backend/internal/service/auth/oauth.go
+++ b/backend/internal/service/auth/oauth.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"errors"
-	"net/url"
 	"slices"
 	"strings"
 	"time"
@@ -46,8 +45,7 @@ func (s *OAuthService) RegisterClient(ctx context.Context, clientName string, re
 		return RegisterClientResult{}, ErrOAuthInvalidRequest
 	}
 	for _, uri := range redirectURIs {
-		parsed, err := url.Parse(uri)
-		if err != nil || parsed.Scheme == "" {
+		if err := oauth.ValidateRedirectURI(uri); err != nil {
 			return RegisterClientResult{}, ErrOAuthInvalidRedirect
 		}
 	}


### PR DESCRIPTION
## What this fixes

The three public OAuth 2.1 endpoints had no rate limiting. Zero. Every other auth-facing route in the codebase has it: `/auth/login` is capped at 10 req/min per IP, `/auth/register` at 5, even `/auth/refresh` at 30. The OAuth routes sat right next to them with nothing.

```
POST /oauth/register   -- no limit
GET  /oauth/authorize  -- no limit
POST /oauth/token      -- no limit
```

The second issue is in `OAuthService.RegisterClient`. Redirect URI validation was a single check:

```go
parsed, err := url.Parse(uri)
if err != nil || parsed.Scheme == "" {
    return RegisterClientResult{}, ErrOAuthInvalidRedirect
}
```

An empty scheme gets rejected. Everything else passes. That means `javascript:alert(1)`, `data:text/html,<script>...`, `file:///etc/passwd`, and plain `http://evil.com` are all accepted as legitimate redirect targets. Once someone registers a client with one of those, they can send a victim to `/oauth/authorize` and control exactly where the authorization code lands.

The impact here is bounded — the attacker still needs the victim to visit the consent page while logged in, which is a real precondition. But the door is open and the fix is straightforward, so there's no reason to leave it.

---

## What changed

**`backend/internal/oauth/redirect.go` (new file)**

One exported function: `ValidateRedirectURI(uri string) error`.

Accepted:
- `https://` for any external host
- `http://localhost`, `http://127.0.0.1`, `http://[::1]` for local dev clients

Everything else is rejected. The function lives in the `oauth` package, not the service layer, so it's testable independently and can be reused if more OAuth flows get added.

**`backend/internal/service/auth/oauth.go`**

`RegisterClient` now calls `oauth.ValidateRedirectURI` instead of the old bare scheme check. The `net/url` import was removed — it was only there for that one check.

**`backend/internal/app/app.go`**

Rate limits:
- `/oauth/register`: 10 req/min per IP, matching the `/auth/login` ceiling
- `/oauth/authorize`: 20 req/min per IP
- `/oauth/token`: 20 req/min per IP

The authorize and token limits are deliberately a bit looser. A normal OAuth handshake involves several browser redirects in quick succession, and a developer with multiple tabs open or a flaky connection shouldn't get bounced mid-flow.

---

## Tests

`redirect_test.go` covers the full allow/deny boundary:

```
ACCEPT  https://example.com/callback
ACCEPT  https://app.example.com/oauth/callback?foo=bar
ACCEPT  http://localhost/callback
ACCEPT  http://localhost:8080/callback
ACCEPT  http://127.0.0.1/callback
ACCEPT  http://127.0.0.1:3000/callback
ACCEPT  http://[::1]:9000/callback

REJECT  javascript:alert(1)
REJECT  data:text/html,<script>alert(1)</script>
REJECT  file:///etc/passwd
REJECT  http://evil.com/callback
REJECT  http://192.168.1.1/callback
REJECT  example.com/callback          (no scheme)
REJECT  ""                            (empty)
REJECT  https://                      (no host)
REJECT  myapp://callback              (custom scheme)
```

All 16 pass. `go build ./...` is clean, `go vet` is clean.

---

## Verification

Before this PR, passing `javascript:alert(1)` to `RegisterClient` returned a success response with that URI stored. After, it returns `ErrOAuthInvalidRedirect`. The test `TestValidateRedirectURI/javascript_scheme` encodes this directly and fails if the fix is removed.

---

## Compatibility

This is a breaking change for any MCP client registered with an `http://` redirect pointing at a non-loopback host. That setup would be unusual for a real MCP deployment — tools connecting over plain HTTP to a remote host are rare and generally unintentional. If anyone runs into it, re-registering with an `https://` URI resolves it.