### PR TITLE
fix(kanban): move task filters to the server

### DIFF
--- a/backend/internal/dto/operational/kanban.go
+++ b/backend/internal/dto/operational/kanban.go
@@ -52,3 +52,9 @@ type MyTaskItem struct {
 	DueDate     string `json:"due_date"`
 	Priority    string `json:"priority"`
 }
+
+type ListKanbanTasksQuery struct {
+	ColumnID string
+	Limit    int
+	Offset   int
+}

--- a/backend/internal/dto/operational/kanban.go
+++ b/backend/internal/dto/operational/kanban.go
@@ -54,7 +54,11 @@ type MyTaskItem struct {
 }
 
 type ListKanbanTasksQuery struct {
-	ColumnID string
-	Limit    int
-	Offset   int
+	ColumnID   string
+	AssigneeID string
+	Priority   string
+	Label      string
+	DueDate    string
+	Limit      int
+	Offset     int
 }

--- a/backend/internal/dto/operational/kanban_task_page.go
+++ b/backend/internal/dto/operational/kanban_task_page.go
@@ -1,0 +1,11 @@
+package operational
+
+import "github.com/kana-consultant/kantor/backend/internal/model"
+
+type KanbanTaskPage struct {
+	Items   []model.KanbanTask `json:"items"`
+	Total   int                `json:"total"`
+	Limit   int                `json:"limit"`
+	Offset  int                `json:"offset"`
+	HasMore bool               `json:"has_more"`
+}

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-playground/validator/v10"
@@ -181,12 +182,10 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	query := operationaldto.ListKanbanTasksQuery{
-		AssigneeID: strings.TrimSpace(r.URL.Query().Get("assignee_id")),
-		Priority:   strings.TrimSpace(r.URL.Query().Get("priority")),
-		Label:      strings.TrimSpace(r.URL.Query().Get("label")),
-		DueDate:    strings.TrimSpace(r.URL.Query().Get("due_date")),
-		Limit:      parseKanbanPositiveInt(r.URL.Query().Get("limit")),
-		Offset:     parseKanbanPositiveInt(r.URL.Query().Get("offset")),
+		Priority: strings.TrimSpace(r.URL.Query().Get("priority")),
+		Label:    strings.TrimSpace(r.URL.Query().Get("label")),
+		Limit:    parseKanbanPositiveInt(r.URL.Query().Get("limit")),
+		Offset:   parseKanbanPositiveInt(r.URL.Query().Get("offset")),
 	}
 	if columnID := strings.TrimSpace(r.URL.Query().Get("column_id")); columnID != "" {
 		validatedColumnID, ok := validateKanbanUUIDParam(w, "column_id", columnID)
@@ -194,6 +193,20 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		query.ColumnID = validatedColumnID
+	}
+	if assigneeID := strings.TrimSpace(r.URL.Query().Get("assignee_id")); assigneeID != "" {
+		validatedAssigneeID, ok := validateKanbanUUIDParam(w, "assignee_id", assigneeID)
+		if !ok {
+			return
+		}
+		query.AssigneeID = validatedAssigneeID
+	}
+	if dueDate := strings.TrimSpace(r.URL.Query().Get("due_date")); dueDate != "" {
+		if _, err := time.Parse("2006-01-02", dueDate); err != nil {
+			response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "due_date must be formatted as YYYY-MM-DD", map[string]string{"due_date": "invalid date"})
+			return
+		}
+		query.DueDate = dueDate
 	}
 
 	result, err := h.service.ListTasksPage(r.Context(), projectID, query)

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -181,8 +181,12 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	query := operationaldto.ListKanbanTasksQuery{
-		Limit:  parseKanbanPositiveInt(r.URL.Query().Get("limit")),
-		Offset: parseKanbanPositiveInt(r.URL.Query().Get("offset")),
+		AssigneeID: strings.TrimSpace(r.URL.Query().Get("assignee_id")),
+		Priority:   strings.TrimSpace(r.URL.Query().Get("priority")),
+		Label:      strings.TrimSpace(r.URL.Query().Get("label")),
+		DueDate:    strings.TrimSpace(r.URL.Query().Get("due_date")),
+		Limit:      parseKanbanPositiveInt(r.URL.Query().Get("limit")),
+		Offset:     parseKanbanPositiveInt(r.URL.Query().Get("offset")),
 	}
 	if columnID := strings.TrimSpace(r.URL.Query().Get("column_id")); columnID != "" {
 		validatedColumnID, ok := validateKanbanUUIDParam(w, "column_id", columnID)

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -179,13 +180,34 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.service.ListTasks(r.Context(), projectID)
+	query := operationaldto.ListKanbanTasksQuery{
+		Limit:  parseKanbanPositiveInt(r.URL.Query().Get("limit")),
+		Offset: parseKanbanPositiveInt(r.URL.Query().Get("offset")),
+	}
+	if columnID := strings.TrimSpace(r.URL.Query().Get("column_id")); columnID != "" {
+		validatedColumnID, ok := validateKanbanUUIDParam(w, "column_id", columnID)
+		if !ok {
+			return
+		}
+		query.ColumnID = validatedColumnID
+	}
+
+	result, err := h.service.ListTasksPage(r.Context(), projectID, query)
 	if err != nil {
 		h.writeError(r.Context(), w, err)
 		return
 	}
 
 	response.WriteJSON(w, http.StatusOK, result, nil)
+}
+
+func parseKanbanPositiveInt(raw string) int {
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || value < 0 {
+		return 0
+	}
+
+	return value
 }
 
 // ListMyTasks handles GET /operational/tasks/mine, self-scoped to the caller.

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -25,9 +25,13 @@ const (
 )
 
 type ListKanbanTasksFilter struct {
-	ColumnID string
-	Limit    int
-	Offset   int
+	ColumnID   string
+	AssigneeID string
+	Priority   string
+	Label      string
+	DueDate    string
+	Limit      int
+	Offset     int
 }
 
 type KanbanRepository struct {
@@ -390,9 +394,18 @@ func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID stri
 		LEFT JOIN users ON users.id = kanban_tasks.assignee_id
 		WHERE kanban_tasks.project_id = $1::uuid
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
+		  AND ($5 = '' OR kanban_tasks.assignee_id = $5::uuid)
+		  AND ($6 = '' OR kanban_tasks.priority = $6)
+		  AND ($7 = '' OR kanban_tasks.label ILIKE '%' || $7 || '%')
+		  AND ($8 = '' OR kanban_tasks.due_date::date = $8::date)
 		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC, kanban_tasks.id ASC
 		LIMIT NULLIF($3, 0) OFFSET $4
-	`, projectID, columnID, limit, offset)
+	`, projectID, columnID, limit, offset,
+		strings.TrimSpace(filter.AssigneeID),
+		strings.TrimSpace(filter.Priority),
+		strings.TrimSpace(filter.Label),
+		strings.TrimSpace(filter.DueDate),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -390,7 +390,7 @@ func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID stri
 		LEFT JOIN users ON users.id = kanban_tasks.assignee_id
 		WHERE kanban_tasks.project_id = $1::uuid
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
-		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC
+		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC, kanban_tasks.id ASC
 		LIMIT NULLIF($3, 0) OFFSET $4
 	`, projectID, columnID, limit, offset)
 	if err != nil {

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -17,6 +17,19 @@ var (
 	ErrKanbanTaskNotFound   = errors.New("kanban task not found")
 )
 
+const (
+	defaultKanbanTaskLimit = 20
+	maxKanbanTaskLimit     = 100
+
+	KanbanTaskLimitAll = -1
+)
+
+type ListKanbanTasksFilter struct {
+	ColumnID string
+	Limit    int
+	Offset   int
+}
+
 type KanbanRepository struct {
 	db repository.DBTX
 }
@@ -335,8 +348,26 @@ func (r *KanbanRepository) ReorderColumns(ctx context.Context, projectID string,
 }
 
 func (r *KanbanRepository) ListTasks(ctx context.Context, projectID string) ([]model.KanbanTask, error) {
+	return r.ListTasksFiltered(ctx, projectID, ListKanbanTasksFilter{Limit: KanbanTaskLimitAll})
+}
+
+func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID string, filter ListKanbanTasksFilter) ([]model.KanbanTask, error) {
 	ctx, cancel := repository.QueryContext(ctx)
 	defer cancel()
+	columnID := strings.TrimSpace(filter.ColumnID)
+	limit := filter.Limit
+	switch {
+	case limit == KanbanTaskLimitAll:
+		limit = 0
+	case limit <= 0:
+		limit = defaultKanbanTaskLimit
+	case limit > maxKanbanTaskLimit:
+		limit = maxKanbanTaskLimit
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
+	}
 	rows, err := repository.DB(ctx, r.db).Query(ctx, `
 		SELECT
 			kanban_tasks.id::text,
@@ -358,8 +389,10 @@ func (r *KanbanRepository) ListTasks(ctx context.Context, projectID string) ([]m
 		FROM kanban_tasks
 		LEFT JOIN users ON users.id = kanban_tasks.assignee_id
 		WHERE kanban_tasks.project_id = $1::uuid
+		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
 		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC
-	`, projectID)
+		LIMIT NULLIF($3, 0) OFFSET $4
+	`, projectID, columnID, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -396,14 +396,14 @@ func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID stri
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
 		  AND ($5 = '' OR kanban_tasks.assignee_id = $5::uuid)
 		  AND ($6 = '' OR kanban_tasks.priority = $6)
-		  AND ($7 = '' OR kanban_tasks.label ILIKE '%' || $7 || '%')
+		  AND ($7 = '' OR kanban_tasks.label ILIKE '%' || $7 || '%' ESCAPE '\')
 		  AND ($8 = '' OR kanban_tasks.due_date::date = $8::date)
 		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC, kanban_tasks.id ASC
 		LIMIT NULLIF($3, 0) OFFSET $4
 	`, projectID, columnID, limit, offset,
 		strings.TrimSpace(filter.AssigneeID),
 		strings.TrimSpace(filter.Priority),
-		strings.TrimSpace(filter.Label),
+		escapeLikePattern(strings.TrimSpace(filter.Label)),
 		strings.TrimSpace(filter.DueDate),
 	)
 	if err != nil {

--- a/backend/internal/repository/operational/kanban_count.go
+++ b/backend/internal/repository/operational/kanban_count.go
@@ -1,0 +1,23 @@
+package operational
+
+import (
+	"context"
+	"strings"
+
+	repository "github.com/kana-consultant/kantor/backend/internal/repository"
+)
+
+func (r *KanbanRepository) CountTasks(ctx context.Context, projectID string, filter ListKanbanTasksFilter) (int, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var total int
+	err := repository.DB(ctx, r.db).QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM kanban_tasks
+		WHERE kanban_tasks.project_id = $1::uuid
+		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
+	`, projectID, strings.TrimSpace(filter.ColumnID)).Scan(&total)
+
+	return total, err
+}

--- a/backend/internal/repository/operational/kanban_count.go
+++ b/backend/internal/repository/operational/kanban_count.go
@@ -19,15 +19,21 @@ func (r *KanbanRepository) CountTasks(ctx context.Context, projectID string, fil
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
 		  AND ($3 = '' OR kanban_tasks.assignee_id = $3::uuid)
 		  AND ($4 = '' OR kanban_tasks.priority = $4)
-		  AND ($5 = '' OR kanban_tasks.label ILIKE '%' || $5 || '%')
+		  AND ($5 = '' OR kanban_tasks.label ILIKE '%' || $5 || '%' ESCAPE '\')
 		  AND ($6 = '' OR kanban_tasks.due_date::date = $6::date)
 	`, projectID,
 		strings.TrimSpace(filter.ColumnID),
 		strings.TrimSpace(filter.AssigneeID),
 		strings.TrimSpace(filter.Priority),
-		strings.TrimSpace(filter.Label),
+		escapeLikePattern(strings.TrimSpace(filter.Label)),
 		strings.TrimSpace(filter.DueDate),
 	).Scan(&total)
 
 	return total, err
+}
+
+// escapeLikePattern escapes LIKE/ILIKE wildcards so a user-supplied filter term
+// matches those characters literally. Pair it with `ESCAPE '\'` in the query.
+func escapeLikePattern(value string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(value)
 }

--- a/backend/internal/repository/operational/kanban_count.go
+++ b/backend/internal/repository/operational/kanban_count.go
@@ -17,7 +17,17 @@ func (r *KanbanRepository) CountTasks(ctx context.Context, projectID string, fil
 		FROM kanban_tasks
 		WHERE kanban_tasks.project_id = $1::uuid
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
-	`, projectID, strings.TrimSpace(filter.ColumnID)).Scan(&total)
+		  AND ($3 = '' OR kanban_tasks.assignee_id = $3::uuid)
+		  AND ($4 = '' OR kanban_tasks.priority = $4)
+		  AND ($5 = '' OR kanban_tasks.label ILIKE '%' || $5 || '%')
+		  AND ($6 = '' OR kanban_tasks.due_date::date = $6::date)
+	`, projectID,
+		strings.TrimSpace(filter.ColumnID),
+		strings.TrimSpace(filter.AssigneeID),
+		strings.TrimSpace(filter.Priority),
+		strings.TrimSpace(filter.Label),
+		strings.TrimSpace(filter.DueDate),
+	).Scan(&total)
 
 	return total, err
 }

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -33,6 +33,8 @@ type kanbanRepository interface {
 	DeleteColumn(ctx context.Context, projectID string, columnID string) error
 	ReorderColumns(ctx context.Context, projectID string, columnIDs []string) error
 	ListTasks(ctx context.Context, projectID string) ([]model.KanbanTask, error)
+	ListTasksFiltered(ctx context.Context, projectID string, filter operationalrepo.ListKanbanTasksFilter) ([]model.KanbanTask, error)
+	CountTasks(ctx context.Context, projectID string, filter operationalrepo.ListKanbanTasksFilter) (int, error)
 	CreateTask(ctx context.Context, projectID string, params operationalrepo.CreateKanbanTaskParams) (model.KanbanTask, error)
 	UpdateTask(ctx context.Context, projectID string, taskID string, params operationalrepo.UpdateKanbanTaskParams) (model.KanbanTask, error)
 	DeleteTask(ctx context.Context, projectID string, taskID string) error
@@ -118,6 +120,32 @@ func (s *KanbanService) ReorderColumns(ctx context.Context, projectID string, re
 
 func (s *KanbanService) ListTasks(ctx context.Context, projectID string) ([]model.KanbanTask, error) {
 	return s.repo.ListTasks(ctx, projectID)
+}
+
+func (s *KanbanService) ListTasksPage(ctx context.Context, projectID string, query operationaldto.ListKanbanTasksQuery) (operationaldto.KanbanTaskPage, error) {
+	filter := operationalrepo.ListKanbanTasksFilter{
+		ColumnID: strings.TrimSpace(query.ColumnID),
+		Limit:    query.Limit,
+		Offset:   query.Offset,
+	}
+
+	tasks, err := s.repo.ListTasksFiltered(ctx, projectID, filter)
+	if err != nil {
+		return operationaldto.KanbanTaskPage{}, err
+	}
+
+	total, err := s.repo.CountTasks(ctx, projectID, filter)
+	if err != nil {
+		return operationaldto.KanbanTaskPage{}, err
+	}
+
+	return operationaldto.KanbanTaskPage{
+		Items:   tasks,
+		Total:   total,
+		Limit:   query.Limit,
+		Offset:  query.Offset,
+		HasMore: query.Offset+len(tasks) < total,
+	}, nil
 }
 
 // ListMyTasks returns the caller's assigned tasks across all projects,

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -124,9 +124,13 @@ func (s *KanbanService) ListTasks(ctx context.Context, projectID string) ([]mode
 
 func (s *KanbanService) ListTasksPage(ctx context.Context, projectID string, query operationaldto.ListKanbanTasksQuery) (operationaldto.KanbanTaskPage, error) {
 	filter := operationalrepo.ListKanbanTasksFilter{
-		ColumnID: strings.TrimSpace(query.ColumnID),
-		Limit:    query.Limit,
-		Offset:   query.Offset,
+		ColumnID:   strings.TrimSpace(query.ColumnID),
+		AssigneeID: strings.TrimSpace(query.AssigneeID),
+		Priority:   strings.TrimSpace(query.Priority),
+		Label:      strings.TrimSpace(query.Label),
+		DueDate:    strings.TrimSpace(query.DueDate),
+		Limit:      query.Limit,
+		Offset:     query.Offset,
 	}
 
 	tasks, err := s.repo.ListTasksFiltered(ctx, projectID, filter)

--- a/backend/internal/service/operational/kanban_test.go
+++ b/backend/internal/service/operational/kanban_test.go
@@ -173,6 +173,14 @@ func (f *fakeKanbanRepository) ListTasks(ctx context.Context, projectID string) 
 	return nil, nil
 }
 
+func (f *fakeKanbanRepository) ListTasksFiltered(ctx context.Context, projectID string, filter operationalrepo.ListKanbanTasksFilter) ([]model.KanbanTask, error) {
+	return nil, nil
+}
+
+func (f *fakeKanbanRepository) CountTasks(ctx context.Context, projectID string, filter operationalrepo.ListKanbanTasksFilter) (int, error) {
+	return 0, nil
+}
+
 func (f *fakeKanbanRepository) CreateTask(ctx context.Context, projectID string, params operationalrepo.CreateKanbanTaskParams) (model.KanbanTask, error) {
 	if f.createTaskFunc == nil {
 		return model.KanbanTask{}, nil

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -27,7 +27,6 @@ import {
 	type ColumnModalState,
 } from "@/components/shared/kanban-dialogs";
 import {
-	matchesFilters,
 } from "@/components/shared/kanban-dnd";
 import { useKanbanDrag } from "@/hooks/use-kanban-drag";
 import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
@@ -157,10 +156,14 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		() => Object.values(loadedTasks).flat(),
 		[loadedTasks],
 	);
-	const filterTasks = useCallback(
-		(columnTasks: KanbanTask[]) =>
-			columnTasks.filter((task) => matchesFilters(task, filters)),
-		[filters],
+	const taskFilters = useMemo(
+		() => ({
+			assigneeId: filters.assignee,
+			priority: filters.priority,
+			label: filters.label,
+			dueDate: filters.dueDate,
+		}),
+		[filters.assignee, filters.dueDate, filters.label, filters.priority],
 	);
 
 	useEffect(() => {
@@ -302,7 +305,7 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 							{columns.map((column) => (
 								<KanbanColumnContainer
 									column={column}
-									filterTasks={filterTasks}
+									filters={taskFilters}
 									key={column.id}
 									onDeleteColumn={() => setColumnToDelete(column)}
 									onEditColumn={() => startColumnEdit(column)}

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -26,8 +26,6 @@ import {
 	KanbanDialogs,
 	type ColumnModalState,
 } from "@/components/shared/kanban-dialogs";
-import {
-} from "@/components/shared/kanban-dnd";
 import { useKanbanDrag } from "@/hooks/use-kanban-drag";
 import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
 import { KanbanToolbar } from "@/components/shared/kanban-toolbar";

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -5,56 +5,41 @@ import {
 	DragOverlay,
 	PointerSensor,
 	closestCorners,
-	useDroppable,
 	useSensor,
 	useSensors,
-	type DragEndEvent,
-	type DragStartEvent,
 } from "@dnd-kit/core";
 import {
 	SortableContext,
-	arrayMove,
 	horizontalListSortingStrategy,
-	useSortable,
-	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useForm, type UseFormReturn } from "react-hook-form";
+import { useQuery } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { GripVertical, Plus } from "lucide-react";
 
-import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+
 import {
-	Drawer,
-	DrawerBody,
-	DrawerClose,
-	DrawerContent,
-	DrawerDescription,
-	DrawerHeader,
-	DrawerTitle,
-} from "@/components/shared/drawer";
-import { FormModal } from "@/components/shared/form-modal";
-import { PermissionGate } from "@/components/shared/permission-gate";
-import { ProtectedAvatar } from "@/components/shared/protected-avatar";
-import { Button } from "@/components/ui/button";
+	ColumnOverlay,
+	KanbanColumnCard,
+	TaskOverlay,
+} from "@/components/shared/kanban-cards";
+import {
+	KanbanDialogs,
+	type ColumnModalState,
+} from "@/components/shared/kanban-dialogs";
+import {
+	matchesFilters,
+	sortTaskList,
+} from "@/components/shared/kanban-dnd";
+import { useKanbanDrag } from "@/hooks/use-kanban-drag";
+import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
+import { KanbanToolbar } from "@/components/shared/kanban-toolbar";
+import { TaskModal } from "@/components/shared/task-modal";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { permissions } from "@/lib/permissions";
-import { extractDateInputValue, formatCalendarDate } from "@/lib/date";
-import { cn } from "@/lib/utils";
+import { extractDateInputValue } from "@/lib/date";
 import {
-	createKanbanColumn,
-	createKanbanTask,
-	deleteKanbanColumn,
-	deleteKanbanTask,
 	kanbanKeys,
 	listKanbanColumns,
 	listKanbanTasks,
-	moveKanbanTask,
-	reorderKanbanColumns,
-	updateKanbanColumn,
-	updateKanbanTask,
 } from "@/services/operational-kanban";
 import type {
 	KanbanColumn,
@@ -62,7 +47,7 @@ import type {
 	KanbanTask,
 	TaskFormValues,
 } from "@/types/kanban";
-import type { ProjectMember, ProjectPriority } from "@/types/project";
+import type { ProjectMember } from "@/types/project";
 
 const taskSchema = z.object({
 	title: z.string().trim().min(2, "Judul minimal 2 karakter").max(160),
@@ -96,22 +81,11 @@ interface KanbanBoardProps {
 	members: ProjectMember[];
 }
 
-interface DragSnapshot {
-	columns: KanbanColumn[];
-	tasks: KanbanTask[];
-}
-
-type ColumnModalState = { mode: "create" } | { mode: "edit"; columnId: string };
-
 type TaskModalState =
 	| { mode: "create"; columnId: string }
 	| { mode: "edit"; columnId: string; taskId: string };
 
-type DragTaskData = { type: "task"; task: KanbanTask };
-type DragColumnData = { type: "column"; column: KanbanColumn };
-
 export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
-	const queryClient = useQueryClient();
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
 	);
@@ -126,9 +100,6 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	const [columnForm, setColumnForm] = useState({ name: "", color: "#38BDF8" });
 	const [taskModal, setTaskModal] = useState<TaskModalState | null>(null);
 	const [boardError, setBoardError] = useState<string | null>(null);
-	const [activeTask, setActiveTask] = useState<KanbanTask | null>(null);
-	const [activeColumn, setActiveColumn] = useState<KanbanColumn | null>(null);
-	const [dragSnapshot, setDragSnapshot] = useState<DragSnapshot | null>(null);
 	const [columnToDelete, setColumnToDelete] = useState<KanbanColumn | null>(
 		null,
 	);
@@ -148,82 +119,34 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		resolver: zodResolver(taskSchema),
 		defaultValues: emptyTaskForm,
 	});
-
-	const createColumnMutation = useMutation({
-		mutationFn: (payload: { name: string; color?: string }) =>
-			createKanbanColumn(projectId, payload),
-		onSuccess: async () => {
+	const {
+		createColumn: createColumnMutation,
+		updateColumn: updateColumnMutation,
+		deleteColumn: deleteColumnMutation,
+		createTask: createTaskMutation,
+		updateTask: updateTaskMutation,
+		deleteTask: deleteTaskMutation,
+	} = useKanbanMutations(projectId, {
+		onError: setBoardError,
+		onColumnSaved: () => {
 			setColumnForm({ name: "", color: "#38BDF8" });
 			setColumnModal(null);
-			await invalidateBoard(queryClient, projectId);
 		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const updateColumnMutation = useMutation({
-		mutationFn: (payload: { columnId: string; name: string; color?: string }) =>
-			updateKanbanColumn(projectId, payload.columnId, {
-				name: payload.name,
-				color: payload.color,
-			}),
-		onSuccess: async () => {
-			setColumnModal(null);
-			await invalidateBoard(queryClient, projectId);
-		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const deleteColumnMutation = useMutation({
-		mutationFn: (columnId: string) => deleteKanbanColumn(projectId, columnId),
-		onSuccess: async () => {
-			setColumnToDelete(null);
-			await invalidateBoard(queryClient, projectId);
-		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const createTaskMutation = useMutation({
-		mutationFn: (payload: { column_id: string } & TaskFormValues) =>
-			createKanbanTask(projectId, payload),
-		onSuccess: async () => {
+		onColumnDeleted: () => setColumnToDelete(null),
+		onTaskSaved: () => {
 			form.reset(emptyTaskForm);
 			setTaskModal(null);
-			await invalidateBoard(queryClient, projectId);
 		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const updateTaskMutation = useMutation({
-		mutationFn: (payload: { taskId: string; values: TaskFormValues }) =>
-			updateKanbanTask(projectId, payload.taskId, payload.values),
-		onSuccess: async () => {
-			form.reset(emptyTaskForm);
-			setTaskModal(null);
-			await invalidateBoard(queryClient, projectId);
-		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const deleteTaskMutation = useMutation({
-		mutationFn: (taskId: string) => deleteKanbanTask(projectId, taskId),
-		onSuccess: async () => {
+		onTaskDeleted: () => {
 			form.reset(emptyTaskForm);
 			setTaskModal(null);
 			setTaskToDelete(null);
-			await invalidateBoard(queryClient, projectId);
 		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
 	});
 
 	const columns = columnsQuery.data ?? [];
 	const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
 	const filteredTasks = tasks.filter((task) => matchesFilters(task, filters));
-	const activeFilterCount = [
-		filters.assignee,
-		filters.priority,
-		filters.label,
-		filters.dueDate,
-	].filter(Boolean).length;
 
 	useEffect(() => {
 		if (!taskModal) {
@@ -318,80 +241,8 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		setColumnForm({ name: "", color: "#38BDF8" });
 	}
 
-	function handleDragStart(event: DragStartEvent) {
-		const data = event.active.data.current;
-
-		if (isTaskDragData(data)) {
-			setActiveTask(data.task);
-			setDragSnapshot({ columns, tasks });
-			return;
-		}
-
-		if (isColumnDragData(data)) {
-			setActiveColumn(data.column);
-			setDragSnapshot({ columns, tasks });
-		}
-	}
-
-	function rollbackDrag() {
-		if (!dragSnapshot) {
-			return;
-		}
-
-		queryClient.setQueryData(
-			kanbanKeys.columns(projectId),
-			dragSnapshot.columns,
-		);
-		queryClient.setQueryData(kanbanKeys.tasks(projectId), dragSnapshot.tasks);
-	}
-
-	function resetDrag() {
-		setActiveTask(null);
-		setActiveColumn(null);
-		setDragSnapshot(null);
-	}
-
-	function handleDragEnd(event: DragEndEvent) {
-		if (!event.over) {
-			rollbackDrag();
-			resetDrag();
-			return;
-		}
-
-		const activeData = event.active.data.current;
-
-		if (isColumnDragData(activeData)) {
-			finishColumnDrag(
-				event,
-				columns,
-				tasks,
-				dragSnapshot,
-				queryClient,
-				projectId,
-			);
-			resetDrag();
-			return;
-		}
-
-		if (isTaskDragData(activeData)) {
-			const nextTasks = moveTaskInMemory(
-				dragSnapshot?.tasks ?? tasks,
-				activeData.task.id,
-				event.over.data.current,
-				event.over.id.toString(),
-			);
-
-			finishTaskDrag(
-				activeData.task.id,
-				nextTasks,
-				dragSnapshot,
-				queryClient,
-				projectId,
-			);
-		}
-
-		resetDrag();
-	}
+	const { activeTask, activeColumn, handleDragStart, handleDragEnd } =
+		useKanbanDrag(projectId, columns, tasks);
 
 	if (columnsQuery.isLoading || tasksQuery.isLoading) {
 		return <Card className="p-8">Memuat board proyek...</Card>;
@@ -412,111 +263,15 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 
 	return (
 		<div className="space-y-6">
-			<Card className="p-6">
-				<div className="flex flex-col gap-5">
-					<div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-						<div>
-							<p className="mb-1 text-[11px] font-[700] uppercase tracking-[0.08em] text-ops">
-								Board proyek
-							</p>
-							<h4 className="text-[20px] font-[700] text-text-primary leading-tight">
-								Ruang kerja task proyek
-							</h4>
-							<p className="mt-1 max-w-3xl text-[13px] text-text-secondary">
-								Kelola task proyek dalam satu board, pindahkan kartu antar tahap
-								kerja, dan gunakan filter tanpa keluar dari halaman ini.
-							</p>
-						</div>
-
-						<PermissionGate permission={permissions.operationalColumnManage}>
-							<div className="flex w-full flex-col items-stretch gap-3 xl:w-auto xl:items-end">
-								<Button
-									variant="ops"
-									className="xl:self-end"
-									onClick={() => {
-										setBoardError(null);
-										startColumnCreate();
-									}}
-									type="button">
-									<Plus className="h-4 w-4" />
-									Kolom baru
-								</Button>
-							</div>
-						</PermissionGate>
-					</div>
-
-					<div className="grid gap-4 xl:grid-cols-[repeat(4,minmax(0,1fr))_auto]">
-						<select
-							className="flex h-[44px] w-full rounded-[6px] border border-transparent bg-surface-muted px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
-							onChange={(event) =>
-								setFilters((current) => ({
-									...current,
-									assignee: event.target.value,
-								}))
-							}
-							value={filters.assignee}>
-							<option value="">Semua PIC</option>
-							{members.map((member) => (
-								<option
-									key={member.user_id}
-									value={member.user_id}>
-									{member.full_name || member.user_email || member.user_id}
-								</option>
-							))}
-						</select>
-						<select
-							className="flex h-[44px] w-full rounded-[6px] border border-transparent bg-surface-muted px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
-							onChange={(event) =>
-								setFilters((current) => ({
-									...current,
-									priority: event.target.value,
-								}))
-							}
-							value={filters.priority}>
-							<option value="">Semua prioritas</option>
-							<option value="low">Rendah</option>
-							<option value="medium">Medium</option>
-							<option value="high">Tinggi</option>
-							<option value="critical">Kritis</option>
-						</select>
-						<Input
-							className="h-[44px] focus-visible:border-ops focus-visible:ring-ops/10"
-							onChange={(event) =>
-								setFilters((current) => ({
-									...current,
-									label: event.target.value,
-								}))
-							}
-							placeholder="Filter label"
-							value={filters.label}
-						/>
-						<Input
-							className="h-[44px] focus-visible:border-ops focus-visible:ring-ops/10"
-							onChange={(event) =>
-								setFilters((current) => ({
-									...current,
-									dueDate: event.target.value,
-								}))
-							}
-							type="date"
-							value={filters.dueDate}
-						/>
-						<Button
-							onClick={() =>
-								setFilters({
-									assignee: "",
-									priority: "",
-									label: "",
-									dueDate: "",
-								})
-							}
-							variant="secondary"
-							className="h-[44px]">
-							Reset {activeFilterCount > 0 ? `(${activeFilterCount})` : ""}
-						</Button>
-					</div>
-				</div>
-			</Card>
+			<KanbanToolbar
+				filters={filters}
+				members={members}
+				onColumnCreate={() => {
+					setBoardError(null);
+					startColumnCreate();
+				}}
+				onFiltersChange={setFilters}
+			/>
 
 			{boardError ? (
 				<Card className="p-4 text-[13px] font-[500] text-priority-high border-priority-high/20 bg-priority-high/5">
@@ -602,871 +357,36 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 				/>
 			) : null}
 
-			<FormModal
-				isLoading={
+			<KanbanDialogs
+				columnColorOptions={columnColorOptions}
+				columnForm={columnForm}
+				columnModal={columnModal}
+				columnToDelete={columnToDelete}
+				isColumnDeleting={deleteColumnMutation.isPending}
+				isColumnSaving={
 					createColumnMutation.isPending || updateColumnMutation.isPending
 				}
-				isOpen={Boolean(columnModal)}
-				onClose={() => {
-					setColumnModal(null);
-					setColumnForm({ name: "", color: "#38BDF8" });
-				}}
-				onSubmit={(event) => {
-					event.preventDefault();
-					handleColumnSubmit();
-				}}
-				size="sm"
-				submitLabel={
-					columnModal?.mode === "edit" ? "Simpan kolom" : "Buat kolom"
-				}
-				title={columnModal?.mode === "edit" ? "Edit kolom" : "Buat kolom"}
-				subtitle="Gunakan nama singkat dan warna aksen yang jelas agar kolom mudah dipindai di board.">
-				<div className="space-y-2">
-					<label className="text-[13px] font-[600] text-text-primary">
-						Nama kolom
-					</label>
-					<Input
-						className="focus-visible:border-ops focus-visible:ring-ops/10"
-						onChange={(event) =>
-							setColumnForm((current) => ({
-								...current,
-								name: event.target.value,
-							}))
-						}
-						placeholder="Review"
-						value={columnForm.name}
-					/>
-				</div>
-				<div className="space-y-2">
-					<p className="text-[13px] font-[600] text-text-primary">
-						Warna aksen
-					</p>
-					<div className="flex flex-wrap gap-2">
-						{columnColorOptions.map((color) => (
-							<button
-								aria-label={`Choose list color ${color}`}
-								className={cn(
-									"h-9 w-9 rounded-full border-2 transition hover:scale-105",
-									columnForm.color === color
-										? "border-foreground shadow-sm"
-										: "border-transparent",
-								)}
-								key={color}
-								onClick={() =>
-									setColumnForm((current) => ({ ...current, color }))
-								}
-								style={{ backgroundColor: color }}
-								type="button"
-							/>
-						))}
-					</div>
-				</div>
-			</FormModal>
-
-			<ConfirmDialog
-				confirmLabel="Hapus kolom"
-				description={
-					columnToDelete
-						? `Semua task di dalam "${columnToDelete.name}" akan ikut terhapus bersama kolom ini.`
-						: ""
-				}
-				isLoading={deleteColumnMutation.isPending}
-				isOpen={Boolean(columnToDelete)}
-				onClose={() => setColumnToDelete(null)}
-				onConfirm={() => {
+				isTaskDeleting={deleteTaskMutation.isPending}
+				onColumnDeleteClose={() => setColumnToDelete(null)}
+				onColumnDeleteConfirm={() => {
 					if (columnToDelete) {
 						deleteColumnMutation.mutate(columnToDelete.id);
 					}
 				}}
-				title={
-					columnToDelete ? `Hapus ${columnToDelete.name}?` : "Hapus kolom?"
-				}
-			/>
-
-			<ConfirmDialog
-				confirmLabel="Hapus task"
-				description={
-					taskToDelete
-						? `Task "${taskToDelete.title}" akan dihapus dari board ini.`
-						: ""
-				}
-				isLoading={deleteTaskMutation.isPending}
-				isOpen={Boolean(taskToDelete)}
-				onClose={() => setTaskToDelete(null)}
-				onConfirm={() => {
+				onColumnFormChange={setColumnForm}
+				onColumnModalClose={() => {
+					setColumnModal(null);
+					setColumnForm({ name: "", color: "#38BDF8" });
+				}}
+				onColumnSubmit={handleColumnSubmit}
+				onTaskDeleteClose={() => setTaskToDelete(null)}
+				onTaskDeleteConfirm={() => {
 					if (taskToDelete) {
 						deleteTaskMutation.mutate(taskToDelete.id);
 					}
 				}}
-				title={taskToDelete ? `Hapus ${taskToDelete.title}?` : "Hapus task?"}
+				taskToDelete={taskToDelete}
 			/>
 		</div>
 	);
-}
-
-function matchesFilters(task: KanbanTask, filters: KanbanFilters) {
-	if (filters.assignee && task.assignee_id !== filters.assignee) {
-		return false;
-	}
-	if (filters.priority && task.priority !== filters.priority) {
-		return false;
-	}
-	if (filters.label) {
-		const label = task.label?.toLowerCase() ?? "";
-		if (!label.includes(filters.label.toLowerCase())) {
-			return false;
-		}
-	}
-	if (
-		filters.dueDate &&
-		(!task.due_date || extractDateInputValue(task.due_date) !== filters.dueDate)
-	) {
-		return false;
-	}
-	return true;
-}
-
-function moveTaskInMemory(
-	tasks: KanbanTask[],
-	activeTaskId: string,
-	overData: unknown,
-	overId: string,
-) {
-	const activeTask = tasks.find((task) => task.id === activeTaskId);
-	if (!activeTask) {
-		return null;
-	}
-
-	const buckets = buildTaskBuckets(tasks);
-	const sourceList = [...(buckets[activeTask.column_id] ?? [])];
-	const sourceIndex = sourceList.findIndex((task) => task.id === activeTaskId);
-	if (sourceIndex < 0) {
-		return null;
-	}
-
-	const [movingTask] = sourceList.splice(sourceIndex, 1);
-	buckets[activeTask.column_id] = sourceList;
-
-	let destinationColumnId = activeTask.column_id;
-	let destinationIndex = sourceList.length;
-
-	if (isTaskDragData(overData)) {
-		destinationColumnId = overData.task.column_id;
-		const targetList =
-			destinationColumnId === activeTask.column_id
-				? sourceList
-				: [...(buckets[destinationColumnId] ?? [])];
-		const overIndex = targetList.findIndex(
-			(task) => task.id === overData.task.id,
-		);
-		destinationIndex = overIndex >= 0 ? overIndex : targetList.length;
-	} else if (isColumnDragData(overData)) {
-		destinationColumnId = overData.column.id;
-		const targetList =
-			destinationColumnId === activeTask.column_id
-				? sourceList
-				: [...(buckets[destinationColumnId] ?? [])];
-		destinationIndex = targetList.length;
-	} else {
-		const targetList = buckets[activeTask.column_id] ?? [];
-		const overIndex = targetList.findIndex((task) => task.id === overId);
-		destinationIndex = overIndex >= 0 ? overIndex : targetList.length;
-	}
-
-	const destinationList =
-		destinationColumnId === activeTask.column_id
-			? sourceList
-			: [...(buckets[destinationColumnId] ?? [])];
-	destinationList.splice(destinationIndex, 0, {
-		...movingTask!,
-		column_id: destinationColumnId,
-	});
-	buckets[destinationColumnId] = destinationList;
-
-	return flattenTaskBuckets(buckets);
-}
-
-function buildTaskBuckets(tasks: KanbanTask[]) {
-	const buckets: Record<string, KanbanTask[]> = {};
-	for (const task of [...tasks].sort(sortTaskList)) {
-		if (!buckets[task.column_id]) {
-			buckets[task.column_id] = [];
-		}
-		buckets[task.column_id]!.push(task);
-	}
-	return buckets;
-}
-
-function flattenTaskBuckets(buckets: Record<string, KanbanTask[]>) {
-	const nextTasks: KanbanTask[] = [];
-	for (const columnId of Object.keys(buckets)) {
-		buckets[columnId]!.forEach((task, index) => {
-			nextTasks.push({ ...task, column_id: columnId, position: index + 1 });
-		});
-	}
-	return nextTasks.sort(sortTaskList);
-}
-
-// function taskPlacementChanged(currentTasks: KanbanTask[], nextTasks: KanbanTask[], taskId: string) {
-//   const currentTask = currentTasks.find((task) => task.id === taskId);
-//   const nextTask = nextTasks.find((task) => task.id === taskId);
-
-//   if (!currentTask || !nextTask) {
-//     return false;
-//   }
-
-//   return currentTask.column_id !== nextTask.column_id || currentTask.position !== nextTask.position;
-// }
-
-function sortTaskList(left: KanbanTask, right: KanbanTask) {
-	if (left.column_id === right.column_id) {
-		return left.position - right.position;
-	}
-	return left.column_id.localeCompare(right.column_id);
-}
-
-async function invalidateBoard(
-	queryClient: ReturnType<typeof useQueryClient>,
-	projectId: string,
-) {
-	await queryClient.invalidateQueries({ queryKey: kanbanKeys.all(projectId) });
-}
-
-function finishTaskDrag(
-	taskId: string,
-	nextTasks: KanbanTask[] | null,
-	snapshot: DragSnapshot | null,
-	queryClient: ReturnType<typeof useQueryClient>,
-	projectId: string,
-) {
-	if (!snapshot || !nextTasks) {
-		return;
-	}
-
-	const previousTask = snapshot.tasks.find((task) => task.id === taskId);
-	const nextTask = nextTasks.find((task) => task.id === taskId);
-
-	if (!previousTask || !nextTask) {
-		queryClient.setQueryData(kanbanKeys.tasks(projectId), snapshot.tasks);
-		return;
-	}
-
-	if (
-		previousTask.column_id === nextTask.column_id &&
-		previousTask.position === nextTask.position
-	) {
-		return;
-	}
-
-	queryClient.setQueryData(kanbanKeys.tasks(projectId), nextTasks);
-	void moveKanbanTask(
-		projectId,
-		nextTask.id,
-		nextTask.column_id,
-		nextTask.position,
-	)
-		.then(async () => {
-			await invalidateBoard(queryClient, projectId);
-		})
-		.catch(async () => {
-			queryClient.setQueryData(kanbanKeys.tasks(projectId), snapshot.tasks);
-			await invalidateBoard(queryClient, projectId);
-		});
-}
-
-function finishColumnDrag(
-	event: DragEndEvent,
-	columns: KanbanColumn[],
-	tasks: KanbanTask[],
-	snapshot: DragSnapshot | null,
-	queryClient: ReturnType<typeof useQueryClient>,
-	projectId: string,
-) {
-	if (!snapshot) {
-		return;
-	}
-
-	const currentColumns =
-		queryClient.getQueryData<KanbanColumn[]>(kanbanKeys.columns(projectId)) ??
-		columns;
-	const activeIndex = currentColumns.findIndex(
-		(column) => column.id === event.active.id,
-	);
-	const currentTasks =
-		queryClient.getQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId)) ??
-		tasks;
-	const overColumnId = resolveOverColumnId(event, currentColumns, currentTasks);
-	const overIndex = currentColumns.findIndex(
-		(column) => column.id === overColumnId,
-	);
-	if (activeIndex < 0 || overIndex < 0 || activeIndex === overIndex) {
-		return;
-	}
-
-	const nextColumns = arrayMove(currentColumns, activeIndex, overIndex).map(
-		(column, index) => ({
-			...column,
-			position: index + 1,
-		}),
-	);
-
-	queryClient.setQueryData(kanbanKeys.columns(projectId), nextColumns);
-	void reorderKanbanColumns(
-		projectId,
-		nextColumns.map((column) => column.id),
-	)
-		.then(async () => {
-			await invalidateBoard(queryClient, projectId);
-		})
-		.catch(async () => {
-			queryClient.setQueryData(kanbanKeys.columns(projectId), snapshot.columns);
-			await invalidateBoard(queryClient, projectId);
-		});
-}
-
-function resolveOverColumnId(
-	event: DragEndEvent,
-	columns: KanbanColumn[],
-	tasks: KanbanTask[],
-) {
-	const overData = event.over?.data.current;
-	if (isColumnDragData(overData)) {
-		return overData.column.id;
-	}
-
-	const overId = event.over?.id?.toString();
-	if (!overId) {
-		return null;
-	}
-
-	if (columns.some((column) => column.id === overId)) {
-		return overId;
-	}
-
-	return tasks.find((task) => task.id === overId)?.column_id ?? null;
-}
-
-function isTaskDragData(value: unknown): value is DragTaskData {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		"type" in value &&
-		value.type === "task"
-	);
-}
-
-function isColumnDragData(value: unknown): value is DragColumnData {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		"type" in value &&
-		value.type === "column"
-	);
-}
-
-function extractErrorMessage(error: unknown) {
-	return error instanceof Error
-		? error.message
-		: "Terjadi kesalahan yang tidak terduga";
-}
-
-interface KanbanColumnCardProps {
-	column: KanbanColumn;
-	tasks: KanbanTask[];
-	quickDraft: string;
-	onQuickDraftChange: (value: string) => void;
-	onQuickAdd: () => void;
-	onTaskClick: (task: KanbanTask) => void;
-	onTaskCreate: () => void;
-	onEditColumn: () => void;
-	onDeleteColumn: () => void;
-}
-
-function KanbanColumnCard(props: KanbanColumnCardProps) {
-	const sortable = useSortable({
-		id: props.column.id,
-		data: { type: "column", column: props.column } satisfies DragColumnData,
-	});
-	const droppable = useDroppable({
-		id: `column-drop-${props.column.id}`,
-		data: { type: "column", column: props.column } satisfies DragColumnData,
-	});
-	const style = {
-		transform: CSS.Transform.toString(sortable.transform),
-		transition: sortable.transition,
-	};
-
-	return (
-		<div
-			className="w-[min(82vw,320px)] shrink-0 md:w-[320px]"
-			ref={sortable.setNodeRef}
-			style={style}>
-			<Card
-				className={cn(
-					"flex h-full min-h-[420px] flex-col border-border bg-surface-muted p-3 shadow-sm transition-all md:min-h-[500px] md:p-4",
-					sortable.isDragging && "opacity-70",
-					droppable.isOver && "border-ops/40 bg-ops/5 shadow-card",
-				)}
-				ref={droppable.setNodeRef}>
-				<div className="flex items-start justify-between gap-3">
-					<div className="flex items-center gap-3">
-						<button
-							{...sortable.attributes}
-							{...sortable.listeners}
-							className="rounded-[6px] border border-border bg-background px-2 py-1 text-[11px] font-[700] uppercase tracking-[0.08em] text-text-secondary hover:bg-surface-muted transition-colors cursor-grab"
-							type="button">
-							Geser
-						</button>
-						<div>
-							<div className="flex items-center gap-2">
-								<span
-									className="h-2.5 w-2.5 rounded-full"
-									style={{ backgroundColor: props.column.color ?? "#94A3B8" }}
-								/>
-								<h5 className="font-[600] text-[14px] text-text-primary truncate max-w-[120px]">
-									{props.column.name}
-								</h5>
-							</div>
-							<p className="text-[12px] font-[500] text-text-tertiary">
-								{props.tasks.length} task
-							</p>
-						</div>
-					</div>
-
-					<PermissionGate permission={permissions.operationalColumnManage}>
-						<div className="flex gap-2">
-							<Button
-								onClick={props.onEditColumn}
-								size="sm"
-								variant="secondary"
-								className="h-7 px-2 text-[11px]">
-								Edit
-							</Button>
-							<PermissionGate permission={permissions.operationalColumnManage}>
-								<Button
-									onClick={props.onDeleteColumn}
-									size="sm"
-									variant="ghost"
-									className="h-7 px-2 text-[11px]">
-									Hapus
-								</Button>
-							</PermissionGate>
-						</div>
-					</PermissionGate>
-				</div>
-
-				<div className="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 max-h-[460px]">
-					<SortableContext
-						items={props.tasks.map((task) => task.id)}
-						strategy={verticalListSortingStrategy}>
-						{props.tasks.map((task) => (
-							<KanbanTaskCard
-								key={task.id}
-								onClick={() => props.onTaskClick(task)}
-								task={task}
-							/>
-						))}
-					</SortableContext>
-
-					{props.tasks.length === 0 ? (
-						<div className="rounded-[12px] border border-dashed border-border bg-background/50 px-4 py-8 text-center text-[13px] font-[500] text-text-tertiary">
-							Belum ada task di kolom ini.
-						</div>
-					) : null}
-				</div>
-
-				<PermissionGate permission={permissions.operationalTaskCreate}>
-					<div className="mt-4 rounded-[12px] border border-border bg-background p-3 space-y-3">
-						<Input
-							className="focus-visible:border-ops focus-visible:ring-ops/10"
-							onChange={(event) => props.onQuickDraftChange(event.target.value)}
-							placeholder="Tambahkan task cepat"
-							value={props.quickDraft}
-						/>
-						<div className="flex gap-3">
-							<Button
-								variant="ops"
-								onClick={props.onQuickAdd}
-								size="sm">
-								Tambah cepat
-							</Button>
-							<Button
-								onClick={props.onTaskCreate}
-								size="sm"
-								variant="ghost">
-								Form lengkap
-							</Button>
-						</div>
-					</div>
-				</PermissionGate>
-			</Card>
-		</div>
-	);
-}
-
-function KanbanTaskCard({
-	task,
-	onClick,
-}: {
-	task: KanbanTask;
-	onClick: () => void;
-}) {
-	const sortable = useSortable({
-		id: task.id,
-		data: { type: "task", task } satisfies DragTaskData,
-	});
-	const style = {
-		transform: CSS.Transform.toString(sortable.transform),
-		transition: sortable.transition,
-	};
-
-	return (
-		<div
-			ref={sortable.setNodeRef}
-			style={style}>
-			<Card
-				className={cn(
-					"cursor-pointer p-4 shadow-sm transition-all hover:border-ops/30 hover:shadow-card group",
-					sortable.isDragging && "opacity-60 ring-2 ring-ops",
-				)}
-				onClick={onClick}>
-				<div className="flex items-start justify-between gap-3">
-					<div>
-						<div className="flex flex-wrap items-center gap-2 mb-2">
-							<PriorityBadge priority={task.priority} />
-							<AssignmentBadge assignedVia={task.assigned_via} />
-							{task.label ? (
-								<span className="rounded-full bg-surface-muted border border-border px-2 py-0.5 text-[11px] font-[600] uppercase tracking-wider text-text-secondary">
-									{task.label}
-								</span>
-							) : null}
-						</div>
-						<h6 className="text-[14px] font-[600] text-text-primary leading-tight">
-							{task.title}
-						</h6>
-					</div>
-					<button
-						{...sortable.attributes}
-						{...sortable.listeners}
-						aria-label={`Pindahkan task ${task.title}`}
-						className="rounded-[8px] border border-border bg-surface-muted p-2 text-text-tertiary transition hover:border-ops/40 hover:bg-ops/10 hover:text-ops active:cursor-grabbing"
-						onClick={(event) => event.stopPropagation()}
-						type="button">
-						<GripVertical className="h-4 w-4" />
-					</button>
-				</div>
-
-				{task.description ? (
-					<p className="mt-2 line-clamp-2 text-[12px] text-text-secondary leading-relaxed">
-						{task.description}
-					</p>
-				) : null}
-
-				<div className="mt-4 flex items-center justify-between gap-3 border-t border-border pt-4">
-					<div className="flex items-center gap-2">
-						<AvatarBadge
-							avatarUrl={task.avatar_url}
-							name={task.assignee_name}
-						/>
-						<span className="text-[12px] font-[500] text-text-secondary truncate max-w-[120px]">
-							{task.assignee_name ?? "Belum ada PIC"}
-						</span>
-					</div>
-					<span className="text-[11px] font-[600] text-text-tertiary uppercase tracking-wider">
-						{task.due_date ? formatDate(task.due_date) : "Tanpa deadline"}
-					</span>
-				</div>
-			</Card>
-		</div>
-	);
-}
-
-function TaskOverlay({ task }: { task: KanbanTask }) {
-	return (
-		<div className="w-[min(82vw,320px)] md:w-[320px]">
-			<Card className="border-ops shadow-2xl p-4 rotate-2">
-				<PriorityBadge priority={task.priority} />
-				<p className="mt-2 text-[14px] font-[600] text-text-primary leading-tight">
-					{task.title}
-				</p>
-			</Card>
-		</div>
-	);
-}
-
-function ColumnOverlay({
-	column,
-	taskCount,
-}: {
-	column: KanbanColumn;
-	taskCount: number;
-}) {
-	return (
-		<div className="w-[min(82vw,320px)] md:w-[320px]">
-			<Card className="border-ops shadow-2xl p-4 rotate-2">
-				<div className="flex items-center gap-2">
-					<span
-						className="h-2 w-2 rounded-full"
-						style={{ backgroundColor: column.color ?? "#94A3B8" }}
-					/>
-					<p className="text-[14px] font-[600] text-text-primary">
-						{column.name}
-					</p>
-				</div>
-				<p className="mt-1 text-[12px] font-[500] text-text-tertiary">
-					{taskCount} tasks
-				</p>
-			</Card>
-		</div>
-	);
-}
-
-function TaskModal({
-	mode,
-	form,
-	members,
-	isSubmitting,
-	isDeleting,
-	onSubmit,
-	onDelete,
-	onClose,
-}: {
-	mode: "create" | "edit";
-	form: UseFormReturn<TaskFormValues>;
-	members: ProjectMember[];
-	isSubmitting: boolean;
-	isDeleting: boolean;
-	onSubmit: (values: TaskFormValues) => void;
-	onDelete: () => void;
-	onClose: () => void;
-}) {
-	const {
-		register,
-		handleSubmit,
-		formState: { errors },
-	} = form;
-
-	return (
-		<Drawer
-			onOpenChange={(open) => (!open ? onClose() : undefined)}
-			open>
-			<DrawerContent size="lg">
-				<DrawerHeader className="flex items-start justify-between gap-4">
-					<div>
-						<p className="text-[11px] font-[700] uppercase tracking-[0.08em] text-ops mb-1">
-							{mode === "create" ? "Buat task" : "Detail task"}
-						</p>
-						<DrawerTitle>
-							{mode === "create" ? "Task baru" : "Edit task"}
-						</DrawerTitle>
-						<DrawerDescription>
-							{mode === "create"
-								? "Isi ringkasan task, PIC, dan due date tanpa keluar dari board."
-								: "Tinjau detail task, edit informasi pengerjaan, atau hapus task dari board."}
-						</DrawerDescription>
-					</div>
-					<DrawerClose />
-				</DrawerHeader>
-
-				<DrawerBody>
-					<form
-						className="space-y-6"
-						onSubmit={handleSubmit(onSubmit)}>
-						<div className="grid gap-2">
-							<label
-								className="text-[13px] font-[600] text-text-primary"
-								htmlFor="task-title">
-								Judul<span className="ml-0.5 text-priority-high">*</span>
-							</label>
-							<Input
-								className="focus-visible:border-ops focus-visible:ring-ops/10"
-								id="task-title"
-								{...register("title")}
-							/>
-							{errors.title ? (
-								<p className="text-[13px] font-[500] text-priority-high">
-									{errors.title.message}
-								</p>
-							) : null}
-						</div>
-
-						<div className="grid gap-2">
-							<label
-								className="text-[13px] font-[600] text-text-primary"
-								htmlFor="task-description">
-								Deskripsi
-							</label>
-							<textarea
-								className="min-h-32 w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10 disabled:cursor-not-allowed disabled:opacity-50"
-								id="task-description"
-								{...register("description")}
-							/>
-						</div>
-
-						<div className="grid gap-5 md:grid-cols-2">
-							<div className="grid gap-2">
-								<label
-									className="text-[13px] font-[600] text-text-primary"
-									htmlFor="task-assignee">
-									PIC
-								</label>
-								<select
-									className="flex h-[44px] w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
-									id="task-assignee"
-									{...register("assignee_id")}>
-									<option value="">Belum ditentukan</option>
-									{members.map((member) => (
-										<option
-											key={member.user_id}
-											value={member.user_id}>
-											{member.full_name || member.user_email || member.user_id}
-										</option>
-									))}
-								</select>
-							</div>
-
-							<div className="grid gap-2">
-								<label
-									className="text-[13px] font-[600] text-text-primary"
-									htmlFor="task-due-date">
-									Deadline
-								</label>
-								<Input
-									className="focus-visible:border-ops focus-visible:ring-ops/10"
-									id="task-due-date"
-									type="date"
-									{...register("due_date")}
-								/>
-							</div>
-						</div>
-
-						<div className="grid gap-5 md:grid-cols-2">
-							<div className="grid gap-2">
-								<label
-									className="text-[13px] font-[600] text-text-primary"
-									htmlFor="task-priority">
-									Prioritas
-								</label>
-								<select
-									className="flex h-[44px] w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
-									id="task-priority"
-									{...register("priority")}>
-									<option value="low">Rendah</option>
-									<option value="medium">Medium</option>
-									<option value="high">Tinggi</option>
-									<option value="critical">Kritis</option>
-								</select>
-							</div>
-
-							<div className="grid gap-2">
-								<label
-									className="text-[13px] font-[600] text-text-primary"
-									htmlFor="task-label">
-									Label
-								</label>
-								<Input
-									className="focus-visible:border-ops focus-visible:ring-ops/10"
-									id="task-label"
-									placeholder="Bug, desain, backend"
-									{...register("label")}
-								/>
-							</div>
-						</div>
-
-						<div className="flex flex-wrap gap-3 pt-4 border-t border-border">
-							<Button
-								variant="ops"
-								disabled={isSubmitting}
-								type="submit">
-								{isSubmitting
-									? "Menyimpan..."
-									: mode === "create"
-										? "Buat task"
-										: "Simpan perubahan"}
-							</Button>
-							{mode === "edit" ? (
-								<PermissionGate permission={permissions.operationalTaskDelete}>
-									<Button
-										disabled={isDeleting}
-										onClick={onDelete}
-										type="button"
-										variant="ghost">
-										{isDeleting ? "Menghapus..." : "Hapus task"}
-									</Button>
-								</PermissionGate>
-							) : null}
-						</div>
-					</form>
-				</DrawerBody>
-			</DrawerContent>
-		</Drawer>
-	);
-}
-
-function PriorityBadge({ priority }: { priority: ProjectPriority }) {
-	const tone =
-		priority === "critical"
-			? "bg-priority-critical-bg text-priority-critical"
-			: priority === "high"
-				? "bg-priority-high-bg text-priority-high"
-				: priority === "medium"
-					? "bg-priority-medium-bg text-priority-medium"
-					: "bg-surface-muted text-text-secondary border border-border";
-	const label =
-		priority === "critical"
-			? "kritis"
-			: priority === "high"
-				? "tinggi"
-				: priority === "medium"
-					? "medium"
-					: "rendah";
-
-	return (
-		<span
-			className={cn(
-				"rounded-[6px] px-2 py-0.5 text-[11px] font-[700] uppercase tracking-[0.08em]",
-				tone,
-			)}>
-			{label}
-		</span>
-	);
-}
-
-function AssignmentBadge({ assignedVia }: { assignedVia: "manual" | "auto" }) {
-	const tone =
-		assignedVia === "auto"
-			? "bg-ops/10 text-ops"
-			: "bg-surface-muted text-text-secondary border border-border";
-
-	return (
-		<span
-			className={cn(
-				"rounded-[6px] px-2 py-0.5 text-[11px] font-[700] uppercase tracking-[0.08em]",
-				tone,
-			)}>
-			{assignedVia === "auto" ? "otomatis" : "manual"}
-		</span>
-	);
-}
-
-function AvatarBadge({
-	name,
-	avatarUrl,
-}: {
-	name?: string | null;
-	avatarUrl?: string | null;
-}) {
-	return (
-		<ProtectedAvatar
-			alt={name ?? "Unassigned"}
-			avatarUrl={avatarUrl}
-			className="h-8 w-8 shadow-sm ring-2 ring-background"
-			fallbackClassName="bg-ops text-white"
-			iconClassName="h-4 w-4"
-		/>
-	);
-}
-
-function formatDate(value: string) {
-	return formatCalendarDate(value);
 }

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
 	DndContext,
@@ -19,16 +19,15 @@ import { z } from "zod";
 
 import {
 	ColumnOverlay,
-	KanbanColumnCard,
 	TaskOverlay,
 } from "@/components/shared/kanban-cards";
+import { KanbanColumnContainer } from "@/components/shared/kanban-column-container";
 import {
 	KanbanDialogs,
 	type ColumnModalState,
 } from "@/components/shared/kanban-dialogs";
 import {
 	matchesFilters,
-	sortTaskList,
 } from "@/components/shared/kanban-dnd";
 import { useKanbanDrag } from "@/hooks/use-kanban-drag";
 import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
@@ -39,7 +38,6 @@ import { extractDateInputValue } from "@/lib/date";
 import {
 	kanbanKeys,
 	listKanbanColumns,
-	listKanbanTasks,
 } from "@/services/operational-kanban";
 import type {
 	KanbanColumn,
@@ -110,10 +108,20 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		queryFn: () => listKanbanColumns(projectId),
 	});
 
-	const tasksQuery = useQuery({
-		queryKey: kanbanKeys.tasks(projectId),
-		queryFn: () => listKanbanTasks(projectId),
-	});
+	const [loadedTasks, setLoadedTasks] = useState<Record<string, KanbanTask[]>>(
+		{},
+	);
+
+	const handleTasksLoaded = useCallback(
+		(columnId: string, columnTasks: KanbanTask[]) => {
+			setLoadedTasks((current) =>
+				current[columnId] === columnTasks
+					? current
+					: { ...current, [columnId]: columnTasks },
+			);
+		},
+		[],
+	);
 
 	const form = useForm<TaskFormValues>({
 		resolver: zodResolver(taskSchema),
@@ -145,8 +153,15 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	});
 
 	const columns = columnsQuery.data ?? [];
-	const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
-	const filteredTasks = tasks.filter((task) => matchesFilters(task, filters));
+	const tasks = useMemo(
+		() => Object.values(loadedTasks).flat(),
+		[loadedTasks],
+	);
+	const filterTasks = useCallback(
+		(columnTasks: KanbanTask[]) =>
+			columnTasks.filter((task) => matchesFilters(task, filters)),
+		[filters],
+	);
 
 	useEffect(() => {
 		if (!taskModal) {
@@ -244,19 +259,14 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	const { activeTask, activeColumn, handleDragStart, handleDragEnd } =
 		useKanbanDrag(projectId, columns, tasks);
 
-	if (columnsQuery.isLoading || tasksQuery.isLoading) {
+	if (columnsQuery.isLoading) {
 		return <Card className="p-8">Memuat board proyek...</Card>;
 	}
 
-	if (
-		columnsQuery.error instanceof Error ||
-		tasksQuery.error instanceof Error
-	) {
+	if (columnsQuery.error instanceof Error) {
 		return (
 			<Card className="p-8 text-error">
-				{(columnsQuery.error as Error | undefined)?.message ??
-					(tasksQuery.error as Error | undefined)?.message ??
-					"Gagal memuat board proyek"}
+				{columnsQuery.error.message ?? "Gagal memuat board proyek"}
 			</Card>
 		);
 	}
@@ -290,8 +300,10 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 					<div className="-mx-1 overflow-x-auto px-1 pb-3">
 						<div className="flex min-w-max gap-3 md:gap-5">
 							{columns.map((column) => (
-								<KanbanColumnCard
+								<KanbanColumnContainer
 									column={column}
+									filterTasks={filterTasks}
+									key={column.id}
 									onDeleteColumn={() => setColumnToDelete(column)}
 									onEditColumn={() => startColumnEdit(column)}
 									onQuickAdd={() => void handleQuickAdd(column.id)}
@@ -311,10 +323,9 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 									onTaskCreate={() =>
 										setTaskModal({ mode: "create", columnId: column.id })
 									}
+									onTasksLoaded={handleTasksLoaded}
+									projectId={projectId}
 									quickDraft={quickDrafts[column.id] ?? ""}
-									tasks={filteredTasks
-										.filter((task) => task.column_id === column.id)
-										.sort(sortTaskList)}
 								/>
 							))}
 						</div>

--- a/frontend/src/components/shared/kanban-cards.tsx
+++ b/frontend/src/components/shared/kanban-cards.tsx
@@ -1,0 +1,340 @@
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+
+import { PermissionGate } from "@/components/shared/permission-gate";
+import { ProtectedAvatar } from "@/components/shared/protected-avatar";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { formatCalendarDate } from "@/lib/date";
+import { permissions } from "@/lib/permissions";
+import { cn } from "@/lib/utils";
+import type { DragColumnData, DragTaskData } from "@/components/shared/kanban-dnd";
+import type {
+	KanbanColumn,
+	KanbanTask,
+} from "@/types/kanban";
+import type { ProjectPriority } from "@/types/project";
+
+export interface KanbanColumnCardProps {
+	column: KanbanColumn;
+	tasks: KanbanTask[];
+	quickDraft: string;
+	onQuickDraftChange: (value: string) => void;
+	onQuickAdd: () => void;
+	onTaskClick: (task: KanbanTask) => void;
+	onTaskCreate: () => void;
+	onEditColumn: () => void;
+	onDeleteColumn: () => void;
+}
+
+export function KanbanColumnCard(props: KanbanColumnCardProps) {
+	const sortable = useSortable({
+		id: props.column.id,
+		data: { type: "column", column: props.column } satisfies DragColumnData,
+	});
+	const droppable = useDroppable({
+		id: `column-drop-${props.column.id}`,
+		data: { type: "column", column: props.column } satisfies DragColumnData,
+	});
+	const style = {
+		transform: CSS.Transform.toString(sortable.transform),
+		transition: sortable.transition,
+	};
+
+	return (
+		<div
+			className="w-[min(82vw,320px)] shrink-0 md:w-[320px]"
+			ref={sortable.setNodeRef}
+			style={style}>
+			<Card
+				className={cn(
+					"flex h-full min-h-[420px] flex-col border-border bg-surface-muted p-3 shadow-sm transition-all md:min-h-[500px] md:p-4",
+					sortable.isDragging && "opacity-70",
+					droppable.isOver && "border-ops/40 bg-ops/5 shadow-card",
+				)}
+				ref={droppable.setNodeRef}>
+				<div className="flex items-start justify-between gap-3">
+					<div className="flex items-center gap-3">
+						<button
+							{...sortable.attributes}
+							{...sortable.listeners}
+							className="rounded-[6px] border border-border bg-background px-2 py-1 text-[11px] font-[700] uppercase tracking-[0.08em] text-text-secondary hover:bg-surface-muted transition-colors cursor-grab"
+							type="button">
+							Geser
+						</button>
+						<div>
+							<div className="flex items-center gap-2">
+								<span
+									className="h-2.5 w-2.5 rounded-full"
+									style={{ backgroundColor: props.column.color ?? "#94A3B8" }}
+								/>
+								<h5 className="font-[600] text-[14px] text-text-primary truncate max-w-[120px]">
+									{props.column.name}
+								</h5>
+							</div>
+							<p className="text-[12px] font-[500] text-text-tertiary">
+								{props.tasks.length} task
+							</p>
+						</div>
+					</div>
+
+					<PermissionGate permission={permissions.operationalColumnManage}>
+						<div className="flex gap-2">
+							<Button
+								onClick={props.onEditColumn}
+								size="sm"
+								variant="secondary"
+								className="h-7 px-2 text-[11px]">
+								Edit
+							</Button>
+							<PermissionGate permission={permissions.operationalColumnManage}>
+								<Button
+									onClick={props.onDeleteColumn}
+									size="sm"
+									variant="ghost"
+									className="h-7 px-2 text-[11px]">
+									Hapus
+								</Button>
+							</PermissionGate>
+						</div>
+					</PermissionGate>
+				</div>
+
+				<div className="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 max-h-[460px]">
+					<SortableContext
+						items={props.tasks.map((task) => task.id)}
+						strategy={verticalListSortingStrategy}>
+						{props.tasks.map((task) => (
+							<KanbanTaskCard
+								key={task.id}
+								onClick={() => props.onTaskClick(task)}
+								task={task}
+							/>
+						))}
+					</SortableContext>
+
+					{props.tasks.length === 0 ? (
+						<div className="rounded-[12px] border border-dashed border-border bg-background/50 px-4 py-8 text-center text-[13px] font-[500] text-text-tertiary">
+							Belum ada task di kolom ini.
+						</div>
+					) : null}
+
+				</div>
+
+				<PermissionGate permission={permissions.operationalTaskCreate}>
+					<div className="mt-4 rounded-[12px] border border-border bg-background p-3 space-y-3">
+						<Input
+							className="focus-visible:border-ops focus-visible:ring-ops/10"
+							onChange={(event) => props.onQuickDraftChange(event.target.value)}
+							placeholder="Tambahkan task cepat"
+							value={props.quickDraft}
+						/>
+						<div className="flex gap-3">
+							<Button
+								variant="ops"
+								onClick={props.onQuickAdd}
+								size="sm">
+								Tambah cepat
+							</Button>
+							<Button
+								onClick={props.onTaskCreate}
+								size="sm"
+								variant="ghost">
+								Form lengkap
+							</Button>
+						</div>
+					</div>
+				</PermissionGate>
+			</Card>
+		</div>
+	);
+}
+
+export function KanbanTaskCard({
+	task,
+	onClick,
+}: {
+	task: KanbanTask;
+	onClick: () => void;
+}) {
+	const sortable = useSortable({
+		id: task.id,
+		data: { type: "task", task } satisfies DragTaskData,
+	});
+	const style = {
+		transform: CSS.Transform.toString(sortable.transform),
+		transition: sortable.transition,
+	};
+
+	return (
+		<div
+			ref={sortable.setNodeRef}
+			style={style}>
+			<Card
+				className={cn(
+					"cursor-pointer p-4 shadow-sm transition-all hover:border-ops/30 hover:shadow-card group",
+					sortable.isDragging && "opacity-60 ring-2 ring-ops",
+				)}
+				onClick={onClick}>
+				<div className="flex items-start justify-between gap-3">
+					<div>
+						<div className="flex flex-wrap items-center gap-2 mb-2">
+							<PriorityBadge priority={task.priority} />
+							<AssignmentBadge assignedVia={task.assigned_via} />
+							{task.label ? (
+								<span className="rounded-full bg-surface-muted border border-border px-2 py-0.5 text-[11px] font-[600] uppercase tracking-wider text-text-secondary">
+									{task.label}
+								</span>
+							) : null}
+						</div>
+						<h6 className="text-[14px] font-[600] text-text-primary leading-tight">
+							{task.title}
+						</h6>
+					</div>
+					<button
+						{...sortable.attributes}
+						{...sortable.listeners}
+						aria-label={`Pindahkan task ${task.title}`}
+						className="rounded-[8px] border border-border bg-surface-muted p-2 text-text-tertiary transition hover:border-ops/40 hover:bg-ops/10 hover:text-ops active:cursor-grabbing"
+						onClick={(event) => event.stopPropagation()}
+						type="button">
+						<GripVertical className="h-4 w-4" />
+					</button>
+				</div>
+
+				{task.description ? (
+					<p className="mt-2 line-clamp-2 text-[12px] text-text-secondary leading-relaxed">
+						{task.description}
+					</p>
+				) : null}
+
+				<div className="mt-4 flex items-center justify-between gap-3 border-t border-border pt-4">
+					<div className="flex items-center gap-2">
+						<AvatarBadge
+							avatarUrl={task.avatar_url}
+							name={task.assignee_name}
+						/>
+						<span className="text-[12px] font-[500] text-text-secondary truncate max-w-[120px]">
+							{task.assignee_name ?? "Belum ada PIC"}
+						</span>
+					</div>
+					<span className="text-[11px] font-[600] text-text-tertiary uppercase tracking-wider">
+						{task.due_date ? formatDate(task.due_date) : "Tanpa deadline"}
+					</span>
+				</div>
+			</Card>
+		</div>
+	);
+}
+
+export function TaskOverlay({ task }: { task: KanbanTask }) {
+	return (
+		<div className="w-[min(82vw,320px)] md:w-[320px]">
+			<Card className="border-ops shadow-2xl p-4 rotate-2">
+				<PriorityBadge priority={task.priority} />
+				<p className="mt-2 text-[14px] font-[600] text-text-primary leading-tight">
+					{task.title}
+				</p>
+			</Card>
+		</div>
+	);
+}
+
+export function ColumnOverlay({
+	column,
+	taskCount,
+}: {
+	column: KanbanColumn;
+	taskCount: number;
+}) {
+	return (
+		<div className="w-[min(82vw,320px)] md:w-[320px]">
+			<Card className="border-ops shadow-2xl p-4 rotate-2">
+				<div className="flex items-center gap-2">
+					<span
+						className="h-2 w-2 rounded-full"
+						style={{ backgroundColor: column.color ?? "#94A3B8" }}
+					/>
+					<p className="text-[14px] font-[600] text-text-primary">
+						{column.name}
+					</p>
+				</div>
+				<p className="mt-1 text-[12px] font-[500] text-text-tertiary">
+					{taskCount} tasks
+				</p>
+			</Card>
+		</div>
+	);
+}
+
+function PriorityBadge({ priority }: { priority: ProjectPriority }) {
+	const tone =
+		priority === "critical"
+			? "bg-priority-critical-bg text-priority-critical"
+			: priority === "high"
+				? "bg-priority-high-bg text-priority-high"
+				: priority === "medium"
+					? "bg-priority-medium-bg text-priority-medium"
+					: "bg-surface-muted text-text-secondary border border-border";
+	const label =
+		priority === "critical"
+			? "kritis"
+			: priority === "high"
+				? "tinggi"
+				: priority === "medium"
+					? "medium"
+					: "rendah";
+
+	return (
+		<span
+			className={cn(
+				"rounded-[6px] px-2 py-0.5 text-[11px] font-[700] uppercase tracking-[0.08em]",
+				tone,
+			)}>
+			{label}
+		</span>
+	);
+}
+
+function AssignmentBadge({ assignedVia }: { assignedVia: "manual" | "auto" }) {
+	const tone =
+		assignedVia === "auto"
+			? "bg-ops/10 text-ops"
+			: "bg-surface-muted text-text-secondary border border-border";
+
+	return (
+		<span
+			className={cn(
+				"rounded-[6px] px-2 py-0.5 text-[11px] font-[700] uppercase tracking-[0.08em]",
+				tone,
+			)}>
+			{assignedVia === "auto" ? "otomatis" : "manual"}
+		</span>
+	);
+}
+
+function AvatarBadge({
+	name,
+	avatarUrl,
+}: {
+	name?: string | null;
+	avatarUrl?: string | null;
+}) {
+	return (
+		<ProtectedAvatar
+			alt={name ?? "Unassigned"}
+			avatarUrl={avatarUrl}
+			className="h-8 w-8 shadow-sm ring-2 ring-background"
+			fallbackClassName="bg-ops text-white"
+			iconClassName="h-4 w-4"
+		/>
+	);
+}
+
+function formatDate(value: string) {
+	return formatCalendarDate(value);
+}
+

--- a/frontend/src/components/shared/kanban-cards.tsx
+++ b/frontend/src/components/shared/kanban-cards.tsx
@@ -21,6 +21,11 @@ import type { ProjectPriority } from "@/types/project";
 export interface KanbanColumnCardProps {
 	column: KanbanColumn;
 	tasks: KanbanTask[];
+	totalTasks: number;
+	hasMore: boolean;
+	isLoadingTasks: boolean;
+	isFetchingMore: boolean;
+	onLoadMore: () => void;
 	quickDraft: string;
 	onQuickDraftChange: (value: string) => void;
 	onQuickAdd: () => void;
@@ -76,7 +81,7 @@ export function KanbanColumnCard(props: KanbanColumnCardProps) {
 								</h5>
 							</div>
 							<p className="text-[12px] font-[500] text-text-tertiary">
-								{props.tasks.length} task
+								{props.totalTasks} task
 							</p>
 						</div>
 					</div>
@@ -103,7 +108,18 @@ export function KanbanColumnCard(props: KanbanColumnCardProps) {
 					</PermissionGate>
 				</div>
 
-				<div className="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 max-h-[460px]">
+				<div
+					className="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 max-h-[460px]"
+					onScroll={(event) => {
+						const el = event.currentTarget;
+						if (
+							props.hasMore &&
+							!props.isFetchingMore &&
+							el.scrollHeight - el.scrollTop - el.clientHeight < 120
+						) {
+							props.onLoadMore();
+						}
+					}}>
 					<SortableContext
 						items={props.tasks.map((task) => task.id)}
 						strategy={verticalListSortingStrategy}>
@@ -116,12 +132,17 @@ export function KanbanColumnCard(props: KanbanColumnCardProps) {
 						))}
 					</SortableContext>
 
-					{props.tasks.length === 0 ? (
+					{props.tasks.length === 0 && !props.isLoadingTasks ? (
 						<div className="rounded-[12px] border border-dashed border-border bg-background/50 px-4 py-8 text-center text-[13px] font-[500] text-text-tertiary">
 							Belum ada task di kolom ini.
 						</div>
 					) : null}
 
+					{props.isLoadingTasks || props.isFetchingMore ? (
+						<p className="py-3 text-center text-[12px] font-[500] text-text-tertiary">
+							Memuat task...
+						</p>
+					) : null}
 				</div>
 
 				<PermissionGate permission={permissions.operationalTaskCreate}>

--- a/frontend/src/components/shared/kanban-column-container.tsx
+++ b/frontend/src/components/shared/kanban-column-container.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+
+import { KanbanColumnCard } from "@/components/shared/kanban-cards";
+import { sortTaskList } from "@/components/shared/kanban-dnd";
+import { useKanbanColumnTasks } from "@/hooks/use-kanban-column-tasks";
+import type { KanbanColumn, KanbanTask } from "@/types/kanban";
+
+interface KanbanColumnContainerProps {
+	projectId: string;
+	column: KanbanColumn;
+	filterTasks: (tasks: KanbanTask[]) => KanbanTask[];
+	onTasksLoaded: (columnId: string, tasks: KanbanTask[]) => void;
+	onTaskClick: (task: KanbanTask) => void;
+	onTaskCreate: () => void;
+	onEditColumn: () => void;
+	onDeleteColumn: () => void;
+	quickDraft: string;
+	onQuickDraftChange: (value: string) => void;
+	onQuickAdd: () => void;
+}
+
+export function KanbanColumnContainer({
+	projectId,
+	column,
+	filterTasks,
+	onTasksLoaded,
+	...rest
+}: KanbanColumnContainerProps) {
+	const { tasks, total, hasMore, isLoading, isFetchingMore, fetchMore } =
+		useKanbanColumnTasks(projectId, column.id);
+
+	useEffect(() => {
+		onTasksLoaded(column.id, tasks);
+	}, [column.id, onTasksLoaded, tasks]);
+
+	const visibleTasks = filterTasks(tasks).sort(sortTaskList);
+
+	return (
+		<KanbanColumnCard
+			column={column}
+			hasMore={hasMore}
+			isFetchingMore={isFetchingMore}
+			isLoadingTasks={isLoading}
+			onLoadMore={fetchMore}
+			tasks={visibleTasks}
+			totalTasks={total}
+			{...rest}
+		/>
+	);
+}

--- a/frontend/src/components/shared/kanban-column-container.tsx
+++ b/frontend/src/components/shared/kanban-column-container.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { KanbanColumnCard } from "@/components/shared/kanban-cards";
+import type { KanbanTaskQuery } from "@/services/operational-kanban";
 import { sortTaskList } from "@/components/shared/kanban-dnd";
 import { useKanbanColumnTasks } from "@/hooks/use-kanban-column-tasks";
 import type { KanbanColumn, KanbanTask } from "@/types/kanban";
@@ -8,7 +9,7 @@ import type { KanbanColumn, KanbanTask } from "@/types/kanban";
 interface KanbanColumnContainerProps {
 	projectId: string;
 	column: KanbanColumn;
-	filterTasks: (tasks: KanbanTask[]) => KanbanTask[];
+	filters: KanbanTaskQuery;
 	onTasksLoaded: (columnId: string, tasks: KanbanTask[]) => void;
 	onTaskClick: (task: KanbanTask) => void;
 	onTaskCreate: () => void;
@@ -22,18 +23,18 @@ interface KanbanColumnContainerProps {
 export function KanbanColumnContainer({
 	projectId,
 	column,
-	filterTasks,
+	filters,
 	onTasksLoaded,
 	...rest
 }: KanbanColumnContainerProps) {
 	const { tasks, total, hasMore, isLoading, isFetchingMore, fetchMore } =
-		useKanbanColumnTasks(projectId, column.id);
+		useKanbanColumnTasks(projectId, column.id, filters);
 
 	useEffect(() => {
 		onTasksLoaded(column.id, tasks);
 	}, [column.id, onTasksLoaded, tasks]);
 
-	const visibleTasks = filterTasks(tasks).sort(sortTaskList);
+	const visibleTasks = [...tasks].sort(sortTaskList);
 
 	return (
 		<KanbanColumnCard

--- a/frontend/src/components/shared/kanban-dialogs.tsx
+++ b/frontend/src/components/shared/kanban-dialogs.tsx
@@ -1,0 +1,142 @@
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { FormModal } from "@/components/shared/form-modal";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import type { KanbanColumn, KanbanTask } from "@/types/kanban";
+
+export type ColumnModalState =
+	| { mode: "create" }
+	| { mode: "edit"; columnId: string };
+
+export interface ColumnFormValues {
+	name: string;
+	color: string;
+}
+
+interface KanbanDialogsProps {
+	columnModal: ColumnModalState | null;
+	columnForm: ColumnFormValues;
+	columnColorOptions: string[];
+	isColumnSaving: boolean;
+	isColumnDeleting: boolean;
+	isTaskDeleting: boolean;
+	columnToDelete: KanbanColumn | null;
+	taskToDelete: KanbanTask | null;
+	onColumnFormChange: (
+		updater: (current: ColumnFormValues) => ColumnFormValues,
+	) => void;
+	onColumnModalClose: () => void;
+	onColumnSubmit: () => void;
+	onColumnDeleteClose: () => void;
+	onColumnDeleteConfirm: () => void;
+	onTaskDeleteClose: () => void;
+	onTaskDeleteConfirm: () => void;
+}
+
+export function KanbanDialogs({
+	columnModal,
+	columnForm,
+	columnColorOptions,
+	isColumnSaving,
+	isColumnDeleting,
+	isTaskDeleting,
+	columnToDelete,
+	taskToDelete,
+	onColumnFormChange,
+	onColumnModalClose,
+	onColumnSubmit,
+	onColumnDeleteClose,
+	onColumnDeleteConfirm,
+	onTaskDeleteClose,
+	onTaskDeleteConfirm,
+}: KanbanDialogsProps) {
+	return (
+		<>
+		<FormModal
+			isLoading={isColumnSaving}
+			isOpen={Boolean(columnModal)}
+			onClose={onColumnModalClose}
+			onSubmit={(event) => {
+				event.preventDefault();
+				onColumnSubmit();
+			}}
+			size="sm"
+			submitLabel={
+				columnModal?.mode === "edit" ? "Simpan kolom" : "Buat kolom"
+			}
+			title={columnModal?.mode === "edit" ? "Edit kolom" : "Buat kolom"}
+			subtitle="Gunakan nama singkat dan warna aksen yang jelas agar kolom mudah dipindai di board.">
+			<div className="space-y-2">
+				<label className="text-[13px] font-[600] text-text-primary">
+					Nama kolom
+				</label>
+				<Input
+					className="focus-visible:border-ops focus-visible:ring-ops/10"
+					onChange={(event) =>
+						onColumnFormChange((current) => ({
+							...current,
+							name: event.target.value,
+						}))
+					}
+					placeholder="Review"
+					value={columnForm.name}
+				/>
+			</div>
+			<div className="space-y-2">
+				<p className="text-[13px] font-[600] text-text-primary">
+					Warna aksen
+				</p>
+				<div className="flex flex-wrap gap-2">
+					{columnColorOptions.map((color) => (
+						<button
+							aria-label={`Choose list color ${color}`}
+							className={cn(
+								"h-9 w-9 rounded-full border-2 transition hover:scale-105",
+								columnForm.color === color
+									? "border-foreground shadow-sm"
+									: "border-transparent",
+							)}
+							key={color}
+							onClick={() =>
+								onColumnFormChange((current) => ({ ...current, color }))
+							}
+							style={{ backgroundColor: color }}
+							type="button"
+						/>
+					))}
+				</div>
+			</div>
+		</FormModal>
+
+		<ConfirmDialog
+			confirmLabel="Hapus kolom"
+			description={
+				columnToDelete
+					? `Semua task di dalam "${columnToDelete.name}" akan ikut terhapus bersama kolom ini.`
+					: ""
+			}
+			isLoading={isColumnDeleting}
+			isOpen={Boolean(columnToDelete)}
+			onClose={onColumnDeleteClose}
+			onConfirm={onColumnDeleteConfirm}
+			title={
+				columnToDelete ? `Hapus ${columnToDelete.name}?` : "Hapus kolom?"
+			}
+		/>
+
+		<ConfirmDialog
+			confirmLabel="Hapus task"
+			description={
+				taskToDelete
+					? `Task "${taskToDelete.title}" akan dihapus dari board ini.`
+					: ""
+			}
+			isLoading={isTaskDeleting}
+			isOpen={Boolean(taskToDelete)}
+			onClose={onTaskDeleteClose}
+			onConfirm={onTaskDeleteConfirm}
+			title={taskToDelete ? `Hapus ${taskToDelete.title}?` : "Hapus task?"}
+		/>
+		</>
+	);
+}

--- a/frontend/src/components/shared/kanban-dnd.ts
+++ b/frontend/src/components/shared/kanban-dnd.ts
@@ -135,19 +135,85 @@ export function sortTaskList(
 	return left.column_id.localeCompare(right.column_id);
 }
 
+interface TaskPageShape {
+	items: KanbanTask[];
+	total: number;
+	limit: number;
+	offset: number;
+	has_more: boolean;
+}
+
+interface TaskInfiniteShape {
+	pages: TaskPageShape[];
+	pageParams: unknown[];
+}
+
 export function setTasksCache(
 	queryClient: ReturnType<typeof useQueryClient>,
 	projectId: string,
 	tasks: KanbanTask[],
 ) {
-	queryClient.setQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId), tasks);
+	const byId = new Map(tasks.map((task) => [task.id, task]));
+	const entries = queryClient.getQueriesData<TaskInfiniteShape>({
+		queryKey: kanbanKeys.tasks(projectId),
+	});
+
+	for (const [queryKey, current] of entries) {
+		if (!current?.pages) {
+			continue;
+		}
+
+		const columnIndex = queryKey.indexOf("column");
+		const columnId =
+			columnIndex >= 0 ? (queryKey[columnIndex + 1] as string) : undefined;
+
+		const loaded = current.pages.flatMap((page) => page.items);
+		const known = new Set(loaded.map((item) => item.id));
+		const next = loaded
+			.map((item) => byId.get(item.id) ?? item)
+			.filter((item) => !columnId || item.column_id === columnId);
+
+		if (columnId) {
+			for (const task of tasks) {
+				if (task.column_id === columnId && !known.has(task.id)) {
+					next.push(task);
+				}
+			}
+		}
+		next.sort(sortTaskList);
+
+		let cursor = 0;
+		queryClient.setQueryData<TaskInfiniteShape>(queryKey, {
+			...current,
+			pages: current.pages.map((page, index) => {
+				const size =
+					index === current.pages.length - 1
+						? next.length - cursor
+						: page.items.length;
+				const items = next.slice(cursor, cursor + Math.max(size, 0));
+				cursor += items.length;
+				return { ...page, items };
+			}),
+		});
+	}
 }
 
 export function getTasksCache(
 	queryClient: ReturnType<typeof useQueryClient>,
 	projectId: string,
 ) {
-	return queryClient.getQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId));
+	const entries = queryClient.getQueriesData<TaskInfiniteShape>({
+		queryKey: kanbanKeys.tasks(projectId),
+	});
+
+	const tasks: KanbanTask[] = [];
+	for (const [, data] of entries) {
+		for (const page of data?.pages ?? []) {
+			tasks.push(...page.items);
+		}
+	}
+
+	return tasks.length > 0 ? tasks : undefined;
 }
 
 export async function invalidateBoard(

--- a/frontend/src/components/shared/kanban-dnd.ts
+++ b/frontend/src/components/shared/kanban-dnd.ts
@@ -2,17 +2,12 @@ import type { DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import type { useQueryClient } from "@tanstack/react-query";
 
-import { extractDateInputValue } from "@/lib/date";
 import {
 	kanbanKeys,
 	moveKanbanTask,
 	reorderKanbanColumns,
 } from "@/services/operational-kanban";
-import type {
-	KanbanColumn,
-	KanbanFilters,
-	KanbanTask,
-} from "@/types/kanban";
+import type { KanbanColumn, KanbanTask } from "@/types/kanban";
 
 export interface DragSnapshot {
 	columns: KanbanColumn[];
@@ -21,28 +16,6 @@ export interface DragSnapshot {
 
 export type DragTaskData = { type: "task"; task: KanbanTask };
 export type DragColumnData = { type: "column"; column: KanbanColumn };
-
-export function matchesFilters(task: KanbanTask, filters: KanbanFilters) {
-	if (filters.assignee && task.assignee_id !== filters.assignee) {
-		return false;
-	}
-	if (filters.priority && task.priority !== filters.priority) {
-		return false;
-	}
-	if (filters.label) {
-		const label = task.label?.toLowerCase() ?? "";
-		if (!label.includes(filters.label.toLowerCase())) {
-			return false;
-		}
-	}
-	if (
-		filters.dueDate &&
-		(!task.due_date || extractDateInputValue(task.due_date) !== filters.dueDate)
-	) {
-		return false;
-	}
-	return true;
-}
 
 export function moveTaskInMemory(
 	tasks: KanbanTask[],

--- a/frontend/src/components/shared/kanban-dnd.ts
+++ b/frontend/src/components/shared/kanban-dnd.ts
@@ -1,0 +1,296 @@
+import type { DragEndEvent } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+import type { useQueryClient } from "@tanstack/react-query";
+
+import { extractDateInputValue } from "@/lib/date";
+import {
+	kanbanKeys,
+	moveKanbanTask,
+	reorderKanbanColumns,
+} from "@/services/operational-kanban";
+import type {
+	KanbanColumn,
+	KanbanFilters,
+	KanbanTask,
+} from "@/types/kanban";
+
+export interface DragSnapshot {
+	columns: KanbanColumn[];
+	tasks: KanbanTask[];
+}
+
+export type DragTaskData = { type: "task"; task: KanbanTask };
+export type DragColumnData = { type: "column"; column: KanbanColumn };
+
+export function matchesFilters(task: KanbanTask, filters: KanbanFilters) {
+	if (filters.assignee && task.assignee_id !== filters.assignee) {
+		return false;
+	}
+	if (filters.priority && task.priority !== filters.priority) {
+		return false;
+	}
+	if (filters.label) {
+		const label = task.label?.toLowerCase() ?? "";
+		if (!label.includes(filters.label.toLowerCase())) {
+			return false;
+		}
+	}
+	if (
+		filters.dueDate &&
+		(!task.due_date || extractDateInputValue(task.due_date) !== filters.dueDate)
+	) {
+		return false;
+	}
+	return true;
+}
+
+export function moveTaskInMemory(
+	tasks: KanbanTask[],
+	activeTaskId: string,
+	overData: unknown,
+	overId: string,
+) {
+	const activeTask = tasks.find((task) => task.id === activeTaskId);
+	if (!activeTask) {
+		return null;
+	}
+
+	const buckets = buildTaskBuckets(tasks);
+	const sourceList = [...(buckets[activeTask.column_id] ?? [])];
+	const sourceIndex = sourceList.findIndex((task) => task.id === activeTaskId);
+	if (sourceIndex < 0) {
+		return null;
+	}
+
+	const [movingTask] = sourceList.splice(sourceIndex, 1);
+	buckets[activeTask.column_id] = sourceList;
+
+	let destinationColumnId = activeTask.column_id;
+	let destinationIndex = sourceList.length;
+
+	if (isTaskDragData(overData)) {
+		destinationColumnId = overData.task.column_id;
+		const targetList =
+			destinationColumnId === activeTask.column_id
+				? sourceList
+				: [...(buckets[destinationColumnId] ?? [])];
+		const overIndex = targetList.findIndex(
+			(task) => task.id === overData.task.id,
+		);
+		destinationIndex = overIndex >= 0 ? overIndex : targetList.length;
+	} else if (isColumnDragData(overData)) {
+		destinationColumnId = overData.column.id;
+		const targetList =
+			destinationColumnId === activeTask.column_id
+				? sourceList
+				: [...(buckets[destinationColumnId] ?? [])];
+		destinationIndex = targetList.length;
+	} else {
+		const targetList = buckets[activeTask.column_id] ?? [];
+		const overIndex = targetList.findIndex((task) => task.id === overId);
+		destinationIndex = overIndex >= 0 ? overIndex : targetList.length;
+	}
+
+	const destinationList =
+		destinationColumnId === activeTask.column_id
+			? sourceList
+			: [...(buckets[destinationColumnId] ?? [])];
+	destinationList.splice(destinationIndex, 0, {
+		...movingTask!,
+		column_id: destinationColumnId,
+	});
+	buckets[destinationColumnId] = destinationList;
+
+	return flattenTaskBuckets(buckets);
+}
+
+function buildTaskBuckets(tasks: KanbanTask[]) {
+	const buckets: Record<string, KanbanTask[]> = {};
+	for (const task of [...tasks].sort(sortTaskList)) {
+		if (!buckets[task.column_id]) {
+			buckets[task.column_id] = [];
+		}
+		buckets[task.column_id]!.push(task);
+	}
+	return buckets;
+}
+
+function flattenTaskBuckets(buckets: Record<string, KanbanTask[]>) {
+	const nextTasks: KanbanTask[] = [];
+	for (const columnId of Object.keys(buckets)) {
+		buckets[columnId]!.forEach((task, index) => {
+			nextTasks.push({ ...task, column_id: columnId, position: index + 1 });
+		});
+	}
+	return nextTasks.sort(sortTaskList);
+}
+
+export function sortTaskList(
+	left: { column_id: string; position: number },
+	right: { column_id: string; position: number },
+) {
+	if (left.column_id === right.column_id) {
+		return left.position - right.position;
+	}
+	return left.column_id.localeCompare(right.column_id);
+}
+
+export function setTasksCache(
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+	tasks: KanbanTask[],
+) {
+	queryClient.setQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId), tasks);
+}
+
+export function getTasksCache(
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+) {
+	return queryClient.getQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId));
+}
+
+export async function invalidateBoard(
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+) {
+	await queryClient.invalidateQueries({ queryKey: kanbanKeys.all(projectId) });
+}
+
+export function finishTaskDrag(
+	taskId: string,
+	nextTasks: KanbanTask[] | null,
+	snapshot: DragSnapshot | null,
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+) {
+	if (!snapshot || !nextTasks) {
+		return;
+	}
+
+	const previousTask = snapshot.tasks.find((task) => task.id === taskId);
+	const nextTask = nextTasks.find((task) => task.id === taskId);
+
+	if (!previousTask || !nextTask) {
+		setTasksCache(queryClient, projectId, snapshot.tasks);
+		return;
+	}
+
+	if (
+		previousTask.column_id === nextTask.column_id &&
+		previousTask.position === nextTask.position
+	) {
+		return;
+	}
+
+	setTasksCache(queryClient, projectId, nextTasks);
+	void moveKanbanTask(
+		projectId,
+		nextTask.id,
+		nextTask.column_id,
+		nextTask.position,
+	)
+		.then(async () => {
+			await invalidateBoard(queryClient, projectId);
+		})
+		.catch(async () => {
+			setTasksCache(queryClient, projectId, snapshot.tasks);
+			await invalidateBoard(queryClient, projectId);
+		});
+}
+
+export function finishColumnDrag(
+	event: DragEndEvent,
+	columns: KanbanColumn[],
+	tasks: KanbanTask[],
+	snapshot: DragSnapshot | null,
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+) {
+	if (!snapshot) {
+		return;
+	}
+
+	const currentColumns =
+		queryClient.getQueryData<KanbanColumn[]>(kanbanKeys.columns(projectId)) ??
+		columns;
+	const activeIndex = currentColumns.findIndex(
+		(column) => column.id === event.active.id,
+	);
+	const currentTasks =
+		getTasksCache(queryClient, projectId) ??
+		tasks;
+	const overColumnId = resolveOverColumnId(event, currentColumns, currentTasks);
+	const overIndex = currentColumns.findIndex(
+		(column) => column.id === overColumnId,
+	);
+	if (activeIndex < 0 || overIndex < 0 || activeIndex === overIndex) {
+		return;
+	}
+
+	const nextColumns = arrayMove(currentColumns, activeIndex, overIndex).map(
+		(column, index) => ({
+			...column,
+			position: index + 1,
+		}),
+	);
+
+	queryClient.setQueryData(kanbanKeys.columns(projectId), nextColumns);
+	void reorderKanbanColumns(
+		projectId,
+		nextColumns.map((column) => column.id),
+	)
+		.then(async () => {
+			await invalidateBoard(queryClient, projectId);
+		})
+		.catch(async () => {
+			queryClient.setQueryData(kanbanKeys.columns(projectId), snapshot.columns);
+			await invalidateBoard(queryClient, projectId);
+		});
+}
+
+function resolveOverColumnId(
+	event: DragEndEvent,
+	columns: KanbanColumn[],
+	tasks: KanbanTask[],
+) {
+	const overData = event.over?.data.current;
+	if (isColumnDragData(overData)) {
+		return overData.column.id;
+	}
+
+	const overId = event.over?.id?.toString();
+	if (!overId) {
+		return null;
+	}
+
+	if (columns.some((column) => column.id === overId)) {
+		return overId;
+	}
+
+	return tasks.find((task) => task.id === overId)?.column_id ?? null;
+}
+
+export function isTaskDragData(value: unknown): value is DragTaskData {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		value.type === "task"
+	);
+}
+
+export function isColumnDragData(value: unknown): value is DragColumnData {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		value.type === "column"
+	);
+}
+
+export function extractErrorMessage(error: unknown) {
+	return error instanceof Error
+		? error.message
+		: "Terjadi kesalahan yang tidak terduga";
+}

--- a/frontend/src/components/shared/kanban-toolbar.tsx
+++ b/frontend/src/components/shared/kanban-toolbar.tsx
@@ -1,0 +1,137 @@
+import { Plus } from "lucide-react";
+
+import { PermissionGate } from "@/components/shared/permission-gate";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { permissions } from "@/lib/permissions";
+import type { KanbanFilters } from "@/types/kanban";
+import type { ProjectMember } from "@/types/project";
+
+const emptyFilters: KanbanFilters = {
+	assignee: "",
+	priority: "",
+	label: "",
+	dueDate: "",
+};
+
+interface KanbanToolbarProps {
+	members: ProjectMember[];
+	filters: KanbanFilters;
+	onFiltersChange: (
+		updater: (current: KanbanFilters) => KanbanFilters,
+	) => void;
+	onColumnCreate: () => void;
+}
+
+export function KanbanToolbar({
+	members,
+	filters,
+	onFiltersChange,
+	onColumnCreate,
+}: KanbanToolbarProps) {
+	const activeFilterCount = [
+		filters.assignee,
+		filters.priority,
+		filters.label,
+		filters.dueDate,
+	].filter(Boolean).length;
+
+	return (
+		<Card className="p-6">
+			<div className="flex flex-col gap-5">
+				<div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+					<div>
+						<p className="mb-1 text-[11px] font-[700] uppercase tracking-[0.08em] text-ops">
+							Board proyek
+						</p>
+						<h4 className="text-[20px] font-[700] text-text-primary leading-tight">
+							Ruang kerja task proyek
+						</h4>
+						<p className="mt-1 max-w-3xl text-[13px] text-text-secondary">
+							Kelola task proyek dalam satu board, pindahkan kartu antar tahap
+							kerja, dan gunakan filter tanpa keluar dari halaman ini.
+						</p>
+					</div>
+
+					<PermissionGate permission={permissions.operationalColumnManage}>
+						<div className="flex w-full flex-col items-stretch gap-3 xl:w-auto xl:items-end">
+							<Button
+								variant="ops"
+								className="xl:self-end"
+								onClick={onColumnCreate}
+								type="button">
+								<Plus className="h-4 w-4" />
+								Kolom baru
+							</Button>
+						</div>
+					</PermissionGate>
+				</div>
+
+				<div className="grid gap-4 xl:grid-cols-[repeat(4,minmax(0,1fr))_auto]">
+					<select
+						className="flex h-[44px] w-full rounded-[6px] border border-transparent bg-surface-muted px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
+						onChange={(event) =>
+							onFiltersChange((current) => ({
+								...current,
+								assignee: event.target.value,
+							}))
+						}
+						value={filters.assignee}>
+						<option value="">Semua PIC</option>
+						{members.map((member) => (
+							<option
+								key={member.user_id}
+								value={member.user_id}>
+								{member.full_name || member.user_email || member.user_id}
+							</option>
+						))}
+					</select>
+					<select
+						className="flex h-[44px] w-full rounded-[6px] border border-transparent bg-surface-muted px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
+						onChange={(event) =>
+							onFiltersChange((current) => ({
+								...current,
+								priority: event.target.value,
+							}))
+						}
+						value={filters.priority}>
+						<option value="">Semua prioritas</option>
+						<option value="low">Rendah</option>
+						<option value="medium">Medium</option>
+						<option value="high">Tinggi</option>
+						<option value="critical">Kritis</option>
+					</select>
+					<Input
+						className="h-[44px] focus-visible:border-ops focus-visible:ring-ops/10"
+						onChange={(event) =>
+							onFiltersChange((current) => ({
+								...current,
+								label: event.target.value,
+							}))
+						}
+						placeholder="Filter label"
+						value={filters.label}
+					/>
+					<Input
+						className="h-[44px] focus-visible:border-ops focus-visible:ring-ops/10"
+						onChange={(event) =>
+							onFiltersChange((current) => ({
+								...current,
+								dueDate: event.target.value,
+							}))
+						}
+						type="date"
+						value={filters.dueDate}
+					/>
+					<Button
+						onClick={() => onFiltersChange(() => emptyFilters)}
+						variant="secondary"
+						className="h-[44px]">
+						Reset {activeFilterCount > 0 ? `(${activeFilterCount})` : ""}
+					</Button>
+				</div>
+			</div>
+		</Card>
+	);
+}

--- a/frontend/src/components/shared/task-modal-fields.tsx
+++ b/frontend/src/components/shared/task-modal-fields.tsx
@@ -1,0 +1,126 @@
+import type { UseFormReturn } from "react-hook-form";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import type { TaskFormValues } from "@/types/kanban";
+import type { ProjectMember } from "@/types/project";
+
+const selectClassName =
+	"flex h-[44px] w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10";
+
+export function TaskTitleField({
+	form,
+	className,
+}: {
+	form: UseFormReturn<TaskFormValues>;
+	className?: string;
+}) {
+	const {
+		register,
+		formState: { errors },
+	} = form;
+
+	return (
+		<div className={cn("grid gap-2", className)}>
+			<label
+				className="text-[13px] font-[600] text-text-primary"
+				htmlFor="task-title">
+				Judul<span className="ml-0.5 text-priority-high">*</span>
+			</label>
+			<Input
+				className="focus-visible:border-ops focus-visible:ring-ops/10"
+				id="task-title"
+				{...register("title")}
+			/>
+			{errors.title ? (
+				<p className="text-[13px] font-[500] text-priority-high">
+					{errors.title.message}
+				</p>
+			) : null}
+		</div>
+	);
+}
+
+export function TaskMetaFields({
+	form,
+	members,
+	className,
+	idPrefix = "task",
+}: {
+	form: UseFormReturn<TaskFormValues>;
+	members: ProjectMember[];
+	className?: string;
+	idPrefix?: string;
+}) {
+	const { register } = form;
+
+	return (
+		<div className={cn("grid gap-5 md:grid-cols-2", className)}>
+			<div className="grid gap-2">
+				<label
+					className="text-[13px] font-[600] text-text-primary"
+					htmlFor={`${idPrefix}-assignee`}>
+					PIC
+				</label>
+				<select
+					className={selectClassName}
+					id={`${idPrefix}-assignee`}
+					{...register("assignee_id")}>
+					<option value="">Belum ditentukan</option>
+					{members.map((member) => (
+						<option
+							key={member.user_id}
+							value={member.user_id}>
+							{member.full_name || member.user_email || member.user_id}
+						</option>
+					))}
+				</select>
+			</div>
+
+			<div className="grid gap-2">
+				<label
+					className="text-[13px] font-[600] text-text-primary"
+					htmlFor={`${idPrefix}-due-date`}>
+					Deadline
+				</label>
+				<Input
+					className="focus-visible:border-ops focus-visible:ring-ops/10"
+					id={`${idPrefix}-due-date`}
+					type="date"
+					{...register("due_date")}
+				/>
+			</div>
+
+			<div className="grid gap-2">
+				<label
+					className="text-[13px] font-[600] text-text-primary"
+					htmlFor={`${idPrefix}-priority`}>
+					Prioritas
+				</label>
+				<select
+					className={selectClassName}
+					id={`${idPrefix}-priority`}
+					{...register("priority")}>
+					<option value="low">Rendah</option>
+					<option value="medium">Medium</option>
+					<option value="high">Tinggi</option>
+					<option value="critical">Kritis</option>
+				</select>
+			</div>
+
+			<div className="grid gap-2">
+				<label
+					className="text-[13px] font-[600] text-text-primary"
+					htmlFor={`${idPrefix}-label`}>
+					Label
+				</label>
+				<Input
+					className="focus-visible:border-ops focus-visible:ring-ops/10"
+					id={`${idPrefix}-label`}
+					placeholder="Bug, desain, backend"
+					{...register("label")}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/shared/task-modal.tsx
+++ b/frontend/src/components/shared/task-modal.tsx
@@ -1,0 +1,129 @@
+import type { UseFormReturn } from "react-hook-form";
+
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerHeader,
+	DrawerTitle,
+} from "@/components/shared/drawer";
+import { PermissionGate } from "@/components/shared/permission-gate";
+import {
+	TaskMetaFields,
+	TaskTitleField,
+} from "@/components/shared/task-modal-fields";
+import { Button } from "@/components/ui/button";
+import { permissions } from "@/lib/permissions";
+import type { TaskFormValues } from "@/types/kanban";
+import type { ProjectMember } from "@/types/project";
+
+export function TaskModal({
+	mode,
+	form,
+	members,
+	isSubmitting,
+	isDeleting,
+	onSubmit,
+	onDelete,
+	onClose,
+}: {
+	mode: "create" | "edit";
+	form: UseFormReturn<TaskFormValues>;
+	members: ProjectMember[];
+	isSubmitting: boolean;
+	isDeleting: boolean;
+	onSubmit: (values: TaskFormValues) => void;
+	onDelete: () => void;
+	onClose: () => void;
+}) {
+	const { register, handleSubmit } = form;
+
+	return (
+		<Drawer
+			onOpenChange={(open) => (!open ? onClose() : undefined)}
+			open>
+			<DrawerContent size="lg">
+				<form
+					className="flex h-full min-h-0 flex-col"
+					onSubmit={handleSubmit(onSubmit)}>
+					<DrawerHeader className="shrink-0">
+						<div className="flex items-start justify-between gap-4">
+							<div>
+								<p className="text-[11px] font-[700] uppercase tracking-[0.08em] text-ops mb-1">
+									{mode === "create" ? "Buat task" : "Detail task"}
+								</p>
+								<DrawerTitle>
+									{mode === "create" ? "Task baru" : "Edit task"}
+								</DrawerTitle>
+								<DrawerDescription>
+									{mode === "create"
+										? "Isi ringkasan task, PIC, dan due date tanpa keluar dari board."
+										: "Tinjau detail task, edit informasi pengerjaan, atau hapus task dari board."}
+								</DrawerDescription>
+							</div>
+							<DrawerClose />
+						</div>
+					</DrawerHeader>
+
+					<div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 pb-4 pt-6 [scrollbar-gutter:stable]">
+						<TaskTitleField form={form} />
+
+						<div className="grid gap-2">
+							<label
+								className="text-[13px] font-[600] text-text-primary"
+								htmlFor="task-description">
+								Deskripsi
+							</label>
+							<textarea
+								className="min-h-32 w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10 disabled:cursor-not-allowed disabled:opacity-50"
+								id="task-description"
+								{...register("description")}
+							/>
+						</div>
+
+						<TaskMetaFields
+							className="md:hidden"
+							form={form}
+							idPrefix="task-m"
+							members={members}
+						/>
+
+					</div>
+
+					<div className="shrink-0 border-t border-border bg-surface px-6 pb-5 pt-5">
+						<TaskMetaFields
+							className="mb-5 hidden md:grid"
+							form={form}
+							members={members}
+						/>
+
+						<div className="flex flex-wrap gap-3">
+							<Button
+								variant="ops"
+								disabled={isSubmitting}
+								type="submit">
+								{isSubmitting
+									? "Menyimpan..."
+									: mode === "create"
+										? "Buat task"
+										: "Simpan perubahan"}
+							</Button>
+							{mode === "edit" ? (
+								<PermissionGate permission={permissions.operationalTaskDelete}>
+									<Button
+										disabled={isDeleting}
+										onClick={onDelete}
+										type="button"
+										variant="ghost">
+										{isDeleting ? "Menghapus..." : "Hapus task"}
+									</Button>
+								</PermissionGate>
+							) : null}
+						</div>
+					</div>
+				</form>
+			</DrawerContent>
+		</Drawer>
+	);
+}

--- a/frontend/src/components/shared/task-modal.tsx
+++ b/frontend/src/components/shared/task-modal.tsx
@@ -83,21 +83,12 @@ export function TaskModal({
 						</div>
 
 						<TaskMetaFields
-							className="md:hidden"
 							form={form}
-							idPrefix="task-m"
 							members={members}
 						/>
-
 					</div>
 
 					<div className="shrink-0 border-t border-border bg-surface px-6 pb-5 pt-5">
-						<TaskMetaFields
-							className="mb-5 hidden md:grid"
-							form={form}
-							members={members}
-						/>
-
 						<div className="flex flex-wrap gap-3">
 							<Button
 								variant="ops"

--- a/frontend/src/hooks/use-debounced-value.ts
+++ b/frontend/src/hooks/use-debounced-value.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs = 300) {
+	const [debounced, setDebounced] = useState(value);
+
+	useEffect(() => {
+		const timeout = window.setTimeout(() => setDebounced(value), delayMs);
+		return () => window.clearTimeout(timeout);
+	}, [value, delayMs]);
+
+	return debounced;
+}

--- a/frontend/src/hooks/use-kanban-column-tasks.ts
+++ b/frontend/src/hooks/use-kanban-column-tasks.ts
@@ -4,6 +4,7 @@ import {
 	kanbanKeys,
 	kanbanPageSize,
 	listKanbanTasks,
+	type KanbanTaskQuery,
 } from "@/services/operational-kanban";
 import type { KanbanTask } from "@/types/kanban";
 
@@ -20,12 +21,14 @@ export interface ColumnTasksResult {
 export function useKanbanColumnTasks(
 	projectId: string,
 	columnId: string,
+	filters: KanbanTaskQuery,
 ): ColumnTasksResult {
 	const query = useInfiniteQuery({
-		queryKey: kanbanKeys.columnTasks(projectId, columnId, {}),
+		queryKey: kanbanKeys.columnTasks(projectId, columnId, filters),
 		initialPageParam: 0,
 		queryFn: ({ pageParam }) =>
 			listKanbanTasks(projectId, {
+				...filters,
 				columnId,
 				limit: kanbanPageSize,
 				offset: pageParam,

--- a/frontend/src/hooks/use-kanban-column-tasks.ts
+++ b/frontend/src/hooks/use-kanban-column-tasks.ts
@@ -1,0 +1,52 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import {
+	kanbanKeys,
+	kanbanPageSize,
+	listKanbanTasks,
+} from "@/services/operational-kanban";
+import type { KanbanTask } from "@/types/kanban";
+
+export interface ColumnTasksResult {
+	tasks: KanbanTask[];
+	total: number;
+	hasMore: boolean;
+	isLoading: boolean;
+	isFetchingMore: boolean;
+	error: Error | null;
+	fetchMore: () => void;
+}
+
+export function useKanbanColumnTasks(
+	projectId: string,
+	columnId: string,
+): ColumnTasksResult {
+	const query = useInfiniteQuery({
+		queryKey: kanbanKeys.columnTasks(projectId, columnId, {}),
+		initialPageParam: 0,
+		queryFn: ({ pageParam }) =>
+			listKanbanTasks(projectId, {
+				columnId,
+				limit: kanbanPageSize,
+				offset: pageParam,
+			}),
+		getNextPageParam: (lastPage) =>
+			lastPage.has_more ? lastPage.offset + lastPage.items.length : undefined,
+	});
+
+	const pages = query.data?.pages ?? [];
+
+	return {
+		tasks: pages.flatMap((page) => page.items),
+		total: pages[0]?.total ?? 0,
+		hasMore: Boolean(query.hasNextPage),
+		isLoading: query.isLoading,
+		isFetchingMore: query.isFetchingNextPage,
+		error: query.error as Error | null,
+		fetchMore: () => {
+			if (query.hasNextPage && !query.isFetchingNextPage) {
+				void query.fetchNextPage();
+			}
+		},
+	};
+}

--- a/frontend/src/hooks/use-kanban-drag.ts
+++ b/frontend/src/hooks/use-kanban-drag.ts
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+	finishColumnDrag,
+	finishTaskDrag,
+	isColumnDragData,
+	isTaskDragData,
+	moveTaskInMemory,
+	setTasksCache,
+	type DragSnapshot,
+} from "@/components/shared/kanban-dnd";
+import { kanbanKeys } from "@/services/operational-kanban";
+import type {
+	KanbanColumn,
+	KanbanTask,
+} from "@/types/kanban";
+
+export function useKanbanDrag(
+	projectId: string,
+	columns: KanbanColumn[],
+	tasks: KanbanTask[],
+) {
+	const queryClient = useQueryClient();
+	const [activeTask, setActiveTask] = useState<KanbanTask | null>(null);
+	const [activeColumn, setActiveColumn] = useState<KanbanColumn | null>(null);
+	const [dragSnapshot, setDragSnapshot] = useState<DragSnapshot | null>(null);
+
+	function resetDrag() {
+		setActiveTask(null);
+		setActiveColumn(null);
+		setDragSnapshot(null);
+	}
+
+	function rollbackDrag() {
+		if (!dragSnapshot) {
+			return;
+		}
+
+		queryClient.setQueryData(
+			kanbanKeys.columns(projectId),
+			dragSnapshot.columns,
+		);
+		setTasksCache(queryClient, projectId, dragSnapshot.tasks);
+	}
+
+	function handleDragStart(event: DragStartEvent) {
+		const data = event.active.data.current;
+
+		if (isTaskDragData(data)) {
+			setActiveTask(data.task);
+			setDragSnapshot({ columns, tasks });
+			return;
+		}
+
+		if (isColumnDragData(data)) {
+			setActiveColumn(data.column);
+			setDragSnapshot({ columns, tasks });
+		}
+	}
+
+	function handleDragEnd(event: DragEndEvent) {
+		if (!event.over) {
+			rollbackDrag();
+			resetDrag();
+			return;
+		}
+
+		const activeData = event.active.data.current;
+
+		if (isColumnDragData(activeData)) {
+			finishColumnDrag(
+				event,
+				columns,
+				tasks,
+				dragSnapshot,
+				queryClient,
+				projectId,
+			);
+			resetDrag();
+			return;
+		}
+
+		if (isTaskDragData(activeData)) {
+			const nextTasks = moveTaskInMemory(
+				dragSnapshot?.tasks ?? tasks,
+				activeData.task.id,
+				event.over.data.current,
+				event.over.id.toString(),
+			);
+
+			finishTaskDrag(
+				activeData.task.id,
+				nextTasks,
+				dragSnapshot,
+				queryClient,
+				projectId,
+			);
+		}
+
+		resetDrag();
+	}
+
+	return { activeTask, activeColumn, handleDragStart, handleDragEnd };
+}

--- a/frontend/src/hooks/use-kanban-mutations.ts
+++ b/frontend/src/hooks/use-kanban-mutations.ts
@@ -1,0 +1,102 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+	extractErrorMessage,
+	invalidateBoard,
+} from "@/components/shared/kanban-dnd";
+import {
+	createKanbanColumn,
+	createKanbanTask,
+	deleteKanbanColumn,
+	deleteKanbanTask,
+	updateKanbanColumn,
+	updateKanbanTask,
+} from "@/services/operational-kanban";
+import type { TaskFormValues } from "@/types/kanban";
+
+interface KanbanMutationCallbacks {
+	onError: (message: string) => void;
+	onColumnSaved: () => void;
+	onColumnDeleted: () => void;
+	onTaskSaved: () => void;
+	onTaskDeleted: () => void;
+}
+
+export function useKanbanMutations(
+	projectId: string,
+	callbacks: KanbanMutationCallbacks,
+) {
+	const queryClient = useQueryClient();
+	const handleError = (error: unknown) =>
+		callbacks.onError(extractErrorMessage(error));
+
+	const createColumn = useMutation({
+		mutationFn: (payload: { name: string; color?: string }) =>
+			createKanbanColumn(projectId, payload),
+		onSuccess: async () => {
+			callbacks.onColumnSaved();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const updateColumn = useMutation({
+		mutationFn: (payload: { columnId: string; name: string; color?: string }) =>
+			updateKanbanColumn(projectId, payload.columnId, {
+				name: payload.name,
+				color: payload.color,
+			}),
+		onSuccess: async () => {
+			callbacks.onColumnSaved();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const deleteColumn = useMutation({
+		mutationFn: (columnId: string) => deleteKanbanColumn(projectId, columnId),
+		onSuccess: async () => {
+			callbacks.onColumnDeleted();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const createTask = useMutation({
+		mutationFn: (payload: { column_id: string } & TaskFormValues) =>
+			createKanbanTask(projectId, payload),
+		onSuccess: async () => {
+			callbacks.onTaskSaved();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const updateTask = useMutation({
+		mutationFn: (payload: { taskId: string; values: TaskFormValues }) =>
+			updateKanbanTask(projectId, payload.taskId, payload.values),
+		onSuccess: async () => {
+			callbacks.onTaskSaved();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const deleteTask = useMutation({
+		mutationFn: (taskId: string) => deleteKanbanTask(projectId, taskId),
+		onSuccess: async () => {
+			callbacks.onTaskDeleted();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	return {
+		createColumn,
+		updateColumn,
+		deleteColumn,
+		createTask,
+		updateTask,
+		deleteTask,
+	};
+}

--- a/frontend/src/services/operational-kanban.ts
+++ b/frontend/src/services/operational-kanban.ts
@@ -4,6 +4,10 @@ import type { KanbanColumn, KanbanTask, TaskFormValues } from "@/types/kanban";
 
 export interface KanbanTaskQuery {
   columnId?: string;
+  assigneeId?: string;
+  priority?: string;
+  label?: string;
+  dueDate?: string;
   limit?: number;
   offset?: number;
 }
@@ -23,7 +27,15 @@ export const kanbanKeys = {
   columns: (projectId: string) => [...kanbanKeys.all(projectId), "columns"] as const,
   tasks: (projectId: string) => [...kanbanKeys.all(projectId), "tasks"] as const,
   columnTasks: (projectId: string, columnId: string, query: KanbanTaskQuery) =>
-    [...kanbanKeys.tasks(projectId), "column", columnId, query.limit ?? ""] as const,
+    [
+      ...kanbanKeys.tasks(projectId),
+      "column",
+      columnId,
+      query.assigneeId ?? "",
+      query.priority ?? "",
+      query.label ?? "",
+      query.dueDate ?? "",
+    ] as const,
 };
 
 export async function listKanbanColumns(projectId: string) {
@@ -85,6 +97,18 @@ export async function listKanbanTasks(projectId: string, query: KanbanTaskQuery 
   const params = new URLSearchParams();
   if (query.columnId) {
     params.set("column_id", query.columnId);
+  }
+  if (query.assigneeId) {
+    params.set("assignee_id", query.assigneeId);
+  }
+  if (query.priority) {
+    params.set("priority", query.priority);
+  }
+  if (query.label?.trim()) {
+    params.set("label", query.label.trim());
+  }
+  if (query.dueDate) {
+    params.set("due_date", query.dueDate);
   }
   params.set("limit", String(query.limit ?? kanbanPageSize));
   params.set("offset", String(query.offset ?? 0));

--- a/frontend/src/services/operational-kanban.ts
+++ b/frontend/src/services/operational-kanban.ts
@@ -2,10 +2,28 @@
 import { toUTCDateOnlyISOString } from "@/lib/date";
 import type { KanbanColumn, KanbanTask, TaskFormValues } from "@/types/kanban";
 
+export interface KanbanTaskQuery {
+  columnId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface KanbanTaskPage {
+  items: KanbanTask[];
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
+export const kanbanPageSize = 20;
+
 export const kanbanKeys = {
   all: (projectId: string) => ["operational", "projects", projectId, "kanban"] as const,
   columns: (projectId: string) => [...kanbanKeys.all(projectId), "columns"] as const,
   tasks: (projectId: string) => [...kanbanKeys.all(projectId), "tasks"] as const,
+  columnTasks: (projectId: string, columnId: string, query: KanbanTaskQuery) =>
+    [...kanbanKeys.tasks(projectId), "column", columnId, query.limit ?? ""] as const,
 };
 
 export async function listKanbanColumns(projectId: string) {
@@ -63,9 +81,16 @@ export async function reorderKanbanColumns(projectId: string, columnIds: string[
   );
 }
 
-export async function listKanbanTasks(projectId: string) {
-  return authRequestJSON<KanbanTask[]>(
-    `/operational/projects/${projectId}/tasks`,
+export async function listKanbanTasks(projectId: string, query: KanbanTaskQuery = {}) {
+  const params = new URLSearchParams();
+  if (query.columnId) {
+    params.set("column_id", query.columnId);
+  }
+  params.set("limit", String(query.limit ?? kanbanPageSize));
+  params.set("offset", String(query.offset ?? 0));
+
+  return authRequestJSON<KanbanTaskPage>(
+    `/operational/projects/${projectId}/tasks?${params.toString()}`,
     { method: "GET" },
   );
 }


### PR DESCRIPTION
> **Stacked PR 3 of 7 — merge in order.**
> Depends on #151, PR 2. Built on top of `feat/kanban-task-pagination`.
> GitHub does not allow a fork branch as a base, so this targets `main` directly:
> until the PRs before it merge, this diff also shows their changes.
> Once they land, this diff narrows to only what is listed below.
> #151 → #152 → #153 → #154 → #155 → #156 → #157

## Summary

The PIC, priority, label, and due date filters ran **in the browser**, over whatever rows happened to be loaded. That was invisible while the board loaded every task at once. Now that it loads 20 per column, those filters only see the current page and the task total never changes. This PR moves them into SQL.

## What changed

- Filter by assignee, priority, label, and due date in the query itself
- The same filters apply to the count, so the displayed total reflects what is filtered
- Filters travel as query params instead of narrowing already-loaded rows
- Removed the client-side filter helper that could only see the current page

## Why

This is a correctness bug introduced by pagination, not a preference. Filtering "critical" in a 320-task Backlog showed **6 results when the real answer was 75** — the browser was filtering the 20 rows it happened to hold.

### Personal context

I use these filters to answer real questions — "what is assigned to me", "what is overdue". An answer that silently depends on how far I have scrolled is worse than no filter at all, because it looks authoritative while being wrong.

## Verification

Tested on **952 tasks, 7 columns, 5 project members**:

| Filter | Result |
|---|---|
| PIC (5 different members) | 129 / 128 / 129 / 124 / 127, plus 315 unassigned |
| priority=critical | 238 |
| label=backend | 101 |
| due_date=2026-09-15 | 10 |
| column=Done | 60 |

- Totals verified against direct database counts
- Five filters combined still return the correct total
- Infinite scroll continues to work with filters active — no duplicates across pages
- `go build`, `go vet`, `go test`, `tsc`, `eslint`, and production build all pass

## Risk if we don't merge this

Four of the board's filters return wrong results, and the task total ignores them entirely. Anyone trusting a filtered view would be acting on incomplete data.

## Risk of merging this

Low. The filters are additive `AND` conditions on an already-indexed query — an empty filter is a no-op, so an unfiltered board behaves exactly as before. Measured 7–11 ms per filtered query on 952 tasks.

## Screenshots

Before — Client-side filtering:
Filtering was handled on the client side. When there were hundreds of tasks, processing them all on the client could cause performance issues and make the application feel heavy or slow.

**After — network tab shows filters as query params**

<img width="1119" height="990" alt="image" src="https://github.com/user-attachments/assets/57a06a36-a988-453e-bf40-210e241aa7ec" />

