### PR TITLE
feat(profile): expose personal access token management to all users

### DIFF
--- a/frontend/src/routes/_authenticated/admin/settings.tsx
+++ b/frontend/src/routes/_authenticated/admin/settings.tsx
@@ -25,7 +25,6 @@ import {
 } from "@/services/admin-rbac";
 import { toast } from "@/stores/toast-store";
 import { PolicySettingsCard } from "@/components/compensation-policy/policy-settings-card";
-import { TokenManagerCard } from "@/components/personal-access-tokens/token-manager-card";
 
 export const Route = createFileRoute("/_authenticated/admin/settings")({
   beforeLoad: async () => {
@@ -1068,7 +1067,6 @@ function AdminSettingsPage() {
         {hasPermission(permissions.hrisCompensationPolicyView) ? (
           <PolicySettingsCard />
         ) : null}
-        <TokenManagerCard />
       </div>
     </div>
   );

--- a/frontend/src/routes/_authenticated/profile.tsx
+++ b/frontend/src/routes/_authenticated/profile.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import { z } from "zod";
 
+import { TokenManagerCard } from "@/components/personal-access-tokens/token-manager-card";
 import { FormModal } from "@/components/shared/form-modal";
 import { ProtectedAvatar } from "@/components/shared/protected-avatar";
 import { Button } from "@/components/ui/button";
@@ -435,6 +436,8 @@ function ProfilePage() {
           </Button>
         </div>
       </div>
+
+      <TokenManagerCard />
 
       <FormModal
         error={changePasswordMutation.error instanceof ApiError ? changePasswordMutation.error.message : null}


### PR DESCRIPTION
## Summary
- Moves Personal Access Token ("Access Token (MCP)") management from the admin-only Settings page to the user's own Profile page, so any authenticated employee can self-serve a token to connect the KANTOR MCP (e.g. kantor-bot).
- The PAT REST API is already scoped to the authenticated user (not admin-only); this was purely a frontend placement issue — `TokenManagerCard` manages the current user's own tokens and takes no props.
- Removes the now-duplicate `<TokenManagerCard />` render and its import from `admin/settings.tsx` to avoid showing it twice.

## Changes
- `frontend/src/routes/_authenticated/profile.tsx`: import and render `<TokenManagerCard />` as a new section, placed after the "Keamanan Akun" (account security / password) section.
- `frontend/src/routes/_authenticated/admin/settings.tsx`: remove the `TokenManagerCard` import and render.

Frontend-only change; no backend/Go changes.

## Test plan
- [x] `npm run build` passes with no errors
- [x] `eslint` clean on both changed files
- [x] Verified no dangling references to `TokenManagerCard` in `admin/settings.tsx`
- [ ] Manual smoke test: log in as a non-admin employee, visit Profile, confirm the Access Token (MCP) card renders and create/revoke works