### PR TITLE
fix(extension): stop stale-content-script errors + auto-reload tabs on update

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -27,8 +27,14 @@ const HEARTBEAT_INTERVAL_MINUTES = 0.5;
 // with headroom, so a long offline stretch does not silently drop early activity.
 const MAX_QUEUED_ENTRIES = 5000;
 
-browserApi.runtime.onInstalled.addListener(() => {
+browserApi.runtime.onInstalled.addListener((details) => {
   void initializeState();
+  // On update, the KANTOR dashboard tab still runs the OLD content script (dead
+  // runtime). Reload those tabs so a fresh content script loads and the user
+  // does not have to refresh manually or hit "context invalidated".
+  if (details?.reason === "update") {
+    void reloadDashboardTabs();
+  }
 });
 
 browserApi.runtime.onStartup.addListener(() => {
@@ -579,6 +585,35 @@ function resolveDashboardUrl(state) {
     return explicit;
   }
   return toDashboardUrl(state.apiBaseUrl);
+}
+
+// reloadDashboardTabs refreshes the tabs on the configured dashboard origin so
+// that, after an extension update, the orphaned content script is replaced by a
+// fresh one instead of throwing "Extension context invalidated".
+async function reloadDashboardTabs() {
+  const state = await loadState();
+  const origin = dashboardOrigin(resolveDashboardUrl(state)) || dashboardOrigin(state.apiBaseUrl);
+  if (!origin) {
+    return;
+  }
+  try {
+    const tabs = await browserApi.tabs.query({ url: `${origin}/*` });
+    for (const tab of tabs) {
+      if (tab.id != null) {
+        await browserApi.tabs.reload(tab.id);
+      }
+    }
+  } catch {
+    // Best-effort: missing permission or a closed tab must never break startup.
+  }
+}
+
+function dashboardOrigin(value) {
+  try {
+    return new URL(String(value || "").trim()).origin;
+  } catch {
+    return "";
+  }
 }
 
 async function authorizedRequest(path, init) {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "KANTOR Activity Tracker",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Track work activity for KANTOR platform",
   "permissions": ["tabs", "idle", "storage", "alarms"],
   "host_permissions": ["http://*/*", "https://*/*"],

--- a/frontend/src/routes/_authenticated/operational/tracker.tsx
+++ b/frontend/src/routes/_authenticated/operational/tracker.tsx
@@ -118,12 +118,13 @@ async function issueExtensionToken(): Promise<string> {
 }
 
 // A content script from a previous extension build keeps running in the page
-// after the extension updates/reloads; calling it then throws "Extension context
-// invalidated". Reframe that into an actionable message instead of a raw error.
+// after the extension updates/reloads; its runtime handle is then dead, so calls
+// throw either "Extension context invalidated" or "Cannot read properties of
+// undefined (reading 'sendMessage')". Reframe both into an actionable message.
 function describeExtensionError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error ?? "");
-  if (/context invalidated/i.test(message)) {
-    return "Extension baru diperbarui. Muat ulang (refresh) halaman ini, lalu klik Sinkronkan Browser lagi.";
+  if (/context invalidated/i.test(message) || /sendMessage/i.test(message)) {
+    return "Extension perlu dipasang ulang: hapus extension lama, download & pasang versi terbaru (Download Chrome/Firefox), refresh halaman ini, lalu klik Sinkronkan Browser.";
   }
   return message || "Gagal menghubungkan extension tracker";
 }
@@ -344,6 +345,16 @@ function OperationalTrackerPage() {
       if (data.type === "KANTOR_TRACKER_RESULT" && data.requestId) {
         const pending = pendingRequests.get(data.requestId);
         if (!pending) {
+          return;
+        }
+
+        // A stale/orphaned content script (dead runtime after an extension
+        // update) posts an error like "context invalidated" or "reading
+        // 'sendMessage'". Ignore it and keep the request pending so a fresh
+        // content-script instance can still resolve it; the timeout is the
+        // fallback if none does. This is what makes duplicated content scripts
+        // (old + new in the same page) not surface a spurious error.
+        if (!data.success && /context invalidated|sendMessage/i.test(data.error || "")) {
           return;
         }
 


### PR DESCRIPTION
Follow-up to #147 for the *'Cannot read properties of undefined (reading sendMessage)'* toasts.

**Real fix (not just reframing):**
- **Dashboard** ignores error results from a stale/orphaned content script ('context invalidated' / 'sendMessage'), so a fresh instance (or the timeout) decides — no more spurious error toast (the duplicated old+new content scripts were both replying).
- **Extension (v2.0.3)** reloads the dashboard tabs on `onInstalled reason=update`, so after an update a fresh content script loads automatically — no manual refresh, no orphaned-runtime error going forward.

Inherent limit: the *current* update still needs one refresh (browsers orphan old content scripts until reload); from v2.0.3 onward it's automatic.

FE build + extension syntax green.