### PR TITLE
feat(operational): self-scoped GET /operational/tasks/mine

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -480,6 +480,7 @@ func (a *App) buildRouter(
 					module.Route("/projects", projectsHandler.RegisterRoutes)
 					module.With(projectsHandler.RequireProjectAccess).Route("/projects/{projectID}/columns", kanbanHandler.RegisterColumnRoutes)
 					module.With(projectsHandler.RequireProjectAccess).Route("/projects/{projectID}/tasks", kanbanHandler.RegisterTaskRoutes)
+					module.With(platformmiddleware.RequirePermission("operational:task:view")).Get("/tasks/mine", kanbanHandler.ListMyTasks)
 					module.Route("/vps", vpsHandler.RegisterRoutes)
 					module.Route("/domains", domainHandler.RegisterRoutes)
 				})

--- a/backend/internal/dto/operational/kanban.go
+++ b/backend/internal/dto/operational/kanban.go
@@ -40,3 +40,15 @@ type MoveKanbanTaskRequest struct {
 	ColumnID string `json:"column_id" validate:"required,uuid4"`
 	Position int    `json:"position" validate:"required,min=1"`
 }
+
+// MyTaskItem is a cross-project task assigned to the calling user.
+type MyTaskItem struct {
+	TaskID      string `json:"task_id"`
+	Title       string `json:"title"`
+	ProjectID   string `json:"project_id"`
+	ProjectName string `json:"project_name"`
+	ColumnName  string `json:"column_name"`
+	Status      string `json:"status"`
+	DueDate     string `json:"due_date"`
+	Priority    string `json:"priority"`
+}

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -188,6 +188,24 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 	response.WriteJSON(w, http.StatusOK, result, nil)
 }
 
