### PR TITLE
feat(projects): scope projects to member/creator for non-super-admins

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -478,8 +478,8 @@ func (a *App) buildRouter(
 					module.With(platformmiddleware.RequirePermission("operational:project:view")).Get("/overview", operationalOverviewHandler.Get)
 
 					module.Route("/projects", projectsHandler.RegisterRoutes)
-					module.Route("/projects/{projectID}/columns", kanbanHandler.RegisterColumnRoutes)
-					module.Route("/projects/{projectID}/tasks", kanbanHandler.RegisterTaskRoutes)
+					module.With(projectsHandler.RequireProjectAccess).Route("/projects/{projectID}/columns", kanbanHandler.RegisterColumnRoutes)
+					module.With(projectsHandler.RequireProjectAccess).Route("/projects/{projectID}/tasks", kanbanHandler.RegisterTaskRoutes)
 					module.Route("/vps", vpsHandler.RegisterRoutes)
 					module.Route("/domains", domainHandler.RegisterRoutes)
 				})

--- a/backend/internal/handler/operational/projects.go
+++ b/backend/internal/handler/operational/projects.go
@@ -48,11 +48,41 @@ func (h *ProjectsHandler) RegisterRoutes(router chi.Router) {
 	router.With(platformmiddleware.RequirePermission("operational:project:view")).Get("/", h.listProjects)
 	router.With(platformmiddleware.RequirePermission("operational:project:view")).Get("/export", h.exportList)
 	router.With(platformmiddleware.RequirePermission("operational:project:view")).Get("/available-users", h.listAvailableUsers)
-	router.With(platformmiddleware.RequirePermission("operational:project:view")).Get("/{projectID}", h.getProject)
-	router.With(platformmiddleware.RequirePermission("operational:project:view")).Get("/{projectID}/export", h.exportDetail)
-	router.With(platformmiddleware.RequirePermission("operational:project:edit")).Put("/{projectID}", h.updateProject)
-	router.With(platformmiddleware.RequirePermission("operational:project:delete")).Delete("/{projectID}", h.deleteProject)
-	router.With(platformmiddleware.RequirePermission("operational:project:manage_members")).Post("/{projectID}/members", h.mutateMembers)
+	router.With(platformmiddleware.RequirePermission("operational:project:view"), h.RequireProjectAccess).Get("/{projectID}", h.getProject)
+	router.With(platformmiddleware.RequirePermission("operational:project:view"), h.RequireProjectAccess).Get("/{projectID}/export", h.exportDetail)
+	router.With(platformmiddleware.RequirePermission("operational:project:edit"), h.RequireProjectAccess).Put("/{projectID}", h.updateProject)
+	router.With(platformmiddleware.RequirePermission("operational:project:delete"), h.RequireProjectAccess).Delete("/{projectID}", h.deleteProject)
+	router.With(platformmiddleware.RequirePermission("operational:project:manage_members"), h.RequireProjectAccess).Post("/{projectID}/members", h.mutateMembers)
+}
+
+// RequireProjectAccess blocks a non-super-admin from reaching a project they are
+// neither a member of nor the creator of. Super admins pass through.
+func (h *ProjectsHandler) RequireProjectAccess(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+		if !ok {
+			response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+			return
+		}
+		if principal.IsSuperAdmin {
+			next.ServeHTTP(w, r)
+			return
+		}
+		projectID, ok := validateProjectIDParam(w, chi.URLParam(r, "projectID"))
+		if !ok {
+			return
+		}
+		allowed, err := h.repo.IsProjectMemberOrCreator(r.Context(), projectID, principal.UserID)
+		if err != nil {
+			response.WriteInternalError(r.Context(), w, err, "Failed to verify project access")
+			return
+		}
+		if !allowed {
+			response.WriteError(w, http.StatusForbidden, "FORBIDDEN", "You do not have access to this project", nil)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (h *ProjectsHandler) createProject(w http.ResponseWriter, r *http.Request) {
@@ -83,7 +113,13 @@ func (h *ProjectsHandler) listProjects(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	projects, total, page, perPage, err := h.service.ListProjects(r.Context(), query)
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+		return
+	}
+
+	projects, total, page, perPage, err := h.service.ListProjects(r.Context(), query, principal.UserID, !principal.IsSuperAdmin)
 	if err != nil {
 		h.writeError(r.Context(), w, err)
 		return

--- a/backend/internal/handler/operational/projects_export.go
+++ b/backend/internal/handler/operational/projects_export.go
@@ -23,7 +23,13 @@ func (h *ProjectsHandler) exportList(w http.ResponseWriter, r *http.Request) {
 	query.Page = 1
 	query.PerPage = 10000
 
-	items, _, _, _, err := h.service.ListProjects(r.Context(), query)
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+		return
+	}
+
+	items, _, _, _, err := h.service.ListProjects(r.Context(), query, principal.UserID, !principal.IsSuperAdmin)
 	if err != nil {
 		h.writeError(r.Context(), w, err)
 		return

--- a/backend/internal/repository/operational/projects.go
+++ b/backend/internal/repository/operational/projects.go
@@ -26,6 +26,10 @@ type ListProjectsParams struct {
 	Search   string
 	Status   string
 	Priority string
+	// RestrictToRequester limits the result to projects the requester is a member
+	// of or created. Left false for super admins (who see every project).
+	RestrictToRequester bool
+	RequesterID         string
 }
 
 type CreateProjectParams struct {
@@ -129,6 +133,15 @@ func (r *ProjectsRepository) ListProjects(ctx context.Context, params ListProjec
 		index++
 	}
 
+	if params.RestrictToRequester {
+		filters = append(filters, fmt.Sprintf(
+			"(EXISTS (SELECT 1 FROM project_members pm WHERE pm.project_id = projects.id AND pm.user_id = $%d::uuid) OR projects.created_by = $%d::uuid)",
+			index, index,
+		))
+		args = append(args, params.RequesterID)
+		index++
+	}
+
 	whereClause := strings.Join(filters, " AND ")
 
 	countQuery := fmt.Sprintf(`SELECT COUNT(*) FROM projects WHERE %s`, whereClause)
@@ -192,6 +205,23 @@ func (r *ProjectsRepository) ListProjects(ctx context.Context, params ListProjec
 	}
 
 	return projects, total, nil
+}
+
+// IsProjectMemberOrCreator reports whether the user is a member of, or the
+// creator of, the given project. Used to gate per-project access for non-super
+// admins so they can only reach projects assigned to or owned by them.
+func (r *ProjectsRepository) IsProjectMemberOrCreator(ctx context.Context, projectID string, userID string) (bool, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var allowed bool
+	if err := repository.DB(ctx, r.db).QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM project_members WHERE project_id = $1::uuid AND user_id = $2::uuid)
+		    OR EXISTS (SELECT 1 FROM projects WHERE id = $1::uuid AND created_by = $2::uuid)
+	`, projectID, userID).Scan(&allowed); err != nil {
+		return false, err
+	}
+	return allowed, nil
 }
 
 func (r *ProjectsRepository) GetProjectByID(ctx context.Context, projectID string) (model.Project, error) {

--- a/backend/internal/service/operational/projects.go
+++ b/backend/internal/service/operational/projects.go
@@ -105,7 +105,7 @@ func (s *ProjectsService) CreateProject(ctx context.Context, request operational
 	return s.GetProject(ctx, project.ID)
 }
 
-func (s *ProjectsService) ListProjects(ctx context.Context, query operational.ListProjectsQuery) ([]model.Project, int64, int, int, error) {
+func (s *ProjectsService) ListProjects(ctx context.Context, query operational.ListProjectsQuery, requesterID string, restrictToRequester bool) ([]model.Project, int64, int, int, error) {
 	page := query.Page
 	if page <= 0 {
 		page = 1
@@ -117,11 +117,13 @@ func (s *ProjectsService) ListProjects(ctx context.Context, query operational.Li
 	}
 
 	projects, total, err := s.repo.ListProjects(ctx, operationalrepo.ListProjectsParams{
-		Page:     page,
-		PerPage:  perPage,
-		Search:   strings.TrimSpace(query.Search),
-		Status:   query.Status,
-		Priority: query.Priority,
+		Page:                page,
+		PerPage:             perPage,
+		Search:              strings.TrimSpace(query.Search),
+		Status:              query.Status,
+		Priority:            query.Priority,
+		RestrictToRequester: restrictToRequester,
+		RequesterID:         requesterID,
 	})
 	if err != nil {
 		return nil, 0, 0, 0, err


### PR DESCRIPTION
Non-super-admin users now only see projects **assigned to them or created by them** — they no longer appear in the list, and any direct access returns 403.

- **List/export** (`GET /operational/projects`, `/export`): query scoped to `project_members` OR `created_by` for non-super-admins.
- **Per-project access** (`RequireProjectAccess` middleware): `getProject`, export detail, update, delete, members, and the **kanban column/task** routes return 403 for non-members.
- **Super admins** keep full access to every project.

Verified end-to-end (non-super-admin viewer): list returns only their 1 project, own project + tasks + columns = 200, other project + tasks = 403; super admin sees all 4 + full access.