### PR TITLE
fix(extension): Chrome-valid manifest (per-browser background)

### DIFF
--- a/backend/internal/handler/operational/tracker.go
+++ b/backend/internal/handler/operational/tracker.go
@@ -221,7 +221,7 @@ func (h *TrackerHandler) getMyActivity(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *TrackerHandler) downloadExtension(w http.ResponseWriter, r *http.Request) {
-	archiveBytes, filename, err := h.service.BuildExtensionArchive(r.Context())
+	archiveBytes, filename, err := h.service.BuildExtensionArchive(r.Context(), r.URL.Query().Get("browser"))
 	if err != nil {
 		slog.ErrorContext(r.Context(), "failed to build extension archive", "error", err)
 		response.WriteError(w, http.StatusInternalServerError, "TRACKER_EXTENSION_UNAVAILABLE", "Tracker extension package is not available right now", nil)

--- a/backend/internal/service/operational/tracker_extension.go
+++ b/backend/internal/service/operational/tracker_extension.go
@@ -101,7 +101,11 @@ func parseVersionParts(version string) []int {
 	return parts
 }
 
-func (s *TrackerService) BuildExtensionArchive(ctx context.Context) ([]byte, string, error) {
+// BuildExtensionArchive zips the bundled extension. The base manifest targets
+// Chromium (background.service_worker); for browser=="firefox" the manifest is
+// rewritten to a background.scripts event page, since Firefox does not support
+// service workers and Chrome rejects background.scripts in MV3.
+func (s *TrackerService) BuildExtensionArchive(ctx context.Context, browser string) ([]byte, string, error) {
 	extensionDir, err := resolveExtensionDir()
 	if err != nil {
 		slog.ErrorContext(ctx, "failed to resolve extension directory", "error", err)
@@ -131,6 +135,22 @@ func (s *TrackerService) BuildExtensionArchive(ctx context.Context) ([]byte, str
 			return fmt.Errorf("create zip entry %s: %w", zipPath, err)
 		}
 
+		// Rewrite the manifest for Firefox instead of copying it verbatim.
+		if zipPath == "manifest.json" && strings.EqualFold(browser, "firefox") {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("read manifest for firefox: %w", err)
+			}
+			transformed, err := firefoxManifest(raw)
+			if err != nil {
+				return fmt.Errorf("rewrite manifest for firefox: %w", err)
+			}
+			if _, err := writer.Write(transformed); err != nil {
+				return fmt.Errorf("write firefox manifest: %w", err)
+			}
+			return nil
+		}
+
 		file, err := os.Open(path)
 		if err != nil {
 			return fmt.Errorf("open extension file %s: %w", path, err)
@@ -152,7 +172,22 @@ func (s *TrackerService) BuildExtensionArchive(ctx context.Context) ([]byte, str
 		return nil, "", fmt.Errorf("finalize tracker extension archive: %w", err)
 	}
 
-	return buffer.Bytes(), "kantor-activity-tracker.zip", nil
+	filename := "kantor-activity-tracker.zip"
+	if strings.EqualFold(browser, "firefox") {
+		filename = "kantor-activity-tracker-firefox.zip"
+	}
+	return buffer.Bytes(), filename, nil
+}
+
+// firefoxManifest rewrites the Chromium manifest's background key to a Firefox
+// event page (background.scripts), leaving everything else untouched.
+func firefoxManifest(raw []byte) ([]byte, error) {
+	var manifest map[string]any
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return nil, err
+	}
+	manifest["background"] = map[string]any{"scripts": []string{"background.js"}}
+	return json.MarshalIndent(manifest, "", "  ")
 }
 
 func resolveExtensionDir() (string, error) {

--- a/backend/internal/service/operational/tracker_extension_test.go
+++ b/backend/internal/service/operational/tracker_extension_test.go
@@ -1,6 +1,38 @@
 package operational
 
-import "testing"
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFirefoxManifestRewritesBackground(t *testing.T) {
+	raw := []byte(`{"manifest_version":3,"version":"2.0.1","background":{"service_worker":"background.js"},"permissions":["idle"]}`)
+	out, err := firefoxManifest(raw)
+	if err != nil {
+		t.Fatalf("firefoxManifest: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(out, &m); err != nil {
+		t.Fatalf("output not valid json: %v", err)
+	}
+	bg, ok := m["background"].(map[string]any)
+	if !ok {
+		t.Fatalf("background missing/invalid: %v", m["background"])
+	}
+	if _, hasSW := bg["service_worker"]; hasSW {
+		t.Error("firefox manifest must not keep background.service_worker (Chrome-only)")
+	}
+	scripts, ok := bg["scripts"].([]any)
+	if !ok || len(scripts) != 1 || scripts[0] != "background.js" {
+		t.Errorf("expected background.scripts=[background.js], got %v", bg["scripts"])
+	}
+	if m["version"] != "2.0.1" {
+		t.Errorf("version must be preserved, got %v", m["version"])
+	}
+	if m["permissions"] == nil {
+		t.Error("other keys must be preserved")
+	}
+}
 
 func TestIsExtensionVersionOlder(t *testing.T) {
 	tests := []struct {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "KANTOR Activity Tracker",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Track work activity for KANTOR platform",
   "permissions": ["tabs", "idle", "storage", "alarms"],
   "host_permissions": ["http://*/*", "https://*/*"],
@@ -13,8 +13,7 @@
     }
   ],
   "background": {
-    "service_worker": "background.js",
-    "scripts": ["background.js"]
+    "service_worker": "background.js"
   },
   "browser_specific_settings": {
     "gecko": {

--- a/frontend/src/routes/_authenticated/operational/tracker.tsx
+++ b/frontend/src/routes/_authenticated/operational/tracker.tsx
@@ -439,10 +439,10 @@ function OperationalTrackerPage() {
     }
   }
 
-  async function handleExtensionDownload() {
+  async function handleExtensionDownload(browser: "chrome" | "firefox" = "chrome") {
     setIsDownloadingExtension(true);
     try {
-      const result = await downloadTrackerExtension();
+      const result = await downloadTrackerExtension(browser);
       const url = window.URL.createObjectURL(result.blob);
       const anchor = document.createElement("a");
       anchor.href = url;
@@ -451,7 +451,12 @@ function OperationalTrackerPage() {
       anchor.click();
       anchor.remove();
       window.URL.revokeObjectURL(url);
-      toast.success("Extension berhasil diunduh", "Extract file ZIP lalu pasang extension lewat chrome://extensions.");
+      toast.success(
+        "Extension berhasil diunduh",
+        browser === "firefox"
+          ? "Extract ZIP, lalu pasang lewat about:debugging → Load Temporary Add-on (pilih manifest.json)."
+          : "Extract file ZIP lalu pasang extension lewat chrome://extensions.",
+      );
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Gagal mengunduh extension tracker");
     } finally {
@@ -697,9 +702,13 @@ function OperationalTrackerPage() {
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
-          <Button type="button" variant="outline" onClick={() => void handleExtensionDownload()} disabled={isDownloadingExtension}>
+          <Button type="button" variant="outline" onClick={() => void handleExtensionDownload("chrome")} disabled={isDownloadingExtension}>
             <Download className="h-4 w-4" />
-            {isDownloadingExtension ? "Mengunduh..." : "Download Extension"}
+            {isDownloadingExtension ? "Mengunduh..." : "Download (Chrome)"}
+          </Button>
+          <Button type="button" variant="outline" onClick={() => void handleExtensionDownload("firefox")} disabled={isDownloadingExtension}>
+            <Download className="h-4 w-4" />
+            Download (Firefox)
           </Button>
           <Button
             type="button"

--- a/frontend/src/services/operational-tracker.ts
+++ b/frontend/src/services/operational-tracker.ts
@@ -100,8 +100,9 @@ export async function listObservedTrackerDomains() {
   return authGetJSON<TrackerObservedDomain[]>("/tracker/domains/observed");
 }
 
-export async function downloadTrackerExtension() {
-  return authDownload("/tracker/extension/download", {
+export async function downloadTrackerExtension(browser?: "chrome" | "firefox") {
+  const query = browser === "firefox" ? "?browser=firefox" : "";
+  return authDownload(`/tracker/extension/download${query}`, {
     method: "GET",
   });
 }


### PR DESCRIPTION
**Hotfix for #135.** v2.0.0 shipped a manifest with both `background.service_worker` and `background.scripts`. Chrome MV3 **rejects** `background.scripts` (`'background.scripts' requires manifest version of 2 or lower`), so the service worker never registered and the extension showed **'belum terdeteksi'** / didn't run.

Fix:
- bundled manifest targets Chrome (`service_worker` only)
- `GET /tracker/extension/download?browser=firefox` rewrites the manifest to a Firefox event page (`background.scripts`) — Firefox has no service workers
- dashboard offers separate **Download (Chrome)** / **Download (Firefox)** buttons
- bumped to **2.0.1** so the update banner nudges broken 2.0.0 installs to re-download

Verified at runtime: Chrome zip = `{service_worker}`, Firefox zip = `{scripts}`, both v2.0.1. Backend build+tests + frontend build green.