### PR TITLE
fix(ci): auth plain github.com after nix-config dropped ssh aliases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup SSH aliases for private flake inputs
+      - name: Setup SSH keys for private flake inputs
         env:
           GH_FLAKE_A: ${{ secrets.GH_FLAKE_A }}
           GH_FLAKE_B: ${{ secrets.GH_FLAKE_B }}
@@ -71,9 +71,17 @@ jobs:
           echo "$GH_FLAKE_B" > ~/.ssh/flake-b
           chmod 600 ~/.ssh/flake-a ~/.ssh/flake-b
           GH_SCAN=$(ssh-keyscan github.com 2>/dev/null)
+          echo "$GH_SCAN" >> ~/.ssh/known_hosts
           echo "$GH_SCAN" | sed 's/^github.com/github.com-flake-a/' >> ~/.ssh/known_hosts
           echo "$GH_SCAN" | sed 's/^github.com/github.com-flake-b/' >> ~/.ssh/known_hosts
           cat >> ~/.ssh/config <<EOF
+          # nix-config now addresses its private inputs by the real host
+          # (nix-config 760d50b); lp-covertplay is the only one this job
+          # actually fetches over ssh, so its deploy key serves github.com.
+          Host github.com
+            User git
+            IdentityFile ~/.ssh/flake-b
+            IdentitiesOnly yes
           Host github.com-flake-a
             HostName github.com
             User git
@@ -109,10 +117,10 @@ jobs:
       - name: Build NixOS system
         id: build
         run: |
-          # lp-covertplay only depends on the kantor input. Override the other
-          # tenants' private flake inputs (used by porto/doc-project machines)
-          # to the already-cloned nix-config so this job never fetches repos it
-          # has no CI credentials for.
+          # The lp-covertplay machine needs the kantor and lp-covertplay
+          # inputs. Override the other tenants' private flake inputs (used by
+          # porto/doc-project machines) to the already-cloned nix-config so
+          # this job never fetches repos it has no CI credentials for.
           SYSTEM=$(nix build \
             /tmp/nix-config#nixosConfigurations.lp-covertplay.config.system.build.toplevel \
             --override-input kantor . \


### PR DESCRIPTION
## Problem

The `Build & Deploy` run on main (31128963166) failed during `nix build` eval:

```
git@github.com: Permission denied (publickey).
error: Failed to fetch git repository 'ssh://git@github.com/kana-consultant/lp-covertplay'
```

## Root cause

nix-config commit `760d50b` ("fix(flake): address two inputs by their real host, not a local ssh alias") moved the `lp-covertplay` and `segmenter` inputs from the `github.com-flake-a/b` ssh aliases to plain `github.com`, because those aliases only ever existed in one laptop's `~/.ssh/config` and broke on-host deploys.

This workflow's ssh setup only bound `GH_FLAKE_A`/`GH_FLAKE_B` deploy keys to the alias hostnames (`IdentitiesOnly yes`), so a fetch of `ssh://git@github.com/...` has no identity and no known_hosts entry → publickey denied.

The `lp-covertplay` input cannot be overridden away: the `lp-covertplay` machine imports `lp-covertplay.nixosModules.default` (`hosts/lp-covertplay/default.nix`).

## Fix

- Serve the `flake-b` deploy key on plain `github.com` (`lp-covertplay` is the only private input this job still fetches over ssh; the rest stay overridden to the local nix-config clone).
- Add the raw `ssh-keyscan github.com` output to known_hosts.
- Keep the alias host blocks for older locked refs.
- Correct the stale comment claiming the machine only depends on the `kantor` input.

## Verification

- `actionlint`: no errors (only pre-existing SC2001/SC2129 style notes).
- Real proof needs a main run: after merge, the `build` job should get past input fetching. Will re-run `workflow_dispatch` and watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEewDkDprmyH7hqnKsnjsh