### PR TITLE
ci(deploy): exclude wa-bot tenant input from the covertplay build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,6 +119,7 @@ jobs:
             --override-input saas-boilerplate path:/tmp/nix-config \
             --override-input segmenter path:/tmp/nix-config \
             --override-input segmenter-s52ai path:/tmp/nix-config \
+            --override-input wa-bot path:/tmp/nix-config \
             --print-out-paths --no-link)
           echo "path=$SYSTEM" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Fixes the red `build` job on every merge to main.

**Root cause:** the fleet build evaluates `nixosConfigurations.lp-covertplay`, and clan passes every nix-config flake input as a `specialArg`. A newly-added tenant input `KeyCode17/wa-bot` is fetched over SSH (`ssh://git@github.com/KeyCode17/wa-bot`) during eval, but this CI has no key for it → `Permission denied (publickey)`.

lp-covertplay does **not** deploy wa-bot — it's the same class of stray input as `saas-boilerplate`/`segmenter`/`segmenter-s52ai`, which are already overridden to the cloned nix-config path so eval never fetches them. This adds the one matching override line.

PR checks (backend-tests, frontend-build) are unaffected — the `build` job is main-only.