+// ListMyTasks handles GET /operational/tasks/mine, self-scoped to the caller.
+func (h *KanbanHandler) ListMyTasks(w http.ResponseWriter, r *http.Request) {
+	principal, ok := platformmiddleware.PrincipalFromContext(r.Context())
+	if !ok {
+		response.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Authenticated principal is missing", nil)
+		return
+	}
+
+	status := strings.TrimSpace(r.URL.Query().Get("status"))
+	result, err := h.service.ListMyTasks(r.Context(), principal.UserID, status)
+	if err != nil {
+		h.writeError(r.Context(), w, err)
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, result, nil)
+}
+
 func (h *KanbanHandler) updateTask(w http.ResponseWriter, r *http.Request) {
 	projectID, ok := validateKanbanUUIDParam(w, "projectID", chi.URLParam(r, "projectID"))
 	if !ok {

--- a/backend/internal/mcp/annotations.go
+++ b/backend/internal/mcp/annotations.go
@@ -130,6 +130,10 @@ var endpointAnnotations = map[string]EndpointMeta{
 			qs("search", "Free-text search."),
 		},
 	},
+	"GET /api/v1/operational/tasks/mine": {
+		Description: "Your assigned tasks across all projects (status: open/done/overdue). Self-scoped to the caller.",
+		Query:       []QueryParam{qe("status", "Computed status filter.", "open", "done", "overdue", "all")},
+	},
 
 	// ---- Tracker ----
 	"GET /api/v1/tracker/my-activity": {

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -397,6 +397,57 @@ func (r *KanbanRepository) ListTasks(ctx context.Context, projectID string) ([]m
 	return tasks, rows.Err()
 }
 
+// AssignedTaskRow is a raw scan of a task assigned to a user, across projects.
+type AssignedTaskRow struct {
+	TaskID      string
+	Title       string
+	ProjectID   string
+	ProjectName string
+	ColumnName  string
+	ColumnType  string
+	DueDate     string
+	Priority    string
+}
+
+func (r *KanbanRepository) ListTasksAssignedTo(ctx context.Context, userID string) ([]AssignedTaskRow, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+	rows, err := repository.DB(ctx, r.db).Query(ctx, `
+		SELECT kt.id::text, kt.title, p.id::text, p.name,
+			kc.name, kc.column_type,
+			COALESCE(to_char(kt.due_date, 'YYYY-MM-DD'), ''), kt.priority
+		FROM kanban_tasks kt
+		JOIN kanban_columns kc ON kc.id = kt.column_id
+		JOIN projects p ON p.id = kt.project_id
+		WHERE kt.assignee_id = $1::uuid
+		ORDER BY kt.due_date ASC NULLS LAST, kt.priority DESC, kt.created_at ASC
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tasks := make([]AssignedTaskRow, 0)
+	for rows.Next() {
+		var task AssignedTaskRow
+		if err := rows.Scan(
+			&task.TaskID,
+			&task.Title,
+			&task.ProjectID,
+			&task.ProjectName,
+			&task.ColumnName,
+			&task.ColumnType,
+			&task.DueDate,
+			&task.Priority,
+		); err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+
+	return tasks, rows.Err()
+}
+
 func (r *KanbanRepository) GetTask(ctx context.Context, projectID string, taskID string) (model.KanbanTask, error) {
 	var task model.KanbanTask
 	err := repository.DB(ctx, r.db).QueryRow(ctx, `

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -39,6 +39,7 @@ type kanbanRepository interface {
 	MoveTask(ctx context.Context, projectID string, taskID string, destinationColumnID string, destinationPosition int) error
 	Snapshot(ctx context.Context, projectID string) (operationalrepo.KanbanSnapshot, error)
 	GetTask(ctx context.Context, projectID string, taskID string) (model.KanbanTask, error)
+	ListTasksAssignedTo(ctx context.Context, userID string) ([]operationalrepo.AssignedTaskRow, error)
 }
 
 type kanbanProjectsRepository interface {
@@ -117,6 +118,47 @@ func (s *KanbanService) ReorderColumns(ctx context.Context, projectID string, re
 
 func (s *KanbanService) ListTasks(ctx context.Context, projectID string) ([]model.KanbanTask, error) {
 	return s.repo.ListTasks(ctx, projectID)
+}
+
+// ListMyTasks returns the caller's assigned tasks across all projects,
+// optionally filtered by computed status (open/done/overdue/all).
+func (s *KanbanService) ListMyTasks(ctx context.Context, userID string, status string) ([]operationaldto.MyTaskItem, error) {
+	rows, err := s.repo.ListTasksAssignedTo(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	today := time.Now().UTC().Format("2006-01-02")
+	items := make([]operationaldto.MyTaskItem, 0, len(rows))
+	for _, row := range rows {
+		computedStatus := computeTaskStatus(row.ColumnType, row.ColumnName, row.DueDate, today)
+		if status != "" && status != "all" && status != computedStatus {
+			continue
+		}
+
+		items = append(items, operationaldto.MyTaskItem{
+			TaskID:      row.TaskID,
+			Title:       row.Title,
+			ProjectID:   row.ProjectID,
+			ProjectName: row.ProjectName,
+			ColumnName:  row.ColumnName,
+			Status:      computedStatus,
+			DueDate:     row.DueDate,
+			Priority:    row.Priority,
+		})
+	}
+
+	return items, nil
+}
+
+func computeTaskStatus(columnType string, columnName string, dueDate string, today string) string {
+	if columnType == "done" || strings.EqualFold(columnName, "done") || strings.EqualFold(columnName, "archived") {
+		return "done"
+	}
+	if dueDate != "" && dueDate < today {
+		return "overdue"
+	}
+	return "open"
 }
 
 func (s *KanbanService) CreateTask(ctx context.Context, projectID string, request operationaldto.CreateKanbanTaskRequest, createdBy string) (model.KanbanTask, error) {

--- a/backend/internal/service/operational/kanban_test.go
+++ b/backend/internal/service/operational/kanban_test.go
@@ -206,6 +206,10 @@ func (f *fakeKanbanRepository) GetTask(ctx context.Context, projectID string, ta
 	return f.getTaskFunc(ctx, projectID, taskID)
 }
 
+func (f *fakeKanbanRepository) ListTasksAssignedTo(ctx context.Context, userID string) ([]operationalrepo.AssignedTaskRow, error) {
+	return nil, nil
+}
+
 type fakeKanbanProjectsRepository struct {
 	project   model.Project
 	memberIDs []string


### PR DESCRIPTION
## Summary
- Adds a cross-project "my assigned tasks" endpoint (`GET /api/v1/operational/tasks/mine`) hard-filtered server-side to `principal.UserID`, so it's safe to call with any user's PAT.
- Feeds a Discord reminder bot that pulls each user's own tasks. Auto-exposed as MCP tool `get_operational_tasks_mine` via the generic endpoint bridge, no MCP registration code needed.
- Response items include `task_id`, `title`, `project_id`, `project_name`, `column_name`, computed `status` (open/done/overdue), `due_date`, `priority`.
- Optional `status` query param (`open|done|overdue|all`, default `all`) filters the computed status.
- RBAC via the existing `operational:task:view` permission, no new permission added.
- Curated MCP annotation added for the `status` enum param so the tool surfaces useful filter guidance.

## Test plan
- [x] `go build ./...`
- [x] `go vet` on touched packages
- [x] `go test` on touched packages (service/handler/repository/mcp for operational)
- [ ] Manual smoke test against a running DB (call endpoint with a PAT, verify only own tasks returned)