### PR TITLE
fix(ui): prevent theme flash on load and staggered toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,6 +20,19 @@
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>KANTOR</title>
+
+    <!-- Apply the persisted theme before first paint to avoid a light/dark flash. -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem("kantor-theme");
+          var mode = stored ? (JSON.parse(stored).state || {}).mode : null;
+          if (mode !== "dark" && mode !== "light") mode = "light";
+          document.documentElement.classList.toggle("dark", mode === "dark");
+          document.documentElement.style.colorScheme = mode;
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body class="bg-background text-foreground">
     <div id="root"></div>

--- a/frontend/src/components/providers/theme-provider.tsx
+++ b/frontend/src/components/providers/theme-provider.tsx
@@ -8,8 +8,17 @@ export function ThemeProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     const root = document.documentElement;
+    // Flip the theme with transitions momentarily disabled so all elements
+    // switch at once instead of animating (which looked staggered/laggy).
+    root.classList.add("theme-no-transitions");
     root.classList.toggle("dark", mode === "dark");
     root.style.colorScheme = mode;
+    // Force a reflow so the class change is applied before transitions return.
+    void root.offsetHeight;
+    const frame = window.requestAnimationFrame(() => {
+      root.classList.remove("theme-no-transitions");
+    });
+    return () => window.cancelAnimationFrame(frame);
   }, [mode]);
 
   return children;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,19 @@
 @tailwind utilities;
 
 @layer base {
+  /* Suppress transitions while the theme flips so every element switches at
+     once. Without this, elements using transition-all animate the color change
+     and the toggle looks staggered. ThemeProvider adds this class for one frame
+     around the mode change. */
+  .theme-no-transitions,
+  .theme-no-transitions *,
+  .theme-no-transitions *::before,
+  .theme-no-transitions *::after {
+    transition: none !important;
+  }
+}
+
+@layer base {
   :root {
     --background: 210 33% 98%; /* #FAFBFC */
     --foreground: 218 54% 19%; /* #172B4D */


### PR DESCRIPTION
Fixes #133.

**Load flash** — the theme class was only applied after React mounted, so the page painted light first then flipped. Added an inline script in `index.html` that reads the persisted theme from localStorage and sets the `dark` class + `color-scheme` before first paint.

**Staggered toggle** — elements using `transition-all` animated the color change on toggle, so the theme switched unevenly. ThemeProvider now adds a `theme-no-transitions` class for one frame around the mode change, so everything flips at once.

Frontend build green.