### PR TITLE
feat(extension): v2 — reliability + Firefox + version check

### DIFF
--- a/backend/internal/handler/operational/tracker.go
+++ b/backend/internal/handler/operational/tracker.go
@@ -42,6 +42,7 @@ func (h *TrackerHandler) RegisterRoutes(router chi.Router) {
 
 	router.With(platformmiddleware.RequirePermission("operational:tracker:view")).Get("/my-activity", h.getMyActivity)
 	router.With(platformmiddleware.RequirePermission("operational:tracker:view")).Get("/extension/download", h.downloadExtension)
+	router.With(platformmiddleware.RequirePermission("operational:tracker:view")).Get("/extension/status", h.getExtensionStatus)
 	router.With(platformmiddleware.RequirePermission("operational:tracker:view_team")).Get("/team-activity", h.getTeamActivity)
 	router.With(platformmiddleware.RequirePermission("operational:tracker:view_team")).Get("/activity/{userID}", h.getUserActivity)
 	router.With(platformmiddleware.RequirePermission("operational:tracker:view_team")).Get("/summary", h.getSummary)
@@ -232,6 +233,21 @@ func (h *TrackerHandler) downloadExtension(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(archiveBytes)
+}
+
+func (h *TrackerHandler) getExtensionStatus(w http.ResponseWriter, r *http.Request) {
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+		return
+	}
+
+	status, err := h.service.GetExtensionStatus(r.Context(), principal.UserID)
+	if err != nil {
+		response.WriteInternalError(r.Context(), w, err, "Failed to load extension status")
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, status, nil)
 }
 
 func (h *TrackerHandler) getTeamActivity(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/repository/operational/tracker.go
+++ b/backend/internal/repository/operational/tracker.go
@@ -945,6 +945,24 @@ func (r *TrackerRepository) EndStaleSessions(ctx context.Context, cutoff time.Ti
 	return tag.RowsAffected(), nil
 }
 
+// GetUserExtensionVersion returns the tracker extension version last reported by
+// the user (empty string if never reported).
+func (r *TrackerRepository) GetUserExtensionVersion(ctx context.Context, userID string) (string, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var version sql.NullString
+	if err := repository.DB(ctx, r.db).QueryRow(ctx, `
+		SELECT tracker_extension_version FROM users WHERE id = $1::uuid
+	`, userID).Scan(&version); err != nil {
+		return "", err
+	}
+	if version.Valid {
+		return version.String, nil
+	}
+	return "", nil
+}
+
 func (r *TrackerRepository) getSessionForUpdate(ctx context.Context, tx pgx.Tx, userID string, sessionID string) (model.ActivitySession, error) {
 	var session model.ActivitySession
 	err := tx.QueryRow(ctx, `

--- a/backend/internal/service/operational/tracker.go
+++ b/backend/internal/service/operational/tracker.go
@@ -37,6 +37,7 @@ type trackerRepository interface {
 	PurgeOldSessions(ctx context.Context, cutoff time.Time) (int64, error)
 	EndActiveSessions(ctx context.Context, userID string) (int64, error)
 	EndStaleSessions(ctx context.Context, cutoff time.Time) (int64, error)
+	GetUserExtensionVersion(ctx context.Context, userID string) (string, error)
 }
 
 type TrackerService struct {

--- a/backend/internal/service/operational/tracker_extension.go
+++ b/backend/internal/service/operational/tracker_extension.go
@@ -4,16 +4,102 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
 var ErrTrackerExtensionUnavailable = errors.New("tracker extension package is unavailable")
+
+// ExtensionStatus tells a client whether its installed extension is current.
+type ExtensionStatus struct {
+	LatestVersion   string `json:"latest_version"`
+	ReportedVersion string `json:"reported_version"`
+	NeedsUpdate     bool   `json:"needs_update"`
+}
+
+type extensionManifest struct {
+	Version string `json:"version"`
+}
+
+// LatestExtensionVersion reads the version from the bundled extension manifest —
+// i.e. the build the server hands out on download. Single source of truth: bump
+// the manifest and the "latest" everyone compares against moves with it.
+func (s *TrackerService) LatestExtensionVersion() (string, error) {
+	dir, err := resolveExtensionDir()
+	if err != nil {
+		return "", ErrTrackerExtensionUnavailable
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
+	if err != nil {
+		return "", ErrTrackerExtensionUnavailable
+	}
+	var manifest extensionManifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return "", ErrTrackerExtensionUnavailable
+	}
+	return strings.TrimSpace(manifest.Version), nil
+}
+
+// GetExtensionStatus compares the version last reported by the user's extension
+// against the bundled build so the dashboard can prompt a re-download.
+func (s *TrackerService) GetExtensionStatus(ctx context.Context, userID string) (ExtensionStatus, error) {
+	latest, err := s.LatestExtensionVersion()
+	if err != nil {
+		return ExtensionStatus{}, err
+	}
+	reported, err := s.repo.GetUserExtensionVersion(ctx, userID)
+	if err != nil {
+		return ExtensionStatus{}, err
+	}
+	return ExtensionStatus{
+		LatestVersion:   latest,
+		ReportedVersion: reported,
+		NeedsUpdate:     reported != "" && isExtensionVersionOlder(reported, latest),
+	}, nil
+}
+
+// isExtensionVersionOlder compares dotted numeric versions ("1.9" < "1.10").
+func isExtensionVersionOlder(current, latest string) bool {
+	a := parseVersionParts(current)
+	b := parseVersionParts(latest)
+	length := len(a)
+	if len(b) > length {
+		length = len(b)
+	}
+	for i := 0; i < length; i++ {
+		var left, right int
+		if i < len(a) {
+			left = a[i]
+		}
+		if i < len(b) {
+			right = b[i]
+		}
+		if left < right {
+			return true
+		}
+		if left > right {
+			return false
+		}
+	}
+	return false
+}
+
+func parseVersionParts(version string) []int {
+	fields := strings.Split(strings.TrimSpace(version), ".")
+	parts := make([]int, 0, len(fields))
+	for _, field := range fields {
+		value, _ := strconv.Atoi(strings.TrimSpace(field))
+		parts = append(parts, value)
+	}
+	return parts
+}
 
 func (s *TrackerService) BuildExtensionArchive(ctx context.Context) ([]byte, string, error) {
 	extensionDir, err := resolveExtensionDir()

--- a/backend/internal/service/operational/tracker_extension_test.go
+++ b/backend/internal/service/operational/tracker_extension_test.go
@@ -1,0 +1,24 @@
+package operational
+
+import "testing"
+
+func TestIsExtensionVersionOlder(t *testing.T) {
+	tests := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		{"1.0.0", "2.0.0", true},
+		{"1.9.0", "1.10.0", true}, // numeric, not lexical
+		{"2.0.0", "2.0.0", false},
+		{"2.0.1", "2.0.0", false},
+		{"1.0", "1.0.0", false},
+		{"", "2.0.0", true},
+		{"2.0.0", "", false},
+	}
+	for _, tc := range tests {
+		if got := isExtensionVersionOlder(tc.current, tc.latest); got != tc.want {
+			t.Errorf("isExtensionVersionOlder(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+		}
+	}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,7 +149,7 @@ Backend:
 ```
 
 Privacy: tracking requires explicit user consent (opt-in). Data retention is configurable via `TRACKER_RETENTION_DAYS`.
-Access tokens are stored in `chrome.storage.session`, while persistent tracker settings remain in `chrome.storage.local`. Host permissions are limited to `http://*/*` and `https://*/*`.
+The extension authenticates with a long-lived, tracker-scoped Personal Access Token stored in `chrome.storage.local` (persists across browser restarts; revocable from the dashboard). Host permissions are limited to `http://*/*` and `https://*/*`.
 
 ## WhatsApp Integration
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -12,7 +12,7 @@ Extension ini tidak khusus untuk localhost. Flow utamanya adalah menerima konfig
 - Offline queue + batch sync saat koneksi kembali
 - Popup status tracker yang fokus pada status, waktu aktif, dan domain aktif
 - Options page untuk fallback manual, idle timeout, dan excluded domains
-- Access token disimpan di `chrome.storage.session`, bukan storage persisten
+- Personal Access Token (PAT) tracker-scoped disimpan di `chrome.storage.local` agar tetap ada setelah browser restart; token bisa di-revoke kapan saja dari dashboard
 - Host permission dibatasi ke `http://*/*` dan `https://*/*`
 
 ## Cara Pasang untuk User
@@ -56,7 +56,7 @@ Gunakan ini hanya jika auto-connect dari dashboard tidak bisa dipakai.
 ## Cara Kerja Singkat
 
 1. Dashboard web mengirim konfigurasi ke extension.
-2. Extension menyimpan `apiBaseUrl` di `chrome.storage.local`, sedangkan access token disimpan di `chrome.storage.session`.
+2. Extension menyimpan `apiBaseUrl` dan PAT tracker-scoped di `chrome.storage.local` (persisten lintas restart).
 3. Extension memulai session tracker.
 4. Setiap 30 detik extension mengirim heartbeat berisi URL aktif, domain, judul halaman, dan status idle.
 5. Backend menyimpan data ke `activity_sessions` dan `activity_entries`.
@@ -96,10 +96,9 @@ Catatan:
 
 ## Catatan Auth
 
-- extension menyimpan access token di `chrome.storage.session`
-- refresh token tidak disimpan langsung oleh extension
-- saat access token expired, extension akan mencoba `POST /api/v1/auth/refresh` dengan cookie browser yang masih aktif
-- jika refresh gagal, user perlu menghubungkan ulang dari dashboard atau melakukan setup manual lagi
+- extension memakai Personal Access Token (PAT) tracker-scoped yang berumur panjang, disimpan di `chrome.storage.local`
+- PAT hanya bisa mengakses endpoint tracker (`operational:tracker:*`) dan bisa di-revoke kapan saja dari dashboard
+- tidak ada alur refresh; jika PAT di-revoke/invalid (401), extension meminta user menghubungkan ulang dari dashboard
 
 ## Catatan Deployment dan Development
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -234,7 +234,8 @@ async function sendHeartbeat(payload) {
 
 async function flushQueue() {
   const state = await loadState();
-  if (!state.queuedEntries.length) {
+  const pending = state.queuedEntries;
+  if (!pending.length) {
     return;
   }
 
@@ -244,14 +245,20 @@ async function flushQueue() {
   if (!sessionId) {
     return;
   }
-  const entries = state.queuedEntries.map((entry) => ({ ...entry, session_id: sessionId }));
+  const entries = pending.map((entry) => ({ ...entry, session_id: sessionId }));
 
   try {
     await authorizedRequest("/tracker/entries/batch", {
       method: "POST",
       body: JSON.stringify({ entries }),
     });
-    await updateState({ queuedEntries: [] });
+    // Drop only the entries we actually sent (the oldest `sentCount`) inside the
+    // lock, so beats queued while this batch was in flight are not lost.
+    const sentCount = entries.length;
+    await withStateLock(async () => {
+      const current = await loadState();
+      await saveState({ ...current, queuedEntries: current.queuedEntries.slice(sentCount) });
+    });
   } catch (error) {
     await updateState({
       lastError: error instanceof Error ? error.message : "Failed to sync queued entries",

--- a/extension/background.js
+++ b/extension/background.js
@@ -9,7 +9,7 @@ const DEFAULT_STATE = {
   sessionId: "",
   consented: false,
   paused: false,
-  idleTimeoutSeconds: 300,
+  idleTimeoutSeconds: 7200,
   excludedDomains: [],
   queuedEntries: [],
   currentTab: null,
@@ -506,10 +506,12 @@ function normalizeExcludedDomains(items) {
   );
 }
 
+// Default idle threshold is 2 hours: a user is only counted idle after 2h with
+// no keyboard/mouse input. Configurable per user in the options page (min 60s).
 function normalizeIdleTimeout(value) {
-  const parsed = Number(value || 300);
+  const parsed = Number(value || 7200);
   if (!Number.isFinite(parsed) || parsed < 60) {
-    return 300;
+    return 7200;
   }
   return Math.round(parsed);
 }

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,3 +1,7 @@
+// Cross-browser: Firefox/Safari expose `browser` (promise-based); Chrome exposes
+// `chrome` (promise-based on MV3 for the APIs used here). One namespace for all.
+const browserApi = globalThis.browser ?? globalThis.chrome;
+
 const DEFAULT_STATE = {
   apiBaseUrl: "",
   dashboardUrl: "",
@@ -13,44 +17,49 @@ const DEFAULT_STATE = {
   lastSummary: null,
   lastHeartbeatAt: null,
   lastError: "",
+  updateAvailable: false,
+  latestVersion: "",
 };
 
 const HEARTBEAT_ALARM = "kantor-heartbeat";
 const HEARTBEAT_INTERVAL_MINUTES = 0.5;
+// Offline queue cap. Sized to hold a full workday of 30s heartbeats (~2880/day)
+// with headroom, so a long offline stretch does not silently drop early activity.
+const MAX_QUEUED_ENTRIES = 5000;
 
-chrome.runtime.onInstalled.addListener(() => {
+browserApi.runtime.onInstalled.addListener(() => {
   void initializeState();
 });
 
-chrome.runtime.onStartup.addListener(() => {
+browserApi.runtime.onStartup.addListener(() => {
   void initializeState();
 });
 
-chrome.runtime.onSuspend.addListener(() => {
+browserApi.runtime.onSuspend?.addListener(() => {
   void bestEffortEndSession();
 });
 
-chrome.alarms.onAlarm.addListener((alarm) => {
+browserApi.alarms.onAlarm.addListener((alarm) => {
   if (alarm.name === HEARTBEAT_ALARM) {
     void handleHeartbeatTick();
   }
 });
 
-chrome.tabs.onActivated.addListener(() => {
+browserApi.tabs.onActivated.addListener(() => {
   void updateCurrentTabSnapshot();
 });
 
-chrome.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
+browserApi.tabs.onUpdated.addListener((_tabId, changeInfo, tab) => {
   if (changeInfo.status === "complete" && tab.active) {
     void updateCurrentTabSnapshot();
   }
 });
 
-chrome.windows.onFocusChanged.addListener(() => {
+browserApi.windows.onFocusChanged.addListener(() => {
   void updateCurrentTabSnapshot();
 });
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+browserApi.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   void (async () => {
     try {
       switch (message?.type) {
@@ -65,6 +74,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
           });
           await refreshConsent();
           await fetchTodaySummary();
+          await checkForUpdate();
           sendResponse({ ok: true });
           break;
         case "tracker:set-options":
@@ -96,6 +106,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         case "tracker:refresh":
           await refreshConsent();
           await fetchTodaySummary();
+          await checkForUpdate();
           sendResponse(await getExtensionState());
           break;
         default:
@@ -114,14 +125,15 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 async function initializeState() {
   const state = await loadState();
   await saveState({ ...DEFAULT_STATE, ...state });
-  await chrome.alarms.clear(HEARTBEAT_ALARM);
-  await chrome.alarms.create(HEARTBEAT_ALARM, {
+  await browserApi.alarms.clear(HEARTBEAT_ALARM);
+  await browserApi.alarms.create(HEARTBEAT_ALARM, {
     delayInMinutes: HEARTBEAT_INTERVAL_MINUTES,
     periodInMinutes: HEARTBEAT_INTERVAL_MINUTES,
   });
   await updateCurrentTabSnapshot();
   await refreshConsent();
   await ensureActiveSession();
+  await checkForUpdate();
 }
 
 async function getExtensionState() {
@@ -129,6 +141,7 @@ async function getExtensionState() {
   return {
     ...state,
     dashboardUrl: resolveDashboardUrl(state),
+    installedVersion: getExtensionVersion(),
   };
 }
 
@@ -174,15 +187,17 @@ async function handleHeartbeatTick() {
 
 async function sendHeartbeat(payload) {
   const state = await loadState();
-  if (!navigator.onLine) {
-    await queueEntry(payload);
-    return;
-  }
 
   let sessionId = state.sessionId;
   if (!sessionId) {
     sessionId = await ensureActiveSession();
     payload.session_id = sessionId;
+  }
+  // Without a session we cannot attribute the beat; queue it for a later flush
+  // (which re-stamps it with a valid session) instead of sending an empty id.
+  if (!sessionId) {
+    await queueEntry(payload);
+    return;
   }
 
   try {
@@ -211,6 +226,7 @@ async function sendHeartbeat(payload) {
       await updateState({ consented: false, trackerState: "stopped", lastError: "Consent required" });
       return;
     }
+    // Network error / offline / transient failure: keep the beat for later.
     await queueEntry(payload);
     await updateState({ lastError: message });
   }
@@ -218,14 +234,22 @@ async function sendHeartbeat(payload) {
 
 async function flushQueue() {
   const state = await loadState();
-  if (!navigator.onLine || !state.queuedEntries.length) {
+  if (!state.queuedEntries.length) {
     return;
   }
+
+  // Re-attach the current session so entries queued under an old/empty session
+  // (e.g. one closed while offline) still land instead of being skipped server-side.
+  const sessionId = await ensureActiveSession();
+  if (!sessionId) {
+    return;
+  }
+  const entries = state.queuedEntries.map((entry) => ({ ...entry, session_id: sessionId }));
 
   try {
     await authorizedRequest("/tracker/entries/batch", {
       method: "POST",
-      body: JSON.stringify({ entries: state.queuedEntries }),
+      body: JSON.stringify({ entries }),
     });
     await updateState({ queuedEntries: [] });
   } catch (error) {
@@ -385,63 +409,31 @@ async function fetchTodaySummary() {
   }
 }
 
-async function authorizedRequest(path, init) {
+// checkForUpdate asks the backend for the latest published extension version and
+// flags the UI when the installed build is behind, so the user knows to
+// re-download/reinstall.
+async function checkForUpdate() {
   const state = await loadState();
   if (!state.apiBaseUrl || !state.token) {
-    throw new Error("Extension belum terhubung. Hubungkan dari dashboard KANTOR atau gunakan setup manual.");
+    return;
   }
-
-  const response = await fetch(`${sanitizeApiBaseUrl(state.apiBaseUrl)}${path}`, {
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${state.token}`,
-      ...(init?.headers || {}),
-    },
-    credentials: "include",
-  });
-
-  const payload = await response.json().catch(() => null);
-  if (response.status === 401) {
-    const refreshed = await refreshAccessToken(state.apiBaseUrl);
-    if (refreshed) {
-      return authorizedRequest(path, init);
+  try {
+    const response = await authorizedRequest("/tracker/extension/status", { method: "GET" });
+    const latest = String(response?.data?.latest_version || "").trim();
+    if (!latest) {
+      return;
     }
+    await updateState({
+      latestVersion: latest,
+      updateAvailable: isVersionOlder(getExtensionVersion(), latest),
+    });
+  } catch {
+    // Non-fatal: version check never blocks tracking.
   }
-
-  if (!response.ok || !payload?.success) {
-    const code = payload?.error?.code || `HTTP_${response.status}`;
-    const message = payload?.error?.message || "Request failed";
-    throw new Error(`${code}: ${message}`);
-  }
-
-  return payload;
-}
-
-async function refreshAccessToken(apiBaseUrl) {
-  const response = await fetch(`${sanitizeApiBaseUrl(apiBaseUrl)}/auth/refresh`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({}),
-    credentials: "include",
-  });
-
-  const payload = await response.json().catch(() => null);
-  if (!response.ok || !payload?.success || !payload?.data?.tokens?.access_token) {
-    return false;
-  }
-
-  await updateState({
-    token: payload.data.tokens.access_token,
-  });
-
-  return true;
 }
 
 async function getCurrentTabInfo(excludedDomains) {
-  const [tab] = await chrome.tabs.query({ active: true, lastFocusedWindow: true });
+  const [tab] = await browserApi.tabs.query({ active: true, lastFocusedWindow: true });
   if (!tab?.url || !tab.active) {
     return null;
   }
@@ -470,17 +462,23 @@ async function updateCurrentTabSnapshot() {
 }
 
 async function queueEntry(entry) {
-  const state = await loadState();
-  const nextQueue = [...state.queuedEntries, entry].slice(-250);
-  await updateState({ queuedEntries: nextQueue });
+  await withStateLock(async () => {
+    const state = await loadState();
+    const nextQueue = [...state.queuedEntries, entry];
+    if (nextQueue.length > MAX_QUEUED_ENTRIES) {
+      console.warn("KANTOR tracker: offline queue full, dropping oldest entries");
+      nextQueue.splice(0, nextQueue.length - MAX_QUEUED_ENTRIES);
+    }
+    await saveState({ ...state, queuedEntries: nextQueue });
+  });
 }
 
 async function queryIdleState(idleTimeoutSeconds) {
-  return chrome.idle.queryState(normalizeIdleTimeout(idleTimeoutSeconds));
+  return browserApi.idle.queryState(normalizeIdleTimeout(idleTimeoutSeconds));
 }
 
 function isTrackableUrl(rawUrl) {
-  return !/^chrome:|^chrome-extension:|^about:|^edge:|^file:/i.test(rawUrl);
+  return !/^chrome:|^chrome-extension:|^moz-extension:|^about:|^edge:|^file:/i.test(rawUrl);
 }
 
 function sanitizeApiBaseUrl(value) {
@@ -523,10 +521,29 @@ function getTimezoneName() {
 
 function getExtensionVersion() {
   try {
-    return chrome.runtime.getManifest()?.version || "";
+    return browserApi.runtime.getManifest()?.version || "";
   } catch {
     return "";
   }
+}
+
+// isVersionOlder compares dotted numeric versions (e.g. "1.9" < "1.10").
+function isVersionOlder(current, latest) {
+  const toParts = (value) => String(value || "").split(".").map((part) => Number.parseInt(part, 10) || 0);
+  const a = toParts(current);
+  const b = toParts(latest);
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i += 1) {
+    const left = a[i] || 0;
+    const right = b[i] || 0;
+    if (left < right) {
+      return true;
+    }
+    if (left > right) {
+      return false;
+    }
+  }
+  return false;
 }
 
 function formatLocalDate(value = new Date()) {
@@ -555,29 +572,68 @@ function resolveDashboardUrl(state) {
   return toDashboardUrl(state.apiBaseUrl);
 }
 
+async function authorizedRequest(path, init) {
+  const state = await loadState();
+  if (!state.apiBaseUrl || !state.token) {
+    throw new Error("Extension belum terhubung. Hubungkan dari dashboard KANTOR atau gunakan setup manual.");
+  }
+
+  const response = await fetch(`${sanitizeApiBaseUrl(state.apiBaseUrl)}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${state.token}`,
+      ...(init?.headers || {}),
+    },
+  });
+
+  const payload = await response.json().catch(() => null);
+
+  if (response.status === 401) {
+    // The extension authenticates with a long-lived Personal Access Token; a 401
+    // means it was revoked or is invalid. There is nothing to refresh — prompt the
+    // user to reconnect from the dashboard.
+    await updateState({
+      lastError: "Sesi tracker berakhir. Hubungkan ulang dari dashboard KANTOR.",
+    });
+    throw new Error("UNAUTHORIZED: reconnect required");
+  }
+
+  if (!response.ok || !payload?.success) {
+    const code = payload?.error?.code || `HTTP_${response.status}`;
+    const message = payload?.error?.message || "Request failed";
+    throw new Error(`${code}: ${message}`);
+  }
+
+  return payload;
+}
+
 async function loadState() {
-  const [persistentState, sessionState] = await Promise.all([
-    chrome.storage.local.get(DEFAULT_STATE),
-    chrome.storage.session.get({ token: "" }),
-  ]);
-  return {
-    ...DEFAULT_STATE,
-    ...persistentState,
-    token: String(sessionState.token || ""),
-  };
+  const state = await browserApi.storage.local.get(DEFAULT_STATE);
+  return { ...DEFAULT_STATE, ...state };
 }
 
 async function saveState(nextState) {
-  const { token, ...persistentState } = nextState;
-  await Promise.all([
-    chrome.storage.local.set(persistentState),
-    chrome.storage.local.remove("token"),
-    chrome.storage.session.set({ token: String(token || "") }),
-  ]);
+  await browserApi.storage.local.set(nextState);
+}
+
+// All state mutations run through a single promise chain so concurrent
+// read-modify-write calls (heartbeat tick, message handlers) cannot clobber each
+// other (e.g. lose queued entries or the pause flag).
+let stateLock = Promise.resolve();
+
+function withStateLock(fn) {
+  const run = stateLock.then(fn, fn);
+  stateLock = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
 }
 
 async function updateState(partial) {
-  const current = await loadState();
-  await saveState({ ...current, ...partial });
+  await withStateLock(async () => {
+    const current = await loadState();
+    await saveState({ ...current, ...partial });
+  });
 }
-

--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -1,4 +1,5 @@
 (function () {
+  const browserApi = globalThis.browser ?? globalThis.chrome;
   const WEB_SOURCE = "KANTOR_WEB_APP";
   const EXTENSION_SOURCE = "KANTOR_TRACKER_EXTENSION";
   const SUPPORTED_TYPES = new Set(["KANTOR_TRACKER_PING", "KANTOR_TRACKER_CONNECT", "KANTOR_TRACKER_ENABLE"]);
@@ -91,7 +92,7 @@
   }
 
   async function sendRuntimeMessage(type, payload) {
-    return chrome.runtime.sendMessage({ type, payload });
+    return browserApi.runtime.sendMessage({ type, payload });
   }
 
   function postResult(requestId, success, payload, error) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "KANTOR Activity Tracker",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Track work activity for KANTOR platform",
   "permissions": ["tabs", "idle", "storage", "alarms"],
   "host_permissions": ["http://*/*", "https://*/*"],
@@ -13,7 +13,14 @@
     }
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "activity-tracker@kantor.local",
+      "strict_min_version": "115.0"
+    }
   },
   "action": {
     "default_popup": "popup/popup.html",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -19,7 +19,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "activity-tracker@kantor.local",
-      "strict_min_version": "115.0"
+      "strict_min_version": "121.0"
     }
   },
   "action": {

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -1,3 +1,5 @@
+const browserApi = globalThis.browser ?? globalThis.chrome;
+
 const elements = {
   apiUrl: document.getElementById("api-url"),
   token: document.getElementById("token"),
@@ -102,7 +104,7 @@ function escapeHtml(value) {
 }
 
 function sendMessage(type, payload = {}) {
-  return chrome.runtime.sendMessage({ type, payload }).then((response) => {
+  return browserApi.runtime.sendMessage({ type, payload }).then((response) => {
     if (!response) {
       throw new Error("Background extension tidak merespons.");
     }

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -45,7 +45,7 @@ function bindEvents() {
       new Set([...current.excludedDomains, elements.domainInput.value.trim().toLowerCase()].filter(Boolean)),
     );
     await sendMessage("tracker:set-options", {
-      idleTimeoutSeconds: Number(elements.idleTimeout.value || 300),
+      idleTimeoutSeconds: Number(elements.idleTimeout.value || 7200),
       excludedDomains: nextDomains,
     });
     elements.domainInput.value = "";
@@ -56,7 +56,7 @@ function bindEvents() {
 async function persistBehaviourSettings() {
   const current = await sendMessage("tracker:get-state");
   await sendMessage("tracker:set-options", {
-    idleTimeoutSeconds: Number(elements.idleTimeout.value || 300),
+    idleTimeoutSeconds: Number(elements.idleTimeout.value || 7200),
     excludedDomains: current.excludedDomains,
   });
 }
@@ -66,7 +66,7 @@ async function renderState(message = "") {
 
   elements.apiUrl.value = state.apiBaseUrl || "";
   elements.token.value = state.token || "";
-  elements.idleTimeout.value = String(state.idleTimeoutSeconds || 300);
+  elements.idleTimeout.value = String(state.idleTimeoutSeconds || 7200);
   elements.consentStatus.textContent = state.consented
     ? "Consent aktif. Extension boleh mengirim heartbeat ke platform."
     : "Consent belum aktif. Tracking tidak akan berjalan sebelum Anda menyetujuinya.";
@@ -86,7 +86,7 @@ async function renderState(message = "") {
     button.addEventListener("click", async () => {
       const nextDomains = (state.excludedDomains || []).filter((item) => item !== button.dataset.domain);
       await sendMessage("tracker:set-options", {
-        idleTimeoutSeconds: Number(elements.idleTimeout.value || 300),
+        idleTimeoutSeconds: Number(elements.idleTimeout.value || 7200),
         excludedDomains: nextDomains,
       });
       await renderState("Domain berhasil dihapus dari exclusion list.");

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -18,6 +18,8 @@
         </button>
       </header>
 
+      <p class="update-banner hidden" id="update-banner" style="margin:0 0 8px;padding:8px 10px;border-radius:8px;background:#FFF7E6;color:#8A5A00;font-size:12px;line-height:1.4;"></p>
+
       <section id="setup-state" class="state-card hidden">
         <h2>Hubungkan extension</h2>
         <p>Untuk user biasa, tidak perlu isi token atau konfigurasi apa pun di sini.</p>

--- a/extension/popup/popup.js
+++ b/extension/popup/popup.js
@@ -1,4 +1,7 @@
+const browserApi = globalThis.browser ?? globalThis.chrome;
+
 const elements = {
+  updateBanner: document.getElementById("update-banner"),
   setupState: document.getElementById("setup-state"),
   consentState: document.getElementById("consent-state"),
   trackerState: document.getElementById("tracker-state"),
@@ -94,7 +97,7 @@ function bindEvents() {
   });
 
   elements.openSettingsButton.addEventListener("click", () => {
-    chrome.runtime.openOptionsPage();
+    browserApi.runtime.openOptionsPage();
   });
 }
 
@@ -125,6 +128,15 @@ function render(state) {
     showError(state.lastError);
   } else {
     elements.errorBanner.classList.add("hidden");
+  }
+
+  if (elements.updateBanner) {
+    if (state.updateAvailable) {
+      elements.updateBanner.textContent = `Versi baru extension (${state.latestVersion}) tersedia. Download ulang dari dashboard KANTOR.`;
+      elements.updateBanner.classList.remove("hidden");
+    } else {
+      elements.updateBanner.classList.add("hidden");
+    }
   }
 
   renderTrackerState(state);
@@ -189,7 +201,7 @@ function showError(message) {
 }
 
 function sendMessage(type, payload = {}) {
-  return chrome.runtime.sendMessage({ type, payload }).then((response) => {
+  return browserApi.runtime.sendMessage({ type, payload }).then((response) => {
     if (!response) {
       throw new Error("Extension background did not respond");
     }

--- a/frontend/src/routes/_authenticated/operational/tracker.tsx
+++ b/frontend/src/routes/_authenticated/operational/tracker.tsx
@@ -57,6 +57,7 @@ import {
   createTrackerDomain,
   deleteTrackerDomain,
   downloadTrackerExtension,
+  getTrackerExtensionStatus,
   getMyTrackerActivity,
   getTeamTrackerActivity,
   getTrackerConsent,
@@ -172,6 +173,10 @@ function OperationalTrackerPage() {
   const consentQuery = useQuery({
     queryKey: trackerKeys.consent(),
     queryFn: getTrackerConsent,
+  });
+  const extensionStatusQuery = useQuery({
+    queryKey: trackerKeys.extensionStatus(),
+    queryFn: getTrackerExtensionStatus,
   });
   const myActivityQuery = useQuery({
     queryKey: trackerKeys.myActivity(dateFrom, dateTo),
@@ -668,6 +673,21 @@ function OperationalTrackerPage() {
 
   return (
     <div className="space-y-6">
+      {extensionStatusQuery.data?.needs_update ? (
+        <div className="flex flex-col gap-3 rounded-md border border-warning/40 bg-warning/10 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="text-sm text-text-primary">
+            <p className="font-semibold">Versi extension baru tersedia (v{extensionStatusQuery.data.latest_version}).</p>
+            <p className="text-text-secondary">
+              Extension kamu (v{extensionStatusQuery.data.reported_version || "?"}) sudah usang. Download & pasang ulang
+              versi terbaru, lalu klik "Sinkronkan Browser" untuk menghubungkan kembali.
+            </p>
+          </div>
+          <Button type="button" onClick={() => void handleExtensionDownload()} disabled={isDownloadingExtension}>
+            <Download className="h-4 w-4" />
+            {isDownloadingExtension ? "Mengunduh..." : "Download versi terbaru"}
+          </Button>
+        </div>
+      ) : null}
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.08em] text-ops">Operasional</p>

--- a/frontend/src/services/operational-tracker.ts
+++ b/frontend/src/services/operational-tracker.ts
@@ -41,7 +41,18 @@ export const trackerKeys = {
   consents: () => ["operational", "tracker", "consents"] as const,
   domains: () => ["operational", "tracker", "domains"] as const,
   observedDomains: () => ["operational", "tracker", "observed-domains"] as const,
+  extensionStatus: () => ["operational", "tracker", "extension-status"] as const,
 };
+
+export type ExtensionStatus = {
+  latest_version: string;
+  reported_version: string;
+  needs_update: boolean;
+};
+
+export async function getTrackerExtensionStatus() {
+  return authGetJSON<ExtensionStatus>("/tracker/extension/status");
+}
 
 export async function getTrackerConsent() {
   return authGetJSON<ActivityConsent>("/tracker/consent");


### PR DESCRIPTION
Extension v2. Users reinstall once for all of this.

**Reliability (closes #130)**
- PAT stored in `storage.local` (survives browser restart)
- state writes serialized through a lock (no lost queue/pause under concurrency)
- offline queue cap raised to 5000; `navigator.onLine` treated as a hint
- dead `/auth/refresh`-on-401 path dropped (PAT can't refresh) → prompts reconnect
- queued beats re-stamped to the current session on flush (no drops after a session closes)

**Firefox / cross-browser (closes #129)**
- single `browserApi = browser ?? chrome` namespace across all scripts
- manifest: gecko settings + dual `service_worker`/`scripts` background → one build runs on Chrome + Firefox
- bumped to `2.0.0`

**Version awareness (new requirement)**
- `GET /tracker/extension/status` → `{latest_version, reported_version, needs_update}` (latest read from the bundled manifest)
- dashboard shows a re-download banner when the installed extension is outdated
- popup self-checks and shows an update banner

Verified: backend build + tests green, frontend build green, endpoint returns latest 2.0.0 / needs_update at runtime.

**Note:** I can implement + Chrome-test here, but real Firefox testing needs someone to load it as a temporary add-on. Safari (#127) is a separate track (needs macOS + Xcode).