### PR TITLE
fix(extension): handle 'Extension context invalidated' gracefully

### DIFF
--- a/extension/content-script.js
+++ b/extension/content-script.js
@@ -92,7 +92,29 @@
   }
 
   async function sendRuntimeMessage(type, payload) {
-    return browserApi.runtime.sendMessage({ type, payload });
+    // After the extension updates/reloads/is removed, this content script keeps
+    // running but its runtime handle is dead — calling it throws "Extension
+    // context invalidated". Detect it and surface an actionable message.
+    if (!isExtensionContextValid()) {
+      throw new Error("Extension baru diperbarui. Muat ulang (refresh) halaman ini, lalu klik Sinkronkan Browser lagi.");
+    }
+    try {
+      return await browserApi.runtime.sendMessage({ type, payload });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (/context invalidated/i.test(message)) {
+        throw new Error("Extension baru diperbarui. Muat ulang (refresh) halaman ini, lalu klik Sinkronkan Browser lagi.");
+      }
+      throw error;
+    }
+  }
+
+  function isExtensionContextValid() {
+    try {
+      return Boolean(browserApi?.runtime?.id);
+    } catch {
+      return false;
+    }
   }
 
   function postResult(requestId, success, payload, error) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "KANTOR Activity Tracker",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Track work activity for KANTOR platform",
   "permissions": ["tabs", "idle", "storage", "alarms"],
   "host_permissions": ["http://*/*", "https://*/*"],

--- a/frontend/src/routes/_authenticated/operational/tracker.tsx
+++ b/frontend/src/routes/_authenticated/operational/tracker.tsx
@@ -116,6 +116,17 @@ async function issueExtensionToken(): Promise<string> {
   });
   return created.token;
 }
+
+// A content script from a previous extension build keeps running in the page
+// after the extension updates/reloads; calling it then throws "Extension context
+// invalidated". Reframe that into an actionable message instead of a raw error.
+function describeExtensionError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  if (/context invalidated/i.test(message)) {
+    return "Extension baru diperbarui. Muat ulang (refresh) halaman ini, lalu klik Sinkronkan Browser lagi.";
+  }
+  return message || "Gagal menghubungkan extension tracker";
+}
 const TRACKER_EXTENSION_SOURCE = "KANTOR_TRACKER_EXTENSION";
 const DOMAIN_CATEGORY_OPTIONS = [
   { value: "development", label: "Development" },
@@ -433,7 +444,7 @@ function OperationalTrackerPage() {
         toast.success("Extension tersambung", "Browser ini sudah terhubung ke KANTOR Tracker.");
       }
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Gagal menghubungkan extension tracker");
+      toast.error(describeExtensionError(error));
     } finally {
       setIsConnectingExtension(false);
     }


### PR DESCRIPTION
When the extension updates/reloads (or is removed), the content script already running in an open dashboard tab keeps a dead runtime handle — calling `runtime.sendMessage` then throws **"Extension context invalidated"**, which the dashboard toasted verbatim (scary, non-actionable).

- **Dashboard**: reframes that error (and any content-script relay failure containing 'context invalidated') into *"Extension baru diperbarui. Muat ulang (refresh) halaman ini, lalu klik Sinkronkan Browser lagi."* — works immediately, no reinstall.
- **Content script**: detects a dead runtime (`runtime.id` gone) up front and returns the same actionable message instead of the raw error.
- Bumped extension to **2.0.2** (the version banner nudges older installs).

FE build + extension syntax green.