### PR TITLE
feat(operational): scheduled Discord task-reminder digest push

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -178,6 +178,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	operationalOverviewRepository := operationalrepo.NewOverviewRepository(pool)
 	trackerRepository := operationalrepo.NewTrackerRepository(pool)
 	trackerReminderRepository := operationalrepo.NewTrackerReminderRepository(pool)
+	discordReminderRepository := operationalrepo.NewDiscordReminderRepository(pool)
 	vpsRepository := operationalrepo.NewVPSRepository(pool)
 	domainRepository := operationalrepo.NewDomainRepository(pool)
 	departmentsRepository := hrisrepo.NewDepartmentsRepository(pool)
@@ -220,6 +221,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 	emailDeliveryService := notificationsservice.NewEmailDeliveryService(authRepository, waRepository, encrypter, cfg)
 
 	trackerReminderService := operationalservice.NewTrackerReminderService(trackerReminderRepository, notificationsRepository, whatsappService)
+	discordReminderService := operationalservice.NewDiscordReminderService(discordReminderRepository)
 	vpsService := operationalservice.NewVPSService(vpsRepository)
 	vpsMonitorService := operationalservice.NewVPSMonitorService(vpsRepository, notificationsRepository, authRepository, pool)
 	domainService := operationalservice.NewDomainService(domainRepository)
@@ -252,6 +254,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		operationalhandler.NewKanbanHandler(kanbanService),
 		operationalhandler.NewTrackerHandler(trackerService),
 		operationalhandler.NewTrackerReminderHandler(trackerReminderService),
+		operationalhandler.NewDiscordReminderHandler(discordReminderService),
 		operationalhandler.NewVPSHandler(vpsService),
 		operationalhandler.NewDomainHandler(domainService),
 		hrishandler.NewOverviewHandler(hrisOverviewService),
@@ -275,7 +278,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 		return nil, fmt.Errorf("build router: %w", err)
 	}
 	application.router = router
-	application.startBackgroundJobs(authService, subscriptionsService, trackerService, trackerReminderService, reimbursementsService, whatsappService, emailDeliveryService, vpsMonitorService, domainMonitorService)
+	application.startBackgroundJobs(authService, subscriptionsService, trackerService, trackerReminderService, discordReminderService, reimbursementsService, whatsappService, emailDeliveryService, vpsMonitorService, domainMonitorService)
 
 	return application, nil
 }
@@ -311,6 +314,7 @@ func (a *App) buildRouter(
 	kanbanHandler *operationalhandler.KanbanHandler,
 	trackerHandler *operationalhandler.TrackerHandler,
 	trackerReminderHandler *operationalhandler.TrackerReminderHandler,
+	discordReminderHandler *operationalhandler.DiscordReminderHandler,
 	vpsHandler *operationalhandler.VPSHandler,
 	domainHandler *operationalhandler.DomainHandler,
 	hrisOverviewHandler *hrishandler.OverviewHandler,
@@ -485,6 +489,11 @@ func (a *App) buildRouter(
 					module.Route("/domains", domainHandler.RegisterRoutes)
 				})
 
+				protected.Route("/discord-reminder", func(r chi.Router) {
+					r.Use(platformmiddleware.RequireModuleAccess(rbac.ModuleOperational))
+					discordReminderHandler.RegisterRoutes(r)
+				})
+
 				protected.Route("/tracker", func(tracker chi.Router) {
 					tracker.Use(platformmiddleware.RequireModuleAccess(rbac.ModuleOperational))
 					trackerHandler.RegisterRoutes(tracker)
@@ -547,7 +556,7 @@ func (a *App) buildRouter(
 	return router, nil
 }
 
-func (a *App) startBackgroundJobs(authService *authservice.Service, subscriptionsService *hrisservice.SubscriptionsService, trackerService *operationalservice.TrackerService, trackerReminderService *operationalservice.TrackerReminderService, reimbursementsService *hrisservice.ReimbursementsService, whatsappService *waservice.Service, emailDeliveryService *notificationsservice.EmailDeliveryService, vpsMonitorService *operationalservice.VPSMonitorService, domainMonitorService *operationalservice.DomainMonitorService) {
+func (a *App) startBackgroundJobs(authService *authservice.Service, subscriptionsService *hrisservice.SubscriptionsService, trackerService *operationalservice.TrackerService, trackerReminderService *operationalservice.TrackerReminderService, discordReminderService *operationalservice.DiscordReminderService, reimbursementsService *hrisservice.ReimbursementsService, whatsappService *waservice.Service, emailDeliveryService *notificationsservice.EmailDeliveryService, vpsMonitorService *operationalservice.VPSMonitorService, domainMonitorService *operationalservice.DomainMonitorService) {
 	ctx, cancel := context.WithCancel(context.Background())
 	a.backgroundCancel = cancel
 
@@ -705,6 +714,10 @@ func (a *App) startBackgroundJobs(authService *authservice.Service, subscription
 
 	runPerTenantTicker("tracker_reminder_scheduler", time.Minute, false, func(tCtx context.Context, t tenant.Info, now time.Time) error {
 		return trackerReminderService.RunReminderJobs(tCtx, now)
+	})
+
+	runPerTenantTicker("discord_reminder_scheduler", time.Minute, false, func(tCtx context.Context, t tenant.Info, now time.Time) error {
+		return discordReminderService.RunReminderJobs(tCtx, now)
 	})
 
 	// Close sessions orphaned by crashed/disconnected extensions so a later
@@ -882,6 +895,28 @@ func seedTenants(ctx context.Context, pool *pgxpool.Pool, tenants []config.Tenan
 		trConn.Release()
 		if err != nil {
 			return fmt.Errorf("seed tracker reminder config for tenant %q: %w", tc.Slug, err)
+		}
+
+		// Ensure discord_reminder_configs row exists (disabled by default;
+		// webhook URL + shared secret set via super-admin API, not env).
+		drConn, err := pool.Acquire(ctx)
+		if err != nil {
+			return fmt.Errorf("acquire conn for discord reminder config seed: %w", err)
+		}
+		_, err = drConn.Exec(ctx, fmt.Sprintf("SET app.current_tenant = '%s'", tenantID))
+		if err != nil {
+			drConn.Release()
+			return fmt.Errorf("set tenant guc for discord reminder config seed: %w", err)
+		}
+		_, err = drConn.Exec(ctx,
+			`INSERT INTO discord_reminder_configs (tenant_id)
+			 VALUES ($1::uuid)
+			 ON CONFLICT (tenant_id) DO NOTHING`,
+			tenantID)
+		_, _ = drConn.Exec(ctx, "RESET ALL")
+		drConn.Release()
+		if err != nil {
+			return fmt.Errorf("seed discord reminder config for tenant %q: %w", tc.Slug, err)
 		}
 
 		// Ensure compensation_policies row exists (defaults seeded, admin tunes via UI).

--- a/backend/internal/dto/operational/discord_reminder.go
+++ b/backend/internal/dto/operational/discord_reminder.go
@@ -1,0 +1,28 @@
+package operational
+
+type UpdateDiscordReminderConfigRequest struct {
+	WebhookURL   string `json:"webhook_url" validate:"omitempty,url"`
+	SharedSecret string `json:"shared_secret"`
+	Enabled      bool   `json:"enabled"`
+	SendHour     int    `json:"send_hour" validate:"min=0,max=23"`
+	WeekdaysOnly bool   `json:"weekdays_only"`
+	Timezone     string `json:"timezone" validate:"required,max=64"`
+}
+
+// DiscordReminderConfigResponse never includes the plaintext shared secret —
+// this endpoint auto-becomes an MCP tool readable by module users, so
+// HasSecret is the only signal exposed about whether one is configured.
+type DiscordReminderConfigResponse struct {
+	TenantID     string `json:"tenant_id"`
+	Enabled      bool   `json:"enabled"`
+	WebhookURL   string `json:"webhook_url"`
+	HasSecret    bool   `json:"has_secret"`
+	SendHour     int    `json:"send_hour"`
+	WeekdaysOnly bool   `json:"weekdays_only"`
+	Timezone     string `json:"timezone"`
+	UpdatedAt    string `json:"updated_at"`
+}
+
+type DiscordReminderTestResponse struct {
+	Sent int `json:"sent"`
+}

--- a/backend/internal/handler/operational/discord_reminder.go
+++ b/backend/internal/handler/operational/discord_reminder.go
@@ -1,0 +1,118 @@
+package operational
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-playground/validator/v10"
+
+	operationaldto "github.com/kana-consultant/kantor/backend/internal/dto/operational"
+	"github.com/kana-consultant/kantor/backend/internal/httputil"
+	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
+	"github.com/kana-consultant/kantor/backend/internal/model"
+	operationalrepo "github.com/kana-consultant/kantor/backend/internal/repository/operational"
+	"github.com/kana-consultant/kantor/backend/internal/response"
+	operationalservice "github.com/kana-consultant/kantor/backend/internal/service/operational"
+)
+
+type DiscordReminderHandler struct {
+	service   *operationalservice.DiscordReminderService
+	validator *validator.Validate
+}
+
+func NewDiscordReminderHandler(service *operationalservice.DiscordReminderService) *DiscordReminderHandler {
+	return &DiscordReminderHandler{
+		service:   service,
+		validator: validator.New(validator.WithRequiredStructEnabled()),
+	}
+}
+
+// Config is stored in the DB and set only via super-admin API — prod env is
+// managed by an external nix-config we can't touch.
+func (h *DiscordReminderHandler) RegisterRoutes(router chi.Router) {
+	router.With(platformmiddleware.SuperAdminMiddleware()).Get("/config", h.getConfig)
+	router.With(platformmiddleware.SuperAdminMiddleware()).Put("/config", h.updateConfig)
+	router.With(platformmiddleware.SuperAdminMiddleware()).Post("/config/test", h.sendTest)
+}
+
+func (h *DiscordReminderHandler) getConfig(w http.ResponseWriter, r *http.Request) {
+	cfg, err := h.service.GetConfig(r.Context())
+	if err != nil {
+		platformmiddleware.LoggerFromContext(r.Context()).Error("discord reminder get config failed", "error", err)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load discord reminder config")
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, toDiscordReminderResponse(cfg), nil)
+}
+
+func (h *DiscordReminderHandler) updateConfig(w http.ResponseWriter, r *http.Request) {
+	var req operationaldto.UpdateDiscordReminderConfigRequest
+	if !httputil.DecodeAndValidate(h.validator, w, r, &req) {
+		return
+	}
+
+	before, err := h.service.GetConfig(r.Context())
+	if err != nil {
+		platformmiddleware.LoggerFromContext(r.Context()).Error("discord reminder get config failed", "error", err)
+		response.WriteInternalError(r.Context(), w, err, "Failed to load discord reminder config")
+		return
+	}
+
+	// Keep the existing stored secret when the request omits it — never
+	// overwrite with blank.
+	sharedSecret := strings.TrimSpace(req.SharedSecret)
+	if sharedSecret == "" {
+		sharedSecret = before.SharedSecret
+	}
+
+	cfg, err := h.service.UpdateConfig(r.Context(), operationalrepo.UpdateDiscordReminderConfigParams{
+		Enabled:      req.Enabled,
+		WebhookURL:   strings.TrimSpace(req.WebhookURL),
+		SharedSecret: sharedSecret,
+		SendHour:     req.SendHour,
+		WeekdaysOnly: req.WeekdaysOnly,
+		Timezone:     strings.TrimSpace(req.Timezone),
+	})
+	if err != nil {
+		platformmiddleware.LoggerFromContext(r.Context()).Error("discord reminder update config failed", "error", err)
+		response.WriteInternalError(r.Context(), w, err, "Failed to update discord reminder config")
+		return
+	}
+
+	// Audit trail must never carry the plaintext secret either.
+	auditBefore, auditAfter := before, cfg
+	auditBefore.SharedSecret, auditAfter.SharedSecret = "", ""
+	platformmiddleware.AuditLog(r.Context(), "update", "operational", "discord_reminder_config", cfg.TenantID, auditBefore, auditAfter)
+
+	response.WriteJSON(w, http.StatusOK, toDiscordReminderResponse(cfg), nil)
+}
+
+func (h *DiscordReminderHandler) sendTest(w http.ResponseWriter, r *http.Request) {
+	sent, err := h.service.SendTestDigest(r.Context(), time.Now())
+	if err != nil {
+		if errors.Is(err, operationalservice.ErrDiscordReminderDisabled) {
+			response.WriteError(w, http.StatusBadRequest, "DISCORD_REMINDER_DISABLED", "Discord reminder push is disabled for this tenant", nil)
+			return
+		}
+		platformmiddleware.LoggerFromContext(r.Context()).Error("discord reminder test push failed", "error", err)
+		response.WriteInternalError(r.Context(), w, err, "Failed to send discord reminder digest")
+		return
+	}
+	response.WriteJSON(w, http.StatusOK, operationaldto.DiscordReminderTestResponse{Sent: sent}, nil)
+}
+
+func toDiscordReminderResponse(cfg model.DiscordReminderConfig) operationaldto.DiscordReminderConfigResponse {
+	return operationaldto.DiscordReminderConfigResponse{
+		TenantID:     cfg.TenantID,
+		Enabled:      cfg.Enabled,
+		WebhookURL:   cfg.WebhookURL,
+		HasSecret:    strings.TrimSpace(cfg.SharedSecret) != "",
+		SendHour:     cfg.SendHour,
+		WeekdaysOnly: cfg.WeekdaysOnly,
+		Timezone:     cfg.Timezone,
+		UpdatedAt:    cfg.UpdatedAt.Format(time.RFC3339),
+	}
+}

--- a/backend/internal/model/discord_reminder.go
+++ b/backend/internal/model/discord_reminder.go
@@ -1,0 +1,31 @@
+package model
+
+import "time"
+
+// DiscordReminderConfig is the per-tenant configuration for pushing the daily
+// task-reminder digest to an external Discord bot over HTTP. Stored in the DB
+// (not env) because prod env is managed by an external nix-config.
+type DiscordReminderConfig struct {
+	TenantID     string    `json:"tenant_id"`
+	Enabled      bool      `json:"enabled"`
+	WebhookURL   string    `json:"webhook_url"`
+	SharedSecret string    `json:"-"` // never serialize the plaintext secret
+	SendHour     int       `json:"send_hour"`
+	WeekdaysOnly bool      `json:"weekdays_only"`
+	Timezone     string    `json:"timezone"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// DiscordReminderTaskRow is a single open kanban task assigned to an active
+// employee, as returned by the digest source query.
+type DiscordReminderTaskRow struct {
+	UserID      string
+	FullName    string
+	TaskID      string
+	Title       string
+	ProjectName string
+	ColumnName  string
+	DueDate     string
+	Priority    string
+}

--- a/backend/internal/repository/operational/discord_reminder.go
+++ b/backend/internal/repository/operational/discord_reminder.go
@@ -1,0 +1,133 @@
+package operational
+
+import (
+	"context"
+
+	"github.com/kana-consultant/kantor/backend/internal/model"
+	repository "github.com/kana-consultant/kantor/backend/internal/repository"
+)
+
+type DiscordReminderRepository struct {
+	db repository.DBTX
+}
+
+func NewDiscordReminderRepository(db repository.DBTX) *DiscordReminderRepository {
+	return &DiscordReminderRepository{db: db}
+}
+
+type UpdateDiscordReminderConfigParams struct {
+	Enabled      bool
+	WebhookURL   string
+	SharedSecret string
+	SendHour     int
+	WeekdaysOnly bool
+	Timezone     string
+}
+
+func (r *DiscordReminderRepository) EnsureRow(ctx context.Context) error {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	_, err := repository.DB(ctx, r.db).Exec(ctx, `
+		INSERT INTO discord_reminder_configs (tenant_id)
+		VALUES (current_setting('app.current_tenant')::uuid)
+		ON CONFLICT (tenant_id) DO NOTHING
+	`)
+	return err
+}
+
+func (r *DiscordReminderRepository) Get(ctx context.Context) (model.DiscordReminderConfig, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var c model.DiscordReminderConfig
+	err := repository.DB(ctx, r.db).QueryRow(ctx, `
+		SELECT tenant_id::text, enabled, webhook_url, shared_secret, send_hour, weekdays_only, timezone,
+		       created_at, updated_at
+		FROM discord_reminder_configs
+		LIMIT 1
+	`).Scan(
+		&c.TenantID,
+		&c.Enabled,
+		&c.WebhookURL,
+		&c.SharedSecret,
+		&c.SendHour,
+		&c.WeekdaysOnly,
+		&c.Timezone,
+		&c.CreatedAt,
+		&c.UpdatedAt,
+	)
+	return c, err
+}
+
+func (r *DiscordReminderRepository) Update(ctx context.Context, p UpdateDiscordReminderConfigParams) (model.DiscordReminderConfig, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var c model.DiscordReminderConfig
+	err := repository.DB(ctx, r.db).QueryRow(ctx, `
+		UPDATE discord_reminder_configs
+		SET enabled = $1,
+		    webhook_url = $2,
+		    shared_secret = $3,
+		    send_hour = $4,
+		    weekdays_only = $5,
+		    timezone = $6,
+		    updated_at = NOW()
+		RETURNING tenant_id::text, enabled, webhook_url, shared_secret, send_hour, weekdays_only, timezone,
+		          created_at, updated_at
+	`, p.Enabled, p.WebhookURL, p.SharedSecret, p.SendHour, p.WeekdaysOnly, p.Timezone).Scan(
+		&c.TenantID,
+		&c.Enabled,
+		&c.WebhookURL,
+		&c.SharedSecret,
+		&c.SendHour,
+		&c.WeekdaysOnly,
+		&c.Timezone,
+		&c.CreatedAt,
+		&c.UpdatedAt,
+	)
+	return c, err
+}
+
+// ListOpenTasksByEmployee returns every open (non-done) kanban task assigned
+// to an active user, ordered by employee so the caller can bucket rows into
+// a per-employee digest. RLS scopes this to the current tenant automatically.
+func (r *DiscordReminderRepository) ListOpenTasksByEmployee(ctx context.Context) ([]model.DiscordReminderTaskRow, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	rows, err := repository.DB(ctx, r.db).Query(ctx, `
+		SELECT u.id::text, u.full_name, kt.id::text, kt.title, p.name, kc.name,
+		       COALESCE(to_char(kt.due_date, 'YYYY-MM-DD'), ''), kt.priority
+		FROM kanban_tasks kt
+		JOIN kanban_columns kc ON kc.id = kt.column_id
+		JOIN projects p ON p.id = kt.project_id
+		JOIN users u ON u.id = kt.assignee_id
+		WHERE kc.column_type <> 'done' AND kt.assignee_id IS NOT NULL AND u.is_active = TRUE
+		ORDER BY u.full_name, kt.due_date NULLS LAST
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]model.DiscordReminderTaskRow, 0)
+	for rows.Next() {
+		var row model.DiscordReminderTaskRow
+		if err := rows.Scan(
+			&row.UserID,
+			&row.FullName,
+			&row.TaskID,
+			&row.Title,
+			&row.ProjectName,
+			&row.ColumnName,
+			&row.DueDate,
+			&row.Priority,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}

--- a/backend/internal/service/operational/discord_reminder.go
+++ b/backend/internal/service/operational/discord_reminder.go
@@ -1,0 +1,213 @@
+package operational
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/kana-consultant/kantor/backend/internal/model"
+	operationalrepo "github.com/kana-consultant/kantor/backend/internal/repository/operational"
+	"github.com/kana-consultant/kantor/backend/internal/tenant"
+)
+
+const (
+	discordReminderStatusOpen    = "open"
+	discordReminderStatusOverdue = "overdue"
+	discordReminderDateLayout    = "2006-01-02"
+)
+
+type discordReminderRepo interface {
+	EnsureRow(ctx context.Context) error
+	Get(ctx context.Context) (model.DiscordReminderConfig, error)
+	Update(ctx context.Context, p operationalrepo.UpdateDiscordReminderConfigParams) (model.DiscordReminderConfig, error)
+	ListOpenTasksByEmployee(ctx context.Context) ([]model.DiscordReminderTaskRow, error)
+}
+
+// DiscordReminderService builds and pushes the daily all-employees open-task
+// digest to an external Discord bot, per tenant.
+type DiscordReminderService struct {
+	repo discordReminderRepo
+
+	// In-memory guard against double-fire on process restart (a restart at
+	// the top of the fire hour would otherwise re-trigger the digest). Keyed
+	// by tenant ID, value is the tenant-local calendar date already fired.
+	mu           sync.Mutex
+	lastFireDate map[string]string
+}
+
+func NewDiscordReminderService(repo discordReminderRepo) *DiscordReminderService {
+	return &DiscordReminderService{
+		repo:         repo,
+		lastFireDate: make(map[string]string),
+	}
+}
+
+func (s *DiscordReminderService) GetConfig(ctx context.Context) (model.DiscordReminderConfig, error) {
+	if err := s.repo.EnsureRow(ctx); err != nil {
+		return model.DiscordReminderConfig{}, err
+	}
+	return s.repo.Get(ctx)
+}
+
+func (s *DiscordReminderService) UpdateConfig(ctx context.Context, p operationalrepo.UpdateDiscordReminderConfigParams) (model.DiscordReminderConfig, error) {
+	if err := s.repo.EnsureRow(ctx); err != nil {
+		return model.DiscordReminderConfig{}, err
+	}
+	return s.repo.Update(ctx, p)
+}
+
+// RunReminderJobs is invoked once per minute per tenant by the scheduler. It
+// only pushes the digest at the top of the configured send hour (tenant
+// timezone), and at most once per tenant-local calendar day.
+func (s *DiscordReminderService) RunReminderJobs(ctx context.Context, now time.Time) error {
+	if err := s.repo.EnsureRow(ctx); err != nil {
+		return err
+	}
+	cfg, err := s.repo.Get(ctx)
+	if err != nil {
+		return err
+	}
+	if !cfg.Enabled {
+		return nil
+	}
+
+	nowLocal := now.In(s.loadLocation(ctx, cfg.Timezone))
+	if !s.shouldFire(ctx, cfg, nowLocal) {
+		return nil
+	}
+
+	count, err := s.pushDigest(ctx, cfg, nowLocal)
+	if err != nil {
+		slog.ErrorContext(ctx, "discord reminder digest push failed", "error", err)
+		return nil
+	}
+	slog.InfoContext(ctx, "discord reminder digest pushed", "employees", count)
+	return nil
+}
+
+// SendTestDigest builds and pushes the digest immediately, ignoring the fire
+// schedule and the once-per-day guard. Used by the manual "test" endpoint.
+func (s *DiscordReminderService) SendTestDigest(ctx context.Context, now time.Time) (int, error) {
+	if err := s.repo.EnsureRow(ctx); err != nil {
+		return 0, err
+	}
+	cfg, err := s.repo.Get(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if !cfg.Enabled {
+		return 0, ErrDiscordReminderDisabled
+	}
+
+	nowLocal := now.In(s.loadLocation(ctx, cfg.Timezone))
+	return s.pushDigest(ctx, cfg, nowLocal)
+}
+
+func (s *DiscordReminderService) loadLocation(ctx context.Context, timezone string) *time.Location {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		slog.WarnContext(ctx, "discord reminder falling back to UTC", "tenant_timezone", timezone, "error", err)
+		return time.UTC
+	}
+	return loc
+}
+
+func (s *DiscordReminderService) shouldFire(ctx context.Context, cfg model.DiscordReminderConfig, nowLocal time.Time) bool {
+	if nowLocal.Minute() != 0 || nowLocal.Hour() != cfg.SendHour {
+		return false
+	}
+	if cfg.WeekdaysOnly {
+		wd := nowLocal.Weekday()
+		if wd == time.Saturday || wd == time.Sunday {
+			return false
+		}
+	}
+
+	tenantID := tenantIDOrFallback(ctx, cfg.TenantID)
+	dateKey := nowLocal.Format(discordReminderDateLayout)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if lastDate, exists := s.lastFireDate[tenantID]; exists && lastDate == dateKey {
+		return false
+	}
+	s.lastFireDate[tenantID] = dateKey
+	return true
+}
+
+func (s *DiscordReminderService) pushDigest(ctx context.Context, cfg model.DiscordReminderConfig, nowLocal time.Time) (int, error) {
+	rows, err := s.repo.ListOpenTasksByEmployee(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	payload := buildDiscordReminderPayload(rows, nowLocal.Format(discordReminderDateLayout))
+	if len(payload.Employees) == 0 {
+		return 0, nil
+	}
+
+	client := NewDiscordReminderClientFromConfig(cfg.WebhookURL, cfg.SharedSecret, cfg.Enabled)
+	if err := client.Push(payload); err != nil {
+		return 0, err
+	}
+	return len(payload.Employees), nil
+}
+
+// buildDiscordReminderPayload groups the flat task rows per employee and
+// computes each task's open/overdue status relative to todayLocal. Only
+// employees with at least one open task are included.
+func buildDiscordReminderPayload(rows []model.DiscordReminderTaskRow, todayLocal string) DiscordReminderDigestPayload {
+	order := make([]string, 0, len(rows))
+	grouped := make(map[string]*DiscordReminderEmployeePayload, len(rows))
+
+	for _, row := range rows {
+		emp, ok := grouped[row.UserID]
+		if !ok {
+			emp = &DiscordReminderEmployeePayload{
+				KantorUserID: row.UserID,
+				Name:         row.FullName,
+				Tasks:        make([]DiscordReminderTaskPayload, 0, 4),
+			}
+			grouped[row.UserID] = emp
+			order = append(order, row.UserID)
+		}
+
+		status := discordReminderStatusOpen
+		if row.DueDate != "" && strings.Compare(row.DueDate, todayLocal) < 0 {
+			status = discordReminderStatusOverdue
+		}
+
+		emp.Tasks = append(emp.Tasks, DiscordReminderTaskPayload{
+			Title:    row.Title,
+			Project:  row.ProjectName,
+			Column:   row.ColumnName,
+			Status:   status,
+			DueDate:  row.DueDate,
+			Priority: row.Priority,
+		})
+	}
+
+	employees := make([]DiscordReminderEmployeePayload, 0, len(order))
+	for _, userID := range order {
+		emp := grouped[userID]
+		if len(emp.Tasks) == 0 {
+			continue
+		}
+		employees = append(employees, *emp)
+	}
+
+	return DiscordReminderDigestPayload{
+		Job:       "task",
+		Date:      todayLocal,
+		Employees: employees,
+	}
+}
+
+func tenantIDOrFallback(ctx context.Context, fallback string) string {
+	if info, ok := tenant.FromContext(ctx); ok && strings.TrimSpace(info.ID) != "" {
+		return info.ID
+	}
+	return fallback
+}

--- a/backend/internal/service/operational/discord_reminder_client.go
+++ b/backend/internal/service/operational/discord_reminder_client.go
@@ -1,0 +1,117 @@
+package operational
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// ErrDiscordReminderDisabled indicates the Discord reminder push is disabled
+// for this tenant.
+var ErrDiscordReminderDisabled = errors.New("discord reminder push is disabled for this tenant")
+
+const discordReminderSecretHeader = "X-Discord-Bot-Secret"
+
+// DiscordReminderTaskPayload is a single task entry in the digest payload.
+type DiscordReminderTaskPayload struct {
+	Title    string `json:"title"`
+	Project  string `json:"project"`
+	Column   string `json:"column"`
+	Status   string `json:"status"`
+	DueDate  string `json:"due_date"`
+	Priority string `json:"priority"`
+}
+
+// DiscordReminderEmployeePayload groups tasks for a single employee.
+type DiscordReminderEmployeePayload struct {
+	KantorUserID string                       `json:"kantor_user_id"`
+	Name         string                       `json:"name"`
+	Tasks        []DiscordReminderTaskPayload `json:"tasks"`
+}
+
+// DiscordReminderDigestPayload is the JSON body posted to the external
+// Discord bot. Field names and shape must match the bot contract exactly.
+type DiscordReminderDigestPayload struct {
+	Job       string                           `json:"job"`
+	Date      string                           `json:"date"`
+	Employees []DiscordReminderEmployeePayload `json:"employees"`
+}
+
+type discordReminderClientConfig struct {
+	WebhookURL   string
+	SharedSecret string
+	Enabled      bool
+}
+
+// DiscordReminderClient pushes the task digest payload to the tenant's
+// configured external Discord bot webhook.
+type DiscordReminderClient struct {
+	cfg        discordReminderClientConfig
+	httpClient *http.Client
+}
+
+func newDiscordReminderClient(cfg discordReminderClientConfig) *DiscordReminderClient {
+	return &DiscordReminderClient{
+		cfg: cfg,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			// Wrap the default transport so each outbound push is captured
+			// as a child span and the W3C traceparent header is injected
+			// for the receiving bot.
+			Transport: otelhttp.NewTransport(http.DefaultTransport),
+		},
+	}
+}
+
+// NewDiscordReminderClientFromConfig creates a DiscordReminderClient from the
+// per-tenant DB config.
+func NewDiscordReminderClientFromConfig(webhookURL string, sharedSecret string, enabled bool) *DiscordReminderClient {
+	return newDiscordReminderClient(discordReminderClientConfig{
+		WebhookURL:   webhookURL,
+		SharedSecret: sharedSecret,
+		Enabled:      enabled,
+	})
+}
+
+// Push sends the digest payload to the configured webhook.
+func (c *DiscordReminderClient) Push(payload DiscordReminderDigestPayload) error {
+	if !c.cfg.Enabled {
+		return ErrDiscordReminderDisabled
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+
+	resp, err := c.doRequest(c.cfg.WebhookURL, body)
+	if err != nil {
+		return fmt.Errorf("push discord reminder digest: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("push discord reminder digest failed (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	return nil
+}
+
+func (c *DiscordReminderClient) doRequest(url string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(discordReminderSecretHeader, c.cfg.SharedSecret)
+
+	return c.httpClient.Do(req)
+}

--- a/backend/internal/service/operational/discord_reminder_test.go
+++ b/backend/internal/service/operational/discord_reminder_test.go
@@ -1,0 +1,135 @@
+package operational
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kana-consultant/kantor/backend/internal/model"
+	operationalrepo "github.com/kana-consultant/kantor/backend/internal/repository/operational"
+)
+
+type fakeDiscordReminderRepo struct {
+	cfg  model.DiscordReminderConfig
+	rows []model.DiscordReminderTaskRow
+}
+
+func (f *fakeDiscordReminderRepo) EnsureRow(ctx context.Context) error { return nil }
+
+func (f *fakeDiscordReminderRepo) Get(ctx context.Context) (model.DiscordReminderConfig, error) {
+	return f.cfg, nil
+}
+
+func (f *fakeDiscordReminderRepo) Update(ctx context.Context, p operationalrepo.UpdateDiscordReminderConfigParams) (model.DiscordReminderConfig, error) {
+	f.cfg.Enabled = p.Enabled
+	f.cfg.WebhookURL = p.WebhookURL
+	f.cfg.SharedSecret = p.SharedSecret
+	f.cfg.SendHour = p.SendHour
+	f.cfg.WeekdaysOnly = p.WeekdaysOnly
+	f.cfg.Timezone = p.Timezone
+	return f.cfg, nil
+}
+
+func (f *fakeDiscordReminderRepo) ListOpenTasksByEmployee(ctx context.Context) ([]model.DiscordReminderTaskRow, error) {
+	return f.rows, nil
+}
+
+func TestBuildDiscordReminderPayloadGroupsAndComputesStatus(t *testing.T) {
+	t.Parallel()
+
+	rows := []model.DiscordReminderTaskRow{
+		{UserID: "u1", FullName: "Alice", TaskID: "t1", Title: "Fix bug", ProjectName: "Proj A", ColumnName: "To Do", DueDate: "2026-07-01", Priority: "high"},
+		{UserID: "u1", FullName: "Alice", TaskID: "t2", Title: "Write docs", ProjectName: "Proj A", ColumnName: "In Progress", DueDate: "", Priority: "low"},
+		{UserID: "u2", FullName: "Bob", TaskID: "t3", Title: "Deploy", ProjectName: "Proj B", ColumnName: "To Do", DueDate: "2026-07-31", Priority: "critical"},
+	}
+
+	payload := buildDiscordReminderPayload(rows, "2026-07-25")
+
+	if payload.Job != "task" {
+		t.Fatalf("Job = %q, want %q", payload.Job, "task")
+	}
+	if payload.Date != "2026-07-25" {
+		t.Fatalf("Date = %q, want %q", payload.Date, "2026-07-25")
+	}
+	if len(payload.Employees) != 2 {
+		t.Fatalf("len(Employees) = %d, want 2", len(payload.Employees))
+	}
+
+	alice := payload.Employees[0]
+	if alice.KantorUserID != "u1" || alice.Name != "Alice" || len(alice.Tasks) != 2 {
+		t.Fatalf("unexpected alice payload: %+v", alice)
+	}
+	if alice.Tasks[0].Status != discordReminderStatusOverdue {
+		t.Fatalf("task 1 status = %q, want overdue", alice.Tasks[0].Status)
+	}
+	if alice.Tasks[1].Status != discordReminderStatusOpen {
+		t.Fatalf("task 2 status = %q, want open (no due date)", alice.Tasks[1].Status)
+	}
+
+	bob := payload.Employees[1]
+	if bob.KantorUserID != "u2" || len(bob.Tasks) != 1 {
+		t.Fatalf("unexpected bob payload: %+v", bob)
+	}
+	if bob.Tasks[0].Status != discordReminderStatusOpen {
+		t.Fatalf("bob task status = %q, want open (due date in future)", bob.Tasks[0].Status)
+	}
+}
+
+func TestBuildDiscordReminderPayloadEmptyRows(t *testing.T) {
+	t.Parallel()
+
+	payload := buildDiscordReminderPayload(nil, "2026-07-25")
+	if len(payload.Employees) != 0 {
+		t.Fatalf("len(Employees) = %d, want 0", len(payload.Employees))
+	}
+}
+
+func TestRunReminderJobsSkipsWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	repo := &fakeDiscordReminderRepo{cfg: model.DiscordReminderConfig{
+		TenantID: "tenant-1",
+		Enabled:  false,
+	}}
+	service := NewDiscordReminderService(repo)
+
+	if err := service.RunReminderJobs(context.Background(), time.Now()); err != nil {
+		t.Fatalf("RunReminderJobs() error = %v", err)
+	}
+}
+
+func TestShouldFireOncePerTenantLocalDay(t *testing.T) {
+	t.Parallel()
+
+	cfg := model.DiscordReminderConfig{
+		TenantID:     "tenant-1",
+		Enabled:      true,
+		SendHour:     8,
+		WeekdaysOnly: true,
+		Timezone:     "UTC",
+	}
+	service := NewDiscordReminderService(&fakeDiscordReminderRepo{cfg: cfg})
+
+	// Monday 08:00 — within window, should fire.
+	monday8am := time.Date(2026, 7, 27, 8, 0, 0, 0, time.UTC)
+	if !service.shouldFire(context.Background(), cfg, monday8am) {
+		t.Fatalf("shouldFire() = false, want true for first fire of the day")
+	}
+
+	// Same tenant-local day, later tick — must not re-fire (restart guard).
+	if service.shouldFire(context.Background(), cfg, monday8am.Add(time.Minute)) {
+		t.Fatalf("shouldFire() = true, want false for a second tick same day")
+	}
+
+	// Off the top of the hour — never fires regardless of dedup state.
+	notTopOfHour := time.Date(2026, 7, 28, 8, 5, 0, 0, time.UTC)
+	if service.shouldFire(context.Background(), cfg, notTopOfHour) {
+		t.Fatalf("shouldFire() = true, want false when minute != 0")
+	}
+
+	// Weekend — weekdays_only should block firing even at the right hour.
+	saturday8am := time.Date(2026, 8, 1, 8, 0, 0, 0, time.UTC)
+	if service.shouldFire(context.Background(), cfg, saturday8am) {
+		t.Fatalf("shouldFire() = true, want false on a weekend with weekdays_only")
+	}
+}

--- a/backend/migrations/20260701010000_discord_reminder_configs.down.sql
+++ b/backend/migrations/20260701010000_discord_reminder_configs.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS discord_reminder_configs;

--- a/backend/migrations/20260701010000_discord_reminder_configs.up.sql
+++ b/backend/migrations/20260701010000_discord_reminder_configs.up.sql
@@ -1,0 +1,24 @@
+CREATE TABLE discord_reminder_configs (
+    tenant_id UUID PRIMARY KEY DEFAULT current_setting('app.current_tenant')::uuid REFERENCES tenants(id) ON DELETE CASCADE,
+    enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    webhook_url TEXT NOT NULL DEFAULT '',
+    shared_secret TEXT NOT NULL DEFAULT '',
+    send_hour SMALLINT NOT NULL DEFAULT 8 CHECK (send_hour BETWEEN 0 AND 23),
+    weekdays_only BOOLEAN NOT NULL DEFAULT TRUE,
+    timezone TEXT NOT NULL DEFAULT 'Asia/Jakarta',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE discord_reminder_configs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE discord_reminder_configs FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON discord_reminder_configs
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+DO $$ BEGIN
+    IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'kantor_app') THEN
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON discord_reminder_configs TO kantor_app';
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

- Adds a per-tenant scheduled job that pushes a daily task-reminder digest of ALL employees' open kanban tasks to an external Discord bot over HTTP (POST with X-Discord-Bot-Secret header auth).
- Config (webhook URL, shared secret, send hour, weekdays-only, timezone, enabled) lives in a new `discord_reminder_configs` table, RLS-scoped per tenant, set only via a super-admin-gated API — not env, since prod env is managed by an external nix-config we can't touch.
- `GET /discord-reminder/config` always masks the secret (`has_secret: bool`, never the plaintext) since this endpoint auto-becomes an MCP tool readable by module users. `PUT` keeps the existing stored secret if the request omits one. `POST /discord-reminder/config/test` pushes the digest immediately for manual verification.
- Scheduler ticks every minute per tenant; fires once at the configured local hour (optionally weekdays-only), with an in-memory guard against double-fire on process restart.
- Separate from PR #145 (`GET /operational/tasks/mine`, self-scoped) — this is an org-wide push feature.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/service/operational/... ./internal/handler/operational/... ./internal/repository/operational/...` pass
- [x] `go test ./...` (full suite) pass
- [x] Manually sanity-checked migration SQL against the existing compensation_policy/tracker_reminder_configs migration pattern (RLS enable+force+policy, kantor_app grant DO-block)