### PR TITLE
fix(auth): prefer canonical tenant domain for password reset links

### DIFF
--- a/backend/internal/service/auth/password_reset_test.go
+++ b/backend/internal/service/auth/password_reset_test.go
@@ -1,0 +1,176 @@
+package auth
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/kana-consultant/kantor/backend/internal/model"
+	authrepo "github.com/kana-consultant/kantor/backend/internal/repository/auth"
+	"github.com/kana-consultant/kantor/backend/internal/security"
+)
+
+const testEncryptionKey = "test-data-encryption-key-0123456789abcdef"
+
+type stubPasswordResetRepo struct {
+	authRepository
+	user          model.User
+	mailRecord    authrepo.MailDeliverySettingRecord
+	primaryDomain string
+	domainErr     error
+	createdToken  bool
+}
+
+func (s *stubPasswordResetRepo) GetUserByEmail(ctx context.Context, email string) (model.User, error) {
+	return s.user, nil
+}
+
+func (s *stubPasswordResetRepo) GetMailDeliveryRecord(ctx context.Context) (authrepo.MailDeliverySettingRecord, error) {
+	return s.mailRecord, nil
+}
+
+func (s *stubPasswordResetRepo) CreatePasswordResetToken(ctx context.Context, params authrepo.CreatePasswordResetTokenParams) error {
+	s.createdToken = true
+	return nil
+}
+
+func (s *stubPasswordResetRepo) GetTenantPrimaryDomain(ctx context.Context) (string, error) {
+	return s.primaryDomain, s.domainErr
+}
+
+type stubPasswordResetMailer struct {
+	messages []passwordResetEmail
+}
+
+func (m *stubPasswordResetMailer) SendPasswordReset(ctx context.Context, config resendMailConfig, message passwordResetEmail) error {
+	m.messages = append(m.messages, message)
+	return nil
+}
+
+func newPasswordResetTestService(repo *stubPasswordResetRepo, mailer *stubPasswordResetMailer, appURL string) *Service {
+	enc, err := security.NewEncrypter(testEncryptionKey)
+	if err != nil {
+		panic(err)
+	}
+	record := repo.mailRecord
+	record.Enabled = true
+	record.Provider = "resend"
+	record.SenderName = "Kantor"
+	record.SenderEmail = "noreply@example.com"
+	record.PasswordResetEnabled = true
+	record.PasswordResetExpiryMinutes = 30
+	record.APIKeyEncrypted, err = enc.EncryptString("resend-test-key")
+	if err != nil {
+		panic(err)
+	}
+	repo.mailRecord = record
+
+	return &Service{
+		repo:           repo,
+		passwordMailer: mailer,
+		encrypter:      enc,
+		fallbackAppURL: strings.TrimRight(strings.TrimSpace(appURL), "/"),
+	}
+}
+
+func TestRequestPasswordReset_PrefersCanonicalTenantDomainOverHostBaseURL(t *testing.T) {
+	repo := &stubPasswordResetRepo{
+		user:          model.User{ID: "u1", Email: "user@example.com", FullName: "User", IsActive: true},
+		primaryDomain: "tenant.example.com",
+	}
+	mailer := &stubPasswordResetMailer{}
+	svc := newPasswordResetTestService(repo, mailer, "")
+
+	err := svc.RequestPasswordReset(context.Background(), "user@example.com", PasswordResetRequestMeta{
+		PublicBaseURL: "https://evil.example",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mailer.messages) != 1 {
+		t.Fatalf("expected 1 email, got %d", len(mailer.messages))
+	}
+	wantPrefix := "https://tenant.example.com/reset-password?token="
+	if !strings.HasPrefix(mailer.messages[0].ResetURL, wantPrefix) {
+		t.Fatalf("reset link must use the canonical tenant domain, got %q, want prefix %q", mailer.messages[0].ResetURL, wantPrefix)
+	}
+}
+
+func TestRequestPasswordReset_FallsBackToHostBaseURLWhenNoCanonicalURLConfigured(t *testing.T) {
+	repo := &stubPasswordResetRepo{
+		user: model.User{ID: "u1", Email: "user@example.com", FullName: "User", IsActive: true},
+	}
+	mailer := &stubPasswordResetMailer{}
+	svc := newPasswordResetTestService(repo, mailer, "")
+
+	err := svc.RequestPasswordReset(context.Background(), "user@example.com", PasswordResetRequestMeta{
+		PublicBaseURL: "http://localhost:5173",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantPrefix := "http://localhost:5173/reset-password?token="
+	if !strings.HasPrefix(mailer.messages[0].ResetURL, wantPrefix) {
+		t.Fatalf("expected host fallback, got %q, want prefix %q", mailer.messages[0].ResetURL, wantPrefix)
+	}
+}
+
+func TestRequestPasswordReset_UsesAppURLWhenNoCanonicalURLOrHostConfigured(t *testing.T) {
+	repo := &stubPasswordResetRepo{
+		user: model.User{ID: "u1", Email: "user@example.com", FullName: "User", IsActive: true},
+	}
+	mailer := &stubPasswordResetMailer{}
+	svc := newPasswordResetTestService(repo, mailer, "https://app.example.com")
+
+	err := svc.RequestPasswordReset(context.Background(), "user@example.com", PasswordResetRequestMeta{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantPrefix := "https://app.example.com/reset-password?token="
+	if !strings.HasPrefix(mailer.messages[0].ResetURL, wantPrefix) {
+		t.Fatalf("expected APP_URL fallback, got %q, want prefix %q", mailer.messages[0].ResetURL, wantPrefix)
+	}
+}
+
+func TestRequestPasswordReset_FailsClosedWhenCanonicalDomainLookupErrors(t *testing.T) {
+	repo := &stubPasswordResetRepo{
+		user:      model.User{ID: "u1", Email: "user@example.com", FullName: "User", IsActive: true},
+		domainErr: errTestDomainLookup,
+	}
+	mailer := &stubPasswordResetMailer{}
+	svc := newPasswordResetTestService(repo, mailer, "")
+
+	err := svc.RequestPasswordReset(context.Background(), "user@example.com", PasswordResetRequestMeta{
+		PublicBaseURL: "https://evil.example",
+	})
+	if err == nil {
+		t.Fatal("expected error when canonical domain lookup fails, got nil")
+	}
+	if len(mailer.messages) != 0 {
+		t.Fatalf("must not send an email with a Host-derived URL when canonical lookup fails, got %d message(s)", len(mailer.messages))
+	}
+}
+
+func TestRequestPasswordReset_InactiveUserSendsNoEmail(t *testing.T) {
+	repo := &stubPasswordResetRepo{
+		user:          model.User{ID: "u1", Email: "user@example.com", FullName: "User", IsActive: false},
+		primaryDomain: "tenant.example.com",
+	}
+	mailer := &stubPasswordResetMailer{}
+	svc := newPasswordResetTestService(repo, mailer, "")
+
+	err := svc.RequestPasswordReset(context.Background(), "user@example.com", PasswordResetRequestMeta{
+		PublicBaseURL: "https://evil.example",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mailer.messages) != 0 {
+		t.Fatalf("inactive user must not receive a reset email, got %d message(s)", len(mailer.messages))
+	}
+	if repo.createdToken {
+		t.Fatal("inactive user must not get a reset token created")
+	}
+}
+
+var errTestDomainLookup = context.DeadlineExceeded

--- a/backend/internal/service/auth/service.go
+++ b/backend/internal/service/auth/service.go
@@ -381,12 +381,12 @@ func (s *Service) RequestPasswordReset(ctx context.Context, email string, meta P
 		return nil
 	}
 
-	baseURL := strings.TrimRight(strings.TrimSpace(meta.PublicBaseURL), "/")
+	baseURL, err := tenant.ResolveBaseURL(ctx, s.repo, s.fallbackAppURL)
+	if err != nil {
+		return err
+	}
 	if baseURL == "" {
-		baseURL, err = tenant.ResolveBaseURL(ctx, s.repo, s.fallbackAppURL)
-		if err != nil {
-			return err
-		}
+		baseURL = strings.TrimRight(strings.TrimSpace(meta.PublicBaseURL), "/")
 	}
 	if baseURL == "" {
 		return ErrPasswordResetDisabled


### PR DESCRIPTION
## Summary
Password reset emails currently build their reset link from the request's `Host` header and the first `X-Forwarded-Proto` header. Neither value is checked against a trusted-proxy list, so anyone who can control request headers also controls the link inside an email sent to a real user's inbox. This PR makes the service prefer the operator-configured canonical tenant domain instead, and demotes the request-derived URL to a last-resort fallback for local and dev setups.

## Problem
In `RequestPasswordReset`, `backend/internal/service/auth/service.go:384` picked `meta.PublicBaseURL` first. That value is assembled by `requestPublicBaseURL` in `backend/internal/handler/auth/handler.go:493-514` from `r.Host` and the first `X-Forwarded-Proto` header, with no validation against a configured trusted-proxy list. A client can set both freely.
Combined with the fact that the email goes to the real account owner, this creates a phishing chain: the victim clicks a link that looks like it came from Kantor, it lands on an attacker-controlled domain, and the token in the URL lets the attacker take over the account.

## Changes
- `backend/internal/service/auth/service.go:384-390`: inverted the priority. `tenant.ResolveBaseURL` (primary tenant domain, then `APP_URL` config) is resolved first. The Host-derived `PublicBaseURL` is used only when canonical resolution comes back empty, which keeps localhost and dev setups working unchanged.
- Fail closed: if the tenant domain lookup errors, the request returns an error instead of silently falling back to the Host-derived URL and emailing a link the operator does not control.
- New tests in `password_reset_test.go`:
  - canonical tenant domain wins over a poisoned Host-derived URL
  - Host fallback when no domain and no `APP_URL` are configured
  - `APP_URL` fallback when nothing else is set
  - fail-closed behavior on domain lookup errors
  - inactive accounts get no email and no token
Out of scope: the OAuth authorize flows still use `requestPublicBaseURL` (`oauth.go`). Those redirect the browser to a consent page, so they rely on the URL the browser itself used, which is a different trust model. They are left untouched to keep this change small and reviewable.

## Test plan
Backend checks, all run locally:
- `go build ./...` passes
- `go vet ./...` passes
- `go test ./...` passes, 19/19 packages, including the 5 new tests
Worth a quick manual check: with a primary tenant domain configured, request a password reset while sending a spoofed `Host` header (`curl -H "Host: evil.example" ...`), and confirm the emailed link still uses the tenant domain.

## Screenshots
None, backend-only change.
