### PR TITLE
fix(mcp): bound tool responses to prevent context overload

### DIFF
--- a/backend/internal/mcp/catalog.go
+++ b/backend/internal/mcp/catalog.go
@@ -28,13 +28,20 @@ var excludedSuffixes = []string{
 	"/auth/change-password",
 	"/notifications/stream",
 	"/health",
+	// Binary / full-dataset endpoints are useless (and huge) as text for an AI
+	// client, and export endpoints force per_page=10000 — a fast way to blow up
+	// the context window. Keep them off the tool surface.
+	"/export",
+	"/extension/download",
 }
 
 // excludedContains drops credential and OAuth self-management endpoints: an AI
-// client must not mint or revoke its own tokens or approve OAuth grants.
+// client must not mint or revoke its own tokens or approve OAuth grants. It also
+// drops file-serving routes, which return binary blobs.
 var excludedContains = []string{
 	"/auth/pat",
 	"/oauth",
+	"/files/",
 }
 
 // BuildCatalog derives the MCP tool surface from the live chi route table, so it

--- a/backend/internal/mcp/dispatch.go
+++ b/backend/internal/mcp/dispatch.go
@@ -79,6 +79,10 @@ func (t ToolSpec) buildRequest(ctx context.Context, baseURL string, args map[str
 		}
 	}
 
+	if t.Meta != nil && t.Meta.Paginated {
+		clampPerPage(query, t.Meta.PerPageMax)
+	}
+
 	target := baseURL + path
 	if encoded := query.Encode(); encoded != "" {
 		target += "?" + encoded
@@ -114,6 +118,30 @@ func (t ToolSpec) buildRequest(ctx context.Context, baseURL string, args map[str
 // as float64, so integers must render without scientific notation/decimals, and
 // arrays become repeated keys (?k=a&k=b). fmt.Sprintf("%v") mangled all of these
 // (e.g. a large per_page -> "1e+06", an array -> "[a b]"), corrupting filters.
+// mcpPerPageCap is the hard upper bound MCP allows for per_page, so an AI client
+// cannot pull an entire table in one call (some endpoints have no server-side cap).
+const mcpPerPageCap = 100
+
+// clampPerPage limits an AI-supplied per_page, using the endpoint's own max when
+// known, else the global MCP cap.
+func clampPerPage(query url.Values, endpointMax int) {
+	limit := mcpPerPageCap
+	if endpointMax > 0 && endpointMax < limit {
+		limit = endpointMax
+	}
+	raw := query.Get("per_page")
+	if raw == "" {
+		return
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return
+	}
+	if n > limit {
+		query.Set("per_page", strconv.Itoa(limit))
+	}
+}
+
 func addQueryValue(query url.Values, key string, value interface{}) {
 	switch v := value.(type) {
 	case nil:

--- a/backend/internal/mcp/hardening_test.go
+++ b/backend/internal/mcp/hardening_test.go
@@ -1,0 +1,94 @@
+package mcp
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestBuildCatalogExcludesExportAndBinary(t *testing.T) {
+	router := chi.NewRouter()
+	h := noopHandler()
+	router.Route("/api/v1", func(api chi.Router) {
+		api.Get("/hris/employees", h)
+		api.Get("/hris/employees/export", h)
+		api.Get("/marketing/leads/export", h)
+		api.Get("/tracker/extension/download", h)
+		api.Get("/files/{type}/{id}/{filename}", h)
+	})
+
+	tools, err := BuildCatalog(router)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	names := map[string]bool{}
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	if !names["get_hris_employees"] {
+		t.Error("expected get_hris_employees to be present")
+	}
+	for _, excluded := range []string{
+		"get_hris_employees_export",
+		"get_marketing_leads_export",
+		"get_tracker_extension_download",
+		"get_files_type_id_filename",
+	} {
+		if names[excluded] {
+			t.Errorf("expected %q to be excluded from the tool surface", excluded)
+		}
+	}
+}
+
+func TestClampPerPage(t *testing.T) {
+	tests := []struct {
+		name        string
+		perPage     string
+		endpointMax int
+		want        string
+	}{
+		{"over global cap", "10000", 0, "100"},
+		{"over endpoint max", "500", 100, "100"},
+		{"under cap unchanged", "20", 100, "20"},
+		{"tighter endpoint max", "80", 50, "50"},
+		{"absent unchanged", "", 0, ""},
+		{"non-numeric unchanged", "abc", 0, "abc"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			q := url.Values{}
+			if tc.perPage != "" {
+				q.Set("per_page", tc.perPage)
+			}
+			clampPerPage(q, tc.endpointMax)
+			if got := q.Get("per_page"); got != tc.want {
+				t.Errorf("per_page = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBoundToolText(t *testing.T) {
+	small := []byte(`{"ok":true}`)
+	if got := boundToolText(small); got != string(small) {
+		t.Errorf("small body should pass through, got %q", got)
+	}
+
+	big := make([]byte, maxToolResponseBytes+5000)
+	for i := range big {
+		big[i] = 'x'
+	}
+	out := boundToolText(big)
+	if len(out) <= maxToolResponseBytes {
+		// truncated body + appended note; note makes it a bit longer than the cap
+		t.Errorf("expected truncated output with a note, len=%d", len(out))
+	}
+	if !strings.Contains(out, "truncated") {
+		t.Error("truncated output must include a note guiding the client to paginate/filter")
+	}
+	if strings.Count(out, "x") > maxToolResponseBytes {
+		t.Error("payload portion must be capped at maxToolResponseBytes")
+	}
+}

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -110,8 +110,21 @@ func (s *Server) callTool(ctx context.Context, req request, authHeader string, h
 
 	return newResult(req.ID, map[string]interface{}{
 		"content": []map[string]interface{}{
-			{"type": "text", "text": string(body)},
+			{"type": "text", "text": boundToolText(body)},
 		},
 		"isError": status >= 400,
 	})
+}
+
+// maxToolResponseBytes caps a single tool result so one over-broad query cannot
+// blow up the AI client's context window (which surfaces as upstream 529
+// "Overloaded" errors). Clients should paginate / filter instead.
+const maxToolResponseBytes = 100 * 1024
+
+func boundToolText(body []byte) string {
+	if len(body) <= maxToolResponseBytes {
+		return string(body)
+	}
+	return string(body[:maxToolResponseBytes]) +
+		"\n\n[response truncated at 100KB — narrow it with query filters or a smaller per_page, then page through the rest]"
 }


### PR DESCRIPTION
The MCP tools returned unbounded data, which blew up the AI client's context and surfaced as upstream 529 **Overloaded** errors.

- **Exclude export/binary endpoints** (`/export`, `/extension/download`, `/files/`) from the tool surface — they force `per_page=10000` / return binaries, useless (and huge) as text.
- **Clamp `per_page`** to 100 (or the endpoint's own max) so a paginated tool can't pull a whole table in one call — the AI paginates instead (Karyudi: *"jangan dikasih semua, dibagi, biar AI-nya yang nentuin"*).
- **Cap a single tool result at 100KB** with a note guiding the client to filter/paginate.

Verified at runtime (via /mcp): tools/list drops all 12 export/download/file tools (204 vs 216); `get_hris_employees` with `per_page=10000` returns clamped to 100. Unit tests cover exclusion, clamp, and the size cap.