### PR TITLE
feat(kanban): add custom columns to the task modal

### DIFF
--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -175,6 +175,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 
 	projectsRepository := operationalrepo.NewProjectsRepository(pool)
 	kanbanRepository := operationalrepo.NewKanbanRepository(pool)
+	kanbanTaskFieldRepository := operationalrepo.NewKanbanTaskFieldRepository(pool)
 	operationalOverviewRepository := operationalrepo.NewOverviewRepository(pool)
 	trackerRepository := operationalrepo.NewTrackerRepository(pool)
 	trackerReminderRepository := operationalrepo.NewTrackerReminderRepository(pool)
@@ -196,6 +197,7 @@ func New(ctx context.Context, cfg config.Config) (*App, error) {
 
 	projectsService := operationalservice.NewProjectsService(projectsRepository, kanbanRepository)
 	kanbanService := operationalservice.NewKanbanService(kanbanRepository, projectsRepository)
+	kanbanService.SetTaskFieldRepository(kanbanTaskFieldRepository)
 	operationalOverviewService := operationalservice.NewOverviewService(operationalOverviewRepository)
 	trackerService := operationalservice.NewTrackerService(trackerRepository, cfg.TrackerRetentionDays)
 	employeesService := hrisservice.NewEmployeesService(employeesRepository)

--- a/backend/internal/dto/operational/kanban.go
+++ b/backend/internal/dto/operational/kanban.go
@@ -54,6 +54,7 @@ type MyTaskItem struct {
 }
 
 type ListKanbanTasksQuery struct {
+	Search     string
 	ColumnID   string
 	AssigneeID string
 	Priority   string

--- a/backend/internal/dto/operational/kanban.go
+++ b/backend/internal/dto/operational/kanban.go
@@ -52,3 +52,9 @@ type MyTaskItem struct {
 	DueDate     string `json:"due_date"`
 	Priority    string `json:"priority"`
 }
+
+type ListKanbanTasksQuery struct {
+	ColumnID string
+	Limit    int
+	Offset   int
+}

--- a/backend/internal/dto/operational/kanban.go
+++ b/backend/internal/dto/operational/kanban.go
@@ -54,7 +54,11 @@ type MyTaskItem struct {
 }
 
 type ListKanbanTasksQuery struct {
-	ColumnID string
-	Limit    int
-	Offset   int
+	ColumnID   string
+	AssigneeID string
+	Priority   string
+	Label      string
+	DueDate    string
+	Limit      int
+	Offset     int
 }

--- a/backend/internal/dto/operational/kanban.go
+++ b/backend/internal/dto/operational/kanban.go
@@ -18,22 +18,24 @@ type ReorderKanbanColumnsRequest struct {
 }
 
 type CreateKanbanTaskRequest struct {
-	ColumnID    string     `json:"column_id" validate:"required,uuid4"`
-	Title       string     `json:"title" validate:"required,min=2,max=160"`
-	Description *string    `json:"description"`
-	AssigneeID  *string    `json:"assignee_id" validate:"omitempty,uuid4"`
-	DueDate     *time.Time `json:"due_date"`
-	Priority    string     `json:"priority" validate:"required,oneof=low medium high critical"`
-	Label       *string    `json:"label"`
+	ColumnID    string                 `json:"column_id" validate:"required,uuid4"`
+	Title       string                 `json:"title" validate:"required,min=2,max=160"`
+	Description *string                `json:"description"`
+	AssigneeID  *string                `json:"assignee_id" validate:"omitempty,uuid4"`
+	DueDate     *time.Time             `json:"due_date"`
+	Priority    string                 `json:"priority" validate:"required,oneof=low medium high critical"`
+	Label       *string                `json:"label"`
+	Fields      []KanbanTaskFieldInput `json:"fields" validate:"omitempty,max=50,dive"`
 }
 
 type UpdateKanbanTaskRequest struct {
-	Title       string     `json:"title" validate:"required,min=2,max=160"`
-	Description *string    `json:"description"`
-	AssigneeID  *string    `json:"assignee_id" validate:"omitempty,uuid4"`
-	DueDate     *time.Time `json:"due_date"`
-	Priority    string     `json:"priority" validate:"required,oneof=low medium high critical"`
-	Label       *string    `json:"label"`
+	Title       string                 `json:"title" validate:"required,min=2,max=160"`
+	Description *string                `json:"description"`
+	AssigneeID  *string                `json:"assignee_id" validate:"omitempty,uuid4"`
+	DueDate     *time.Time             `json:"due_date"`
+	Priority    string                 `json:"priority" validate:"required,oneof=low medium high critical"`
+	Label       *string                `json:"label"`
+	Fields      []KanbanTaskFieldInput `json:"fields" validate:"omitempty,max=50,dive"`
 }
 
 type MoveKanbanTaskRequest struct {

--- a/backend/internal/dto/operational/kanban_task_field.go
+++ b/backend/internal/dto/operational/kanban_task_field.go
@@ -1,0 +1,6 @@
+package operational
+
+type KanbanTaskFieldInput struct {
+	Name  string `json:"name" validate:"required,min=1,max=120"`
+	Value string `json:"value" validate:"max=20000"`
+}

--- a/backend/internal/dto/operational/kanban_task_page.go
+++ b/backend/internal/dto/operational/kanban_task_page.go
@@ -3,7 +3,7 @@ package operational
 import "github.com/kana-consultant/kantor/backend/internal/model"
 
 type KanbanTaskPage struct {
-	Items   []model.KanbanTask `json:"items"`
+	Items   []model.KanbanTaskListItem `json:"items"`
 	Total   int                `json:"total"`
 	Limit   int                `json:"limit"`
 	Offset  int                `json:"offset"`

--- a/backend/internal/dto/operational/kanban_task_page.go
+++ b/backend/internal/dto/operational/kanban_task_page.go
@@ -1,0 +1,11 @@
+package operational
+
+import "github.com/kana-consultant/kantor/backend/internal/model"
+
+type KanbanTaskPage struct {
+	Items   []model.KanbanTask `json:"items"`
+	Total   int                `json:"total"`
+	Limit   int                `json:"limit"`
+	Offset  int                `json:"offset"`
+	HasMore bool               `json:"has_more"`
+}

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -257,7 +257,7 @@ func (h *KanbanHandler) getTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.service.GetTaskDetail(r.Context(), projectID, taskID)
+	result, err := h.service.GetTask(r.Context(), projectID, taskID)
 	if err != nil {
 		h.writeError(r.Context(), w, err)
 		return

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-playground/validator/v10"
@@ -181,12 +182,10 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	query := operationaldto.ListKanbanTasksQuery{
-		AssigneeID: strings.TrimSpace(r.URL.Query().Get("assignee_id")),
-		Priority:   strings.TrimSpace(r.URL.Query().Get("priority")),
-		Label:      strings.TrimSpace(r.URL.Query().Get("label")),
-		DueDate:    strings.TrimSpace(r.URL.Query().Get("due_date")),
-		Limit:      parseKanbanPositiveInt(r.URL.Query().Get("limit")),
-		Offset:     parseKanbanPositiveInt(r.URL.Query().Get("offset")),
+		Priority: strings.TrimSpace(r.URL.Query().Get("priority")),
+		Label:    strings.TrimSpace(r.URL.Query().Get("label")),
+		Limit:    parseKanbanPositiveInt(r.URL.Query().Get("limit")),
+		Offset:   parseKanbanPositiveInt(r.URL.Query().Get("offset")),
 	}
 	if columnID := strings.TrimSpace(r.URL.Query().Get("column_id")); columnID != "" {
 		validatedColumnID, ok := validateKanbanUUIDParam(w, "column_id", columnID)
@@ -194,6 +193,20 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		query.ColumnID = validatedColumnID
+	}
+	if assigneeID := strings.TrimSpace(r.URL.Query().Get("assignee_id")); assigneeID != "" {
+		validatedAssigneeID, ok := validateKanbanUUIDParam(w, "assignee_id", assigneeID)
+		if !ok {
+			return
+		}
+		query.AssigneeID = validatedAssigneeID
+	}
+	if dueDate := strings.TrimSpace(r.URL.Query().Get("due_date")); dueDate != "" {
+		if _, err := time.Parse("2006-01-02", dueDate); err != nil {
+			response.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "due_date must be formatted as YYYY-MM-DD", map[string]string{"due_date": "invalid date"})
+			return
+		}
+		query.DueDate = dueDate
 	}
 
 	result, err := h.service.ListTasksPage(r.Context(), projectID, query)

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -43,6 +43,7 @@ func (h *KanbanHandler) RegisterColumnRoutes(router chi.Router) {
 func (h *KanbanHandler) RegisterTaskRoutes(router chi.Router) {
 	router.With(platformmiddleware.RequirePermission("operational:task:create")).Post("/", h.createTask)
 	router.With(platformmiddleware.RequirePermission("operational:task:view")).Get("/", h.listTasks)
+	router.With(platformmiddleware.RequirePermission("operational:task:view")).Get("/{taskID}", h.getTask)
 	router.With(platformmiddleware.RequirePermission("operational:task:edit")).Put("/{taskID}", h.updateTask)
 	router.With(platformmiddleware.RequirePermission("operational:task:delete")).Delete("/{taskID}", h.deleteTask)
 	router.With(platformmiddleware.RequirePermission("operational:task:edit")).Patch("/{taskID}/move", h.moveTask)
@@ -238,6 +239,25 @@ func (h *KanbanHandler) ListMyTasks(w http.ResponseWriter, r *http.Request) {
 
 	status := strings.TrimSpace(r.URL.Query().Get("status"))
 	result, err := h.service.ListMyTasks(r.Context(), principal.UserID, status)
+	if err != nil {
+		h.writeError(r.Context(), w, err)
+		return
+	}
+
+	response.WriteJSON(w, http.StatusOK, result, nil)
+}
+
+func (h *KanbanHandler) getTask(w http.ResponseWriter, r *http.Request) {
+	projectID, ok := validateKanbanUUIDParam(w, "projectID", chi.URLParam(r, "projectID"))
+	if !ok {
+		return
+	}
+	taskID, ok := validateKanbanUUIDParam(w, "taskID", chi.URLParam(r, "taskID"))
+	if !ok {
+		return
+	}
+
+	result, err := h.service.GetTaskDetail(r.Context(), projectID, taskID)
 	if err != nil {
 		h.writeError(r.Context(), w, err)
 		return

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -182,6 +182,7 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	query := operationaldto.ListKanbanTasksQuery{
+		Search:   strings.TrimSpace(r.URL.Query().Get("q")),
 		Priority: strings.TrimSpace(r.URL.Query().Get("priority")),
 		Label:    strings.TrimSpace(r.URL.Query().Get("label")),
 		Limit:    parseKanbanPositiveInt(r.URL.Query().Get("limit")),

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -181,8 +181,12 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	query := operationaldto.ListKanbanTasksQuery{
-		Limit:  parseKanbanPositiveInt(r.URL.Query().Get("limit")),
-		Offset: parseKanbanPositiveInt(r.URL.Query().Get("offset")),
+		AssigneeID: strings.TrimSpace(r.URL.Query().Get("assignee_id")),
+		Priority:   strings.TrimSpace(r.URL.Query().Get("priority")),
+		Label:      strings.TrimSpace(r.URL.Query().Get("label")),
+		DueDate:    strings.TrimSpace(r.URL.Query().Get("due_date")),
+		Limit:      parseKanbanPositiveInt(r.URL.Query().Get("limit")),
+		Offset:     parseKanbanPositiveInt(r.URL.Query().Get("offset")),
 	}
 	if columnID := strings.TrimSpace(r.URL.Query().Get("column_id")); columnID != "" {
 		validatedColumnID, ok := validateKanbanUUIDParam(w, "column_id", columnID)

--- a/backend/internal/handler/operational/kanban.go
+++ b/backend/internal/handler/operational/kanban.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -179,13 +180,34 @@ func (h *KanbanHandler) listTasks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.service.ListTasks(r.Context(), projectID)
+	query := operationaldto.ListKanbanTasksQuery{
+		Limit:  parseKanbanPositiveInt(r.URL.Query().Get("limit")),
+		Offset: parseKanbanPositiveInt(r.URL.Query().Get("offset")),
+	}
+	if columnID := strings.TrimSpace(r.URL.Query().Get("column_id")); columnID != "" {
+		validatedColumnID, ok := validateKanbanUUIDParam(w, "column_id", columnID)
+		if !ok {
+			return
+		}
+		query.ColumnID = validatedColumnID
+	}
+
+	result, err := h.service.ListTasksPage(r.Context(), projectID, query)
 	if err != nil {
 		h.writeError(r.Context(), w, err)
 		return
 	}
 
 	response.WriteJSON(w, http.StatusOK, result, nil)
+}
+
+func parseKanbanPositiveInt(raw string) int {
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || value < 0 {
+		return 0
+	}
+
+	return value
 }
 
 // ListMyTasks handles GET /operational/tasks/mine, self-scoped to the caller.

--- a/backend/internal/handler/operational/projects_export.go
+++ b/backend/internal/handler/operational/projects_export.go
@@ -8,9 +8,11 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	operationaldto "github.com/kana-consultant/kantor/backend/internal/dto/operational"
 	exportreport "github.com/kana-consultant/kantor/backend/internal/export"
 	"github.com/kana-consultant/kantor/backend/internal/exportutil"
 	platformmiddleware "github.com/kana-consultant/kantor/backend/internal/middleware"
+	operationalrepo "github.com/kana-consultant/kantor/backend/internal/repository/operational"
 	"github.com/kana-consultant/kantor/backend/internal/model"
 	"github.com/kana-consultant/kantor/backend/internal/response"
 )
@@ -86,7 +88,7 @@ func (h *ProjectsHandler) exportDetail(w http.ResponseWriter, r *http.Request) {
 		h.writeError(r.Context(), w, err)
 		return
 	}
-	tasks, err := h.kanban.ListTasks(r.Context(), projectID)
+	tasks, err := h.kanban.ListTasks(r.Context(), projectID, operationaldto.ListKanbanTasksQuery{Limit: operationalrepo.KanbanTaskLimitAll})
 	if err != nil {
 		h.writeError(r.Context(), w, err)
 		return

--- a/backend/internal/model/kanban.go
+++ b/backend/internal/model/kanban.go
@@ -23,20 +23,21 @@ type KanbanColumn struct {
 }
 
 type KanbanTask struct {
-	ID           string     `json:"id"`
-	ColumnID     string     `json:"column_id"`
-	ProjectID    string     `json:"project_id"`
-	Title        string     `json:"title"`
-	Description  *string    `json:"description,omitempty"`
-	AssigneeID   *string    `json:"assignee_id,omitempty"`
-	AssigneeName *string    `json:"assignee_name,omitempty"`
-	AvatarURL    *string    `json:"avatar_url,omitempty"`
-	DueDate      *time.Time `json:"due_date,omitempty"`
-	Priority     string     `json:"priority"`
-	Label        *string    `json:"label,omitempty"`
-	AssignedVia  string     `json:"assigned_via"`
-	Position     int        `json:"position"`
-	CreatedBy    string     `json:"created_by"`
-	CreatedAt    time.Time  `json:"created_at"`
-	UpdatedAt    time.Time  `json:"updated_at"`
+	ID           string            `json:"id"`
+	ColumnID     string            `json:"column_id"`
+	ProjectID    string            `json:"project_id"`
+	Title        string            `json:"title"`
+	Description  *string           `json:"description,omitempty"`
+	AssigneeID   *string           `json:"assignee_id,omitempty"`
+	AssigneeName *string           `json:"assignee_name,omitempty"`
+	AvatarURL    *string           `json:"avatar_url,omitempty"`
+	DueDate      *time.Time        `json:"due_date,omitempty"`
+	Priority     string            `json:"priority"`
+	Label        *string           `json:"label,omitempty"`
+	AssignedVia  string            `json:"assigned_via"`
+	Position     int               `json:"position"`
+	CreatedBy    string            `json:"created_by"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+	Fields       []KanbanTaskField `json:"fields"`
 }

--- a/backend/internal/model/kanban.go
+++ b/backend/internal/model/kanban.go
@@ -22,21 +22,53 @@ type KanbanColumn struct {
 	CreatedAt  time.Time `json:"created_at"`
 }
 
+type KanbanTaskListItem struct {
+	ID           string     `json:"id"`
+	ColumnID     string     `json:"column_id"`
+	Title        string     `json:"title"`
+	Description  *string    `json:"description,omitempty"`
+	AssigneeID   *string    `json:"assignee_id,omitempty"`
+	AssigneeName *string    `json:"assignee_name,omitempty"`
+	AvatarURL    *string    `json:"avatar_url,omitempty"`
+	DueDate      *time.Time `json:"due_date,omitempty"`
+	Priority     string     `json:"priority"`
+	Label        *string    `json:"label,omitempty"`
+	AssignedVia  string     `json:"assigned_via"`
+	Position     int        `json:"position"`
+}
+
+func (t KanbanTask) ToListItem() KanbanTaskListItem {
+	return KanbanTaskListItem{
+		ID:           t.ID,
+		ColumnID:     t.ColumnID,
+		Title:        t.Title,
+		Description:  t.Description,
+		AssigneeID:   t.AssigneeID,
+		AssigneeName: t.AssigneeName,
+		AvatarURL:    t.AvatarURL,
+		DueDate:      t.DueDate,
+		Priority:     t.Priority,
+		Label:        t.Label,
+		AssignedVia:  t.AssignedVia,
+		Position:     t.Position,
+	}
+}
+
 type KanbanTask struct {
-	ID           string            `json:"id"`
-	ColumnID     string            `json:"column_id"`
-	ProjectID    string            `json:"project_id"`
-	Title        string            `json:"title"`
-	Description  *string           `json:"description,omitempty"`
-	AssigneeID   *string           `json:"assignee_id,omitempty"`
-	AssigneeName *string           `json:"assignee_name,omitempty"`
-	AvatarURL    *string           `json:"avatar_url,omitempty"`
-	DueDate      *time.Time        `json:"due_date,omitempty"`
-	Priority     string            `json:"priority"`
-	Label        *string           `json:"label,omitempty"`
-	AssignedVia  string            `json:"assigned_via"`
-	Position     int               `json:"position"`
-	CreatedBy    string            `json:"created_by"`
+	ID           string     `json:"id"`
+	ColumnID     string     `json:"column_id"`
+	ProjectID    string     `json:"project_id"`
+	Title        string     `json:"title"`
+	Description  *string    `json:"description,omitempty"`
+	AssigneeID   *string    `json:"assignee_id,omitempty"`
+	AssigneeName *string    `json:"assignee_name,omitempty"`
+	AvatarURL    *string    `json:"avatar_url,omitempty"`
+	DueDate      *time.Time `json:"due_date,omitempty"`
+	Priority     string     `json:"priority"`
+	Label        *string    `json:"label,omitempty"`
+	AssignedVia  string     `json:"assigned_via"`
+	Position     int        `json:"position"`
+	CreatedBy    string     `json:"created_by"`
 	CreatedAt    time.Time         `json:"created_at"`
 	UpdatedAt    time.Time         `json:"updated_at"`
 	Fields       []KanbanTaskField `json:"fields"`

--- a/backend/internal/model/kanban_task_field.go
+++ b/backend/internal/model/kanban_task_field.go
@@ -1,0 +1,13 @@
+package model
+
+import "time"
+
+type KanbanTaskField struct {
+	ID        string    `json:"id"`
+	TaskID    string    `json:"task_id"`
+	Name      string    `json:"name"`
+	Value     string    `json:"value"`
+	Position  int       `json:"position"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -25,9 +25,13 @@ const (
 )
 
 type ListKanbanTasksFilter struct {
-	ColumnID string
-	Limit    int
-	Offset   int
+	ColumnID   string
+	AssigneeID string
+	Priority   string
+	Label      string
+	DueDate    string
+	Limit      int
+	Offset     int
 }
 
 type KanbanRepository struct {
@@ -390,9 +394,18 @@ func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID stri
 		LEFT JOIN users ON users.id = kanban_tasks.assignee_id
 		WHERE kanban_tasks.project_id = $1::uuid
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
+		  AND ($5 = '' OR kanban_tasks.assignee_id = $5::uuid)
+		  AND ($6 = '' OR kanban_tasks.priority = $6)
+		  AND ($7 = '' OR kanban_tasks.label ILIKE '%' || $7 || '%')
+		  AND ($8 = '' OR kanban_tasks.due_date::date = $8::date)
 		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC, kanban_tasks.id ASC
 		LIMIT NULLIF($3, 0) OFFSET $4
-	`, projectID, columnID, limit, offset)
+	`, projectID, columnID, limit, offset,
+		strings.TrimSpace(filter.AssigneeID),
+		strings.TrimSpace(filter.Priority),
+		strings.TrimSpace(filter.Label),
+		strings.TrimSpace(filter.DueDate),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -91,6 +91,24 @@ func NewKanbanRepository(db repository.DBTX) *KanbanRepository {
 	return &KanbanRepository{db: db}
 }
 
+// WithTx runs fn inside a transaction bound to the request's tenant-scoped
+// connection, so every repository call made with the passed context (task write
+// + custom-field replace) participates in the same transaction and commits or
+// rolls back together.
+func (r *KanbanRepository) WithTx(ctx context.Context, fn func(context.Context) error) error {
+	tx, err := repository.DB(ctx, r.db).Begin(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := fn(repository.WithConn(ctx, tx)); err != nil {
+		_ = tx.Rollback(ctx)
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
 func (r *KanbanRepository) CreateDefaultColumns(ctx context.Context, projectID string) error {
 	ctx, cancel := repository.QueryContext(ctx)
 	defer cancel()

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -359,7 +359,7 @@ func (r *KanbanRepository) ListTasks(ctx context.Context, projectID string) ([]m
 func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID string, filter ListKanbanTasksFilter) ([]model.KanbanTask, error) {
 	ctx, cancel := repository.QueryContext(ctx)
 	defer cancel()
-	search := strings.TrimSpace(filter.Search)
+	search := escapeLikePattern(strings.TrimSpace(filter.Search))
 	columnID := strings.TrimSpace(filter.ColumnID)
 	limit := filter.Limit
 	switch {
@@ -405,11 +405,11 @@ func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID stri
 			OR kanban_tasks.id IN (
 				SELECT id
 				FROM kanban_tasks
-				WHERE project_id = $1::uuid AND title ILIKE '%' || $9 || '%'
+				WHERE project_id = $1::uuid AND title ILIKE '%' || $9 || '%' ESCAPE '\'
 				UNION
 				SELECT id
 				FROM kanban_tasks
-				WHERE project_id = $1::uuid AND description ILIKE '%' || $9 || '%'
+				WHERE project_id = $1::uuid AND description ILIKE '%' || $9 || '%' ESCAPE '\'
 			)
 		  )
 		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC, kanban_tasks.id ASC

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -390,7 +390,7 @@ func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID stri
 		LEFT JOIN users ON users.id = kanban_tasks.assignee_id
 		WHERE kanban_tasks.project_id = $1::uuid
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
-		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC
+		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC, kanban_tasks.id ASC
 		LIMIT NULLIF($3, 0) OFFSET $4
 	`, projectID, columnID, limit, offset)
 	if err != nil {

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -17,6 +17,19 @@ var (
 	ErrKanbanTaskNotFound   = errors.New("kanban task not found")
 )
 
+const (
+	defaultKanbanTaskLimit = 20
+	maxKanbanTaskLimit     = 100
+
+	KanbanTaskLimitAll = -1
+)
+
+type ListKanbanTasksFilter struct {
+	ColumnID string
+	Limit    int
+	Offset   int
+}
+
 type KanbanRepository struct {
 	db repository.DBTX
 }
@@ -335,8 +348,26 @@ func (r *KanbanRepository) ReorderColumns(ctx context.Context, projectID string,
 }
 
 func (r *KanbanRepository) ListTasks(ctx context.Context, projectID string) ([]model.KanbanTask, error) {
+	return r.ListTasksFiltered(ctx, projectID, ListKanbanTasksFilter{Limit: KanbanTaskLimitAll})
+}
+
+func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID string, filter ListKanbanTasksFilter) ([]model.KanbanTask, error) {
 	ctx, cancel := repository.QueryContext(ctx)
 	defer cancel()
+	columnID := strings.TrimSpace(filter.ColumnID)
+	limit := filter.Limit
+	switch {
+	case limit == KanbanTaskLimitAll:
+		limit = 0
+	case limit <= 0:
+		limit = defaultKanbanTaskLimit
+	case limit > maxKanbanTaskLimit:
+		limit = maxKanbanTaskLimit
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
+	}
 	rows, err := repository.DB(ctx, r.db).Query(ctx, `
 		SELECT
 			kanban_tasks.id::text,
@@ -358,8 +389,10 @@ func (r *KanbanRepository) ListTasks(ctx context.Context, projectID string) ([]m
 		FROM kanban_tasks
 		LEFT JOIN users ON users.id = kanban_tasks.assignee_id
 		WHERE kanban_tasks.project_id = $1::uuid
+		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
 		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC
-	`, projectID)
+		LIMIT NULLIF($3, 0) OFFSET $4
+	`, projectID, columnID, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -25,6 +25,7 @@ const (
 )
 
 type ListKanbanTasksFilter struct {
+	Search     string
 	ColumnID   string
 	AssigneeID string
 	Priority   string
@@ -358,6 +359,7 @@ func (r *KanbanRepository) ListTasks(ctx context.Context, projectID string) ([]m
 func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID string, filter ListKanbanTasksFilter) ([]model.KanbanTask, error) {
 	ctx, cancel := repository.QueryContext(ctx)
 	defer cancel()
+	search := strings.TrimSpace(filter.Search)
 	columnID := strings.TrimSpace(filter.ColumnID)
 	limit := filter.Limit
 	switch {
@@ -398,6 +400,18 @@ func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID stri
 		  AND ($6 = '' OR kanban_tasks.priority = $6)
 		  AND ($7 = '' OR kanban_tasks.label ILIKE '%' || $7 || '%' ESCAPE '\')
 		  AND ($8 = '' OR kanban_tasks.due_date::date = $8::date)
+		  AND (
+			$9 = ''
+			OR kanban_tasks.id IN (
+				SELECT id
+				FROM kanban_tasks
+				WHERE project_id = $1::uuid AND title ILIKE '%' || $9 || '%'
+				UNION
+				SELECT id
+				FROM kanban_tasks
+				WHERE project_id = $1::uuid AND description ILIKE '%' || $9 || '%'
+			)
+		  )
 		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC, kanban_tasks.id ASC
 		LIMIT NULLIF($3, 0) OFFSET $4
 	`, projectID, columnID, limit, offset,
@@ -405,6 +419,7 @@ func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID stri
 		strings.TrimSpace(filter.Priority),
 		escapeLikePattern(strings.TrimSpace(filter.Label)),
 		strings.TrimSpace(filter.DueDate),
+		search,
 	)
 	if err != nil {
 		return nil, err

--- a/backend/internal/repository/operational/kanban.go
+++ b/backend/internal/repository/operational/kanban.go
@@ -396,14 +396,14 @@ func (r *KanbanRepository) ListTasksFiltered(ctx context.Context, projectID stri
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
 		  AND ($5 = '' OR kanban_tasks.assignee_id = $5::uuid)
 		  AND ($6 = '' OR kanban_tasks.priority = $6)
-		  AND ($7 = '' OR kanban_tasks.label ILIKE '%' || $7 || '%')
+		  AND ($7 = '' OR kanban_tasks.label ILIKE '%' || $7 || '%' ESCAPE '\')
 		  AND ($8 = '' OR kanban_tasks.due_date::date = $8::date)
 		ORDER BY kanban_tasks.column_id, kanban_tasks.position ASC, kanban_tasks.created_at ASC, kanban_tasks.id ASC
 		LIMIT NULLIF($3, 0) OFFSET $4
 	`, projectID, columnID, limit, offset,
 		strings.TrimSpace(filter.AssigneeID),
 		strings.TrimSpace(filter.Priority),
-		strings.TrimSpace(filter.Label),
+		escapeLikePattern(strings.TrimSpace(filter.Label)),
 		strings.TrimSpace(filter.DueDate),
 	)
 	if err != nil {

--- a/backend/internal/repository/operational/kanban_count.go
+++ b/backend/internal/repository/operational/kanban_count.go
@@ -26,11 +26,11 @@ func (r *KanbanRepository) CountTasks(ctx context.Context, projectID string, fil
 			OR kanban_tasks.id IN (
 				SELECT id
 				FROM kanban_tasks
-				WHERE project_id = $1::uuid AND title ILIKE '%' || $7 || '%'
+				WHERE project_id = $1::uuid AND title ILIKE '%' || $7 || '%' ESCAPE '\'
 				UNION
 				SELECT id
 				FROM kanban_tasks
-				WHERE project_id = $1::uuid AND description ILIKE '%' || $7 || '%'
+				WHERE project_id = $1::uuid AND description ILIKE '%' || $7 || '%' ESCAPE '\'
 			)
 		  )
 	`, projectID,
@@ -39,7 +39,7 @@ func (r *KanbanRepository) CountTasks(ctx context.Context, projectID string, fil
 		strings.TrimSpace(filter.Priority),
 		escapeLikePattern(strings.TrimSpace(filter.Label)),
 		strings.TrimSpace(filter.DueDate),
-		strings.TrimSpace(filter.Search),
+		escapeLikePattern(strings.TrimSpace(filter.Search)),
 	).Scan(&total)
 
 	return total, err

--- a/backend/internal/repository/operational/kanban_count.go
+++ b/backend/internal/repository/operational/kanban_count.go
@@ -21,12 +21,25 @@ func (r *KanbanRepository) CountTasks(ctx context.Context, projectID string, fil
 		  AND ($4 = '' OR kanban_tasks.priority = $4)
 		  AND ($5 = '' OR kanban_tasks.label ILIKE '%' || $5 || '%' ESCAPE '\')
 		  AND ($6 = '' OR kanban_tasks.due_date::date = $6::date)
+		  AND (
+			$7 = ''
+			OR kanban_tasks.id IN (
+				SELECT id
+				FROM kanban_tasks
+				WHERE project_id = $1::uuid AND title ILIKE '%' || $7 || '%'
+				UNION
+				SELECT id
+				FROM kanban_tasks
+				WHERE project_id = $1::uuid AND description ILIKE '%' || $7 || '%'
+			)
+		  )
 	`, projectID,
 		strings.TrimSpace(filter.ColumnID),
 		strings.TrimSpace(filter.AssigneeID),
 		strings.TrimSpace(filter.Priority),
 		escapeLikePattern(strings.TrimSpace(filter.Label)),
 		strings.TrimSpace(filter.DueDate),
+		strings.TrimSpace(filter.Search),
 	).Scan(&total)
 
 	return total, err

--- a/backend/internal/repository/operational/kanban_count.go
+++ b/backend/internal/repository/operational/kanban_count.go
@@ -1,0 +1,23 @@
+package operational
+
+import (
+	"context"
+	"strings"
+
+	repository "github.com/kana-consultant/kantor/backend/internal/repository"
+)
+
+func (r *KanbanRepository) CountTasks(ctx context.Context, projectID string, filter ListKanbanTasksFilter) (int, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	var total int
+	err := repository.DB(ctx, r.db).QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM kanban_tasks
+		WHERE kanban_tasks.project_id = $1::uuid
+		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
+	`, projectID, strings.TrimSpace(filter.ColumnID)).Scan(&total)
+
+	return total, err
+}

--- a/backend/internal/repository/operational/kanban_count.go
+++ b/backend/internal/repository/operational/kanban_count.go
@@ -19,15 +19,21 @@ func (r *KanbanRepository) CountTasks(ctx context.Context, projectID string, fil
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
 		  AND ($3 = '' OR kanban_tasks.assignee_id = $3::uuid)
 		  AND ($4 = '' OR kanban_tasks.priority = $4)
-		  AND ($5 = '' OR kanban_tasks.label ILIKE '%' || $5 || '%')
+		  AND ($5 = '' OR kanban_tasks.label ILIKE '%' || $5 || '%' ESCAPE '\')
 		  AND ($6 = '' OR kanban_tasks.due_date::date = $6::date)
 	`, projectID,
 		strings.TrimSpace(filter.ColumnID),
 		strings.TrimSpace(filter.AssigneeID),
 		strings.TrimSpace(filter.Priority),
-		strings.TrimSpace(filter.Label),
+		escapeLikePattern(strings.TrimSpace(filter.Label)),
 		strings.TrimSpace(filter.DueDate),
 	).Scan(&total)
 
 	return total, err
+}
+
+// escapeLikePattern escapes LIKE/ILIKE wildcards so a user-supplied filter term
+// matches those characters literally. Pair it with `ESCAPE '\'` in the query.
+func escapeLikePattern(value string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(value)
 }

--- a/backend/internal/repository/operational/kanban_count.go
+++ b/backend/internal/repository/operational/kanban_count.go
@@ -17,7 +17,17 @@ func (r *KanbanRepository) CountTasks(ctx context.Context, projectID string, fil
 		FROM kanban_tasks
 		WHERE kanban_tasks.project_id = $1::uuid
 		  AND ($2 = '' OR kanban_tasks.column_id = $2::uuid)
-	`, projectID, strings.TrimSpace(filter.ColumnID)).Scan(&total)
+		  AND ($3 = '' OR kanban_tasks.assignee_id = $3::uuid)
+		  AND ($4 = '' OR kanban_tasks.priority = $4)
+		  AND ($5 = '' OR kanban_tasks.label ILIKE '%' || $5 || '%')
+		  AND ($6 = '' OR kanban_tasks.due_date::date = $6::date)
+	`, projectID,
+		strings.TrimSpace(filter.ColumnID),
+		strings.TrimSpace(filter.AssigneeID),
+		strings.TrimSpace(filter.Priority),
+		strings.TrimSpace(filter.Label),
+		strings.TrimSpace(filter.DueDate),
+	).Scan(&total)
 
 	return total, err
 }

--- a/backend/internal/repository/operational/kanban_task_field.go
+++ b/backend/internal/repository/operational/kanban_task_field.go
@@ -1,0 +1,153 @@
+package operational
+
+import (
+	"context"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/kana-consultant/kantor/backend/internal/model"
+	repository "github.com/kana-consultant/kantor/backend/internal/repository"
+)
+
+type KanbanTaskFieldParams struct {
+	Name  string
+	Value string
+}
+
+type KanbanTaskFieldRepository struct {
+	db repository.DBTX
+}
+
+func NewKanbanTaskFieldRepository(db repository.DBTX) *KanbanTaskFieldRepository {
+	return &KanbanTaskFieldRepository{db: db}
+}
+
+func (r *KanbanTaskFieldRepository) ListByTask(ctx context.Context, taskID string) ([]model.KanbanTaskField, error) {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	return scanTaskFields(ctx, repository.DB(ctx, r.db), `
+		SELECT id::text, task_id::text, name, value, position, created_at, updated_at
+		FROM kanban_task_fields
+		WHERE task_id = $1::uuid
+		ORDER BY position ASC, created_at ASC
+	`, taskID)
+}
+
+func (r *KanbanTaskFieldRepository) Replace(ctx context.Context, taskID string, params []KanbanTaskFieldParams) error {
+	ctx, cancel := repository.QueryContext(ctx)
+	defer cancel()
+
+	db := repository.DB(ctx, r.db)
+	if tx, ok := db.(pgx.Tx); ok {
+		return replaceTaskFields(ctx, tx, taskID, params)
+	}
+
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	if err = replaceTaskFields(ctx, tx, taskID, params); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+func replaceTaskFields(ctx context.Context, tx pgx.Tx, taskID string, params []KanbanTaskFieldParams) error {
+	sanitized := sanitizeTaskFieldParams(params)
+
+	if _, err := tx.Exec(
+		ctx,
+		`DELETE FROM kanban_task_fields WHERE task_id = $1::uuid AND NOT (name = ANY($2::text[]))`,
+		taskID,
+		taskFieldNames(sanitized),
+	); err != nil {
+		return err
+	}
+
+	for index, field := range sanitized {
+		if _, err := tx.Exec(
+			ctx,
+			`
+				INSERT INTO kanban_task_fields (task_id, name, value, position)
+				VALUES ($1::uuid, $2, $3, $4)
+				ON CONFLICT (task_id, name) DO UPDATE
+				SET value = EXCLUDED.value, position = EXCLUDED.position, updated_at = NOW()
+			`,
+			taskID,
+			field.Name,
+			field.Value,
+			index+1,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func sanitizeTaskFieldParams(params []KanbanTaskFieldParams) []KanbanTaskFieldParams {
+	sanitized := make([]KanbanTaskFieldParams, 0, len(params))
+	seen := make(map[string]struct{}, len(params))
+
+	for _, field := range params {
+		name := strings.TrimSpace(field.Name)
+		value := strings.TrimSpace(field.Value)
+		if name == "" || value == "" {
+			continue
+		}
+
+		key := strings.ToLower(name)
+		if _, duplicate := seen[key]; duplicate {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		sanitized = append(sanitized, KanbanTaskFieldParams{Name: name, Value: value})
+	}
+
+	return sanitized
+}
+
+func taskFieldNames(params []KanbanTaskFieldParams) []string {
+	names := make([]string, 0, len(params))
+	for _, field := range params {
+		names = append(names, field.Name)
+	}
+
+	return names
+}
+
+func scanTaskFields(ctx context.Context, db repository.DBTX, query string, args ...interface{}) ([]model.KanbanTaskField, error) {
+	rows, err := db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	fields := make([]model.KanbanTaskField, 0)
+	for rows.Next() {
+		var field model.KanbanTaskField
+		if err := rows.Scan(
+			&field.ID,
+			&field.TaskID,
+			&field.Name,
+			&field.Value,
+			&field.Position,
+			&field.CreatedAt,
+			&field.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		fields = append(fields, field)
+	}
+
+	return fields, rows.Err()
+}

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -124,6 +124,7 @@ func (s *KanbanService) ListTasks(ctx context.Context, projectID string) ([]mode
 
 func (s *KanbanService) ListTasksPage(ctx context.Context, projectID string, query operationaldto.ListKanbanTasksQuery) (operationaldto.KanbanTaskPage, error) {
 	filter := operationalrepo.ListKanbanTasksFilter{
+		Search:     strings.TrimSpace(query.Search),
 		ColumnID:   strings.TrimSpace(query.ColumnID),
 		AssigneeID: strings.TrimSpace(query.AssigneeID),
 		Priority:   strings.TrimSpace(query.Priority),

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -33,6 +33,8 @@ type kanbanRepository interface {
 	DeleteColumn(ctx context.Context, projectID string, columnID string) error
 	ReorderColumns(ctx context.Context, projectID string, columnIDs []string) error
 	ListTasks(ctx context.Context, projectID string) ([]model.KanbanTask, error)
+	ListTasksFiltered(ctx context.Context, projectID string, filter operationalrepo.ListKanbanTasksFilter) ([]model.KanbanTask, error)
+	CountTasks(ctx context.Context, projectID string, filter operationalrepo.ListKanbanTasksFilter) (int, error)
 	CreateTask(ctx context.Context, projectID string, params operationalrepo.CreateKanbanTaskParams) (model.KanbanTask, error)
 	UpdateTask(ctx context.Context, projectID string, taskID string, params operationalrepo.UpdateKanbanTaskParams) (model.KanbanTask, error)
 	DeleteTask(ctx context.Context, projectID string, taskID string) error
@@ -118,6 +120,32 @@ func (s *KanbanService) ReorderColumns(ctx context.Context, projectID string, re
 
 func (s *KanbanService) ListTasks(ctx context.Context, projectID string) ([]model.KanbanTask, error) {
 	return s.repo.ListTasks(ctx, projectID)
+}
+
+func (s *KanbanService) ListTasksPage(ctx context.Context, projectID string, query operationaldto.ListKanbanTasksQuery) (operationaldto.KanbanTaskPage, error) {
+	filter := operationalrepo.ListKanbanTasksFilter{
+		ColumnID: strings.TrimSpace(query.ColumnID),
+		Limit:    query.Limit,
+		Offset:   query.Offset,
+	}
+
+	tasks, err := s.repo.ListTasksFiltered(ctx, projectID, filter)
+	if err != nil {
+		return operationaldto.KanbanTaskPage{}, err
+	}
+
+	total, err := s.repo.CountTasks(ctx, projectID, filter)
+	if err != nil {
+		return operationaldto.KanbanTaskPage{}, err
+	}
+
+	return operationaldto.KanbanTaskPage{
+		Items:   tasks,
+		Total:   total,
+		Limit:   query.Limit,
+		Offset:  query.Offset,
+		HasMore: query.Offset+len(tasks) < total,
+	}, nil
 }
 
 // ListMyTasks returns the caller's assigned tasks across all projects,

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -54,7 +54,12 @@ type kanbanProjectsRepository interface {
 type KanbanService struct {
 	repo         kanbanRepository
 	projectsRepo kanbanProjectsRepository
+	fieldsRepo   kanbanTaskFieldRepository
 	notifiers    []TaskAssignNotifier
+}
+
+func (s *KanbanService) SetTaskFieldRepository(repo kanbanTaskFieldRepository) {
+	s.fieldsRepo = repo
 }
 
 func NewKanbanService(repo kanbanRepository, projectsRepo kanbanProjectsRepository) *KanbanService {
@@ -226,6 +231,11 @@ func (s *KanbanService) CreateTask(ctx context.Context, projectID string, reques
 		return task, err
 	}
 
+	if err := s.replaceTaskFields(ctx, task.ID, request.Fields); err != nil {
+		return model.KanbanTask{}, err
+	}
+	s.attachTaskFields(ctx, &task)
+
 	// Notify assignee (skip self-assign)
 	if task.AssigneeID != nil && *task.AssigneeID != createdBy {
 		slog.InfoContext(ctx,
@@ -278,6 +288,11 @@ func (s *KanbanService) UpdateTask(ctx context.Context, projectID string, taskID
 		return task, err
 	}
 
+	if err := s.replaceTaskFields(ctx, task.ID, request.Fields); err != nil {
+		return model.KanbanTask{}, err
+	}
+	s.attachTaskFields(ctx, &task)
+
 	// Notify new assignee if changed and not self-assign
 	if task.AssigneeID != nil {
 		newAssigneeID := *task.AssigneeID
@@ -305,6 +320,20 @@ func (s *KanbanService) DeleteTask(ctx context.Context, projectID string, taskID
 	}
 
 	return err
+}
+
+func (s *KanbanService) GetTaskDetail(ctx context.Context, projectID string, taskID string) (model.KanbanTask, error) {
+	task, err := s.repo.GetTask(ctx, projectID, taskID)
+	if errors.Is(err, operationalrepo.ErrKanbanTaskNotFound) {
+		return model.KanbanTask{}, ErrKanbanTaskNotFound
+	}
+	if err != nil {
+		return model.KanbanTask{}, err
+	}
+
+	s.attachTaskFields(ctx, &task)
+
+	return task, nil
 }
 
 func (s *KanbanService) MoveTask(ctx context.Context, projectID string, taskID string, request operationaldto.MoveKanbanTaskRequest) error {

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -124,9 +124,13 @@ func (s *KanbanService) ListTasks(ctx context.Context, projectID string) ([]mode
 
 func (s *KanbanService) ListTasksPage(ctx context.Context, projectID string, query operationaldto.ListKanbanTasksQuery) (operationaldto.KanbanTaskPage, error) {
 	filter := operationalrepo.ListKanbanTasksFilter{
-		ColumnID: strings.TrimSpace(query.ColumnID),
-		Limit:    query.Limit,
-		Offset:   query.Offset,
+		ColumnID:   strings.TrimSpace(query.ColumnID),
+		AssigneeID: strings.TrimSpace(query.AssigneeID),
+		Priority:   strings.TrimSpace(query.Priority),
+		Label:      strings.TrimSpace(query.Label),
+		DueDate:    strings.TrimSpace(query.DueDate),
+		Limit:      query.Limit,
+		Offset:     query.Offset,
 	}
 
 	tasks, err := s.repo.ListTasksFiltered(ctx, projectID, filter)

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -124,8 +124,31 @@ func (s *KanbanService) ReorderColumns(ctx context.Context, projectID string, re
 	return err
 }
 
-func (s *KanbanService) ListTasks(ctx context.Context, projectID string) ([]model.KanbanTask, error) {
-	return s.repo.ListTasks(ctx, projectID)
+func (s *KanbanService) ListTasks(ctx context.Context, projectID string, query operationaldto.ListKanbanTasksQuery) ([]model.KanbanTask, error) {
+	return s.repo.ListTasksFiltered(ctx, projectID, operationalrepo.ListKanbanTasksFilter{
+		Search:     strings.TrimSpace(query.Search),
+		ColumnID:   strings.TrimSpace(query.ColumnID),
+		AssigneeID: strings.TrimSpace(query.AssigneeID),
+		Priority:   strings.TrimSpace(query.Priority),
+		Label:      strings.TrimSpace(query.Label),
+		DueDate:    strings.TrimSpace(query.DueDate),
+		Limit:      query.Limit,
+		Offset:     query.Offset,
+	})
+}
+
+func (s *KanbanService) GetTask(ctx context.Context, projectID string, taskID string) (model.KanbanTask, error) {
+	task, err := s.repo.GetTask(ctx, projectID, taskID)
+	if errors.Is(err, operationalrepo.ErrKanbanTaskNotFound) {
+		return model.KanbanTask{}, ErrKanbanTaskNotFound
+	}
+	if err != nil {
+		return model.KanbanTask{}, err
+	}
+
+	s.attachTaskFields(ctx, &task)
+
+	return task, nil
 }
 
 func (s *KanbanService) ListTasksPage(ctx context.Context, projectID string, query operationaldto.ListKanbanTasksQuery) (operationaldto.KanbanTaskPage, error) {
@@ -150,12 +173,17 @@ func (s *KanbanService) ListTasksPage(ctx context.Context, projectID string, que
 		return operationaldto.KanbanTaskPage{}, err
 	}
 
+	items := make([]model.KanbanTaskListItem, 0, len(tasks))
+	for _, task := range tasks {
+		items = append(items, task.ToListItem())
+	}
+
 	return operationaldto.KanbanTaskPage{
-		Items:   tasks,
+		Items:   items,
 		Total:   total,
 		Limit:   query.Limit,
 		Offset:  query.Offset,
-		HasMore: query.Offset+len(tasks) < total,
+		HasMore: query.Offset+len(items) < total,
 	}, nil
 }
 
@@ -335,20 +363,6 @@ func (s *KanbanService) DeleteTask(ctx context.Context, projectID string, taskID
 	}
 
 	return err
-}
-
-func (s *KanbanService) GetTaskDetail(ctx context.Context, projectID string, taskID string) (model.KanbanTask, error) {
-	task, err := s.repo.GetTask(ctx, projectID, taskID)
-	if errors.Is(err, operationalrepo.ErrKanbanTaskNotFound) {
-		return model.KanbanTask{}, ErrKanbanTaskNotFound
-	}
-	if err != nil {
-		return model.KanbanTask{}, err
-	}
-
-	s.attachTaskFields(ctx, &task)
-
-	return task, nil
 }
 
 func (s *KanbanService) MoveTask(ctx context.Context, projectID string, taskID string, request operationaldto.MoveKanbanTaskRequest) error {

--- a/backend/internal/service/operational/kanban.go
+++ b/backend/internal/service/operational/kanban.go
@@ -42,6 +42,7 @@ type kanbanRepository interface {
 	Snapshot(ctx context.Context, projectID string) (operationalrepo.KanbanSnapshot, error)
 	GetTask(ctx context.Context, projectID string, taskID string) (model.KanbanTask, error)
 	ListTasksAssignedTo(ctx context.Context, userID string) ([]operationalrepo.AssignedTaskRow, error)
+	WithTx(ctx context.Context, fn func(context.Context) error) error
 }
 
 type kanbanProjectsRepository interface {
@@ -212,26 +213,33 @@ func (s *KanbanService) CreateTask(ctx context.Context, projectID string, reques
 		return model.KanbanTask{}, err
 	}
 
-	task, err := s.repo.CreateTask(ctx, projectID, operationalrepo.CreateKanbanTaskParams{
-		ColumnID:    request.ColumnID,
-		Title:       strings.TrimSpace(request.Title),
-		Description: normalizeStringPointer(request.Description),
-		AssigneeID:  assigneeID,
-		DueDate:     normalizeTimePointer(request.DueDate),
-		Priority:    request.Priority,
-		Label:       normalizeStringPointer(request.Label),
-		AssignedVia: createAssignedVia(request.AssigneeID, assigneeID),
-		CreatedBy:   createdBy,
+	var task model.KanbanTask
+	err := s.repo.WithTx(ctx, func(txCtx context.Context) error {
+		created, err := s.repo.CreateTask(txCtx, projectID, operationalrepo.CreateKanbanTaskParams{
+			ColumnID:    request.ColumnID,
+			Title:       strings.TrimSpace(request.Title),
+			Description: normalizeStringPointer(request.Description),
+			AssigneeID:  assigneeID,
+			DueDate:     normalizeTimePointer(request.DueDate),
+			Priority:    request.Priority,
+			Label:       normalizeStringPointer(request.Label),
+			AssignedVia: createAssignedVia(request.AssigneeID, assigneeID),
+			CreatedBy:   createdBy,
+		})
+		if err != nil {
+			return err
+		}
+		if err := s.replaceTaskFields(txCtx, created.ID, request.Fields); err != nil {
+			return err
+		}
+		task = created
+		return nil
 	})
 	switch {
 	case errors.Is(err, operationalrepo.ErrKanbanColumnNotFound):
 		return model.KanbanTask{}, ErrKanbanColumnNotFound
 	}
 	if err != nil {
-		return task, err
-	}
-
-	if err := s.replaceTaskFields(ctx, task.ID, request.Fields); err != nil {
 		return model.KanbanTask{}, err
 	}
 	s.attachTaskFields(ctx, &task)
@@ -271,24 +279,31 @@ func (s *KanbanService) UpdateTask(ctx context.Context, projectID string, taskID
 		return model.KanbanTask{}, err
 	}
 
-	task, err := s.repo.UpdateTask(ctx, projectID, taskID, operationalrepo.UpdateKanbanTaskParams{
-		Title:       strings.TrimSpace(request.Title),
-		Description: normalizeStringPointer(request.Description),
-		AssigneeID:  assigneeID,
-		DueDate:     normalizeTimePointer(request.DueDate),
-		Priority:    request.Priority,
-		Label:       normalizeStringPointer(request.Label),
-		AssignedVia: updateAssignedVia(request.AssigneeID, assigneeID, oldAssigneeID),
+	var task model.KanbanTask
+	err := s.repo.WithTx(ctx, func(txCtx context.Context) error {
+		updated, err := s.repo.UpdateTask(txCtx, projectID, taskID, operationalrepo.UpdateKanbanTaskParams{
+			Title:       strings.TrimSpace(request.Title),
+			Description: normalizeStringPointer(request.Description),
+			AssigneeID:  assigneeID,
+			DueDate:     normalizeTimePointer(request.DueDate),
+			Priority:    request.Priority,
+			Label:       normalizeStringPointer(request.Label),
+			AssignedVia: updateAssignedVia(request.AssigneeID, assigneeID, oldAssigneeID),
+		})
+		if err != nil {
+			return err
+		}
+		if err := s.replaceTaskFields(txCtx, updated.ID, request.Fields); err != nil {
+			return err
+		}
+		task = updated
+		return nil
 	})
 	switch {
 	case errors.Is(err, operationalrepo.ErrKanbanTaskNotFound):
 		return model.KanbanTask{}, ErrKanbanTaskNotFound
 	}
 	if err != nil {
-		return task, err
-	}
-
-	if err := s.replaceTaskFields(ctx, task.ID, request.Fields); err != nil {
 		return model.KanbanTask{}, err
 	}
 	s.attachTaskFields(ctx, &task)

--- a/backend/internal/service/operational/kanban_task_field.go
+++ b/backend/internal/service/operational/kanban_task_field.go
@@ -1,0 +1,49 @@
+package operational
+
+import (
+	"context"
+	"strings"
+
+	operationaldto "github.com/kana-consultant/kantor/backend/internal/dto/operational"
+	"github.com/kana-consultant/kantor/backend/internal/model"
+	operationalrepo "github.com/kana-consultant/kantor/backend/internal/repository/operational"
+)
+
+type kanbanTaskFieldRepository interface {
+	ListByTask(ctx context.Context, taskID string) ([]model.KanbanTaskField, error)
+	Replace(ctx context.Context, taskID string, params []operationalrepo.KanbanTaskFieldParams) error
+}
+
+func toTaskFieldParams(inputs []operationaldto.KanbanTaskFieldInput) []operationalrepo.KanbanTaskFieldParams {
+	params := make([]operationalrepo.KanbanTaskFieldParams, 0, len(inputs))
+	for _, input := range inputs {
+		name := strings.TrimSpace(input.Name)
+		value := strings.TrimSpace(input.Value)
+		if name == "" || value == "" {
+			continue
+		}
+		params = append(params, operationalrepo.KanbanTaskFieldParams{Name: name, Value: value})
+	}
+
+	return params
+}
+
+func (s *KanbanService) attachTaskFields(ctx context.Context, task *model.KanbanTask) {
+	if s.fieldsRepo == nil || task == nil {
+		return
+	}
+
+	fields, err := s.fieldsRepo.ListByTask(ctx, task.ID)
+	if err != nil {
+		return
+	}
+	task.Fields = fields
+}
+
+func (s *KanbanService) replaceTaskFields(ctx context.Context, taskID string, inputs []operationaldto.KanbanTaskFieldInput) error {
+	if s.fieldsRepo == nil {
+		return nil
+	}
+
+	return s.fieldsRepo.Replace(ctx, taskID, toTaskFieldParams(inputs))
+}

--- a/backend/internal/service/operational/kanban_task_field.go
+++ b/backend/internal/service/operational/kanban_task_field.go
@@ -2,6 +2,7 @@ package operational
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 
 	operationaldto "github.com/kana-consultant/kantor/backend/internal/dto/operational"
@@ -35,6 +36,8 @@ func (s *KanbanService) attachTaskFields(ctx context.Context, task *model.Kanban
 
 	fields, err := s.fieldsRepo.ListByTask(ctx, task.ID)
 	if err != nil {
+		slog.ErrorContext(ctx, "failed to load kanban task custom fields",
+			"task_id", task.ID, "error", err)
 		return
 	}
 	task.Fields = fields

--- a/backend/internal/service/operational/kanban_test.go
+++ b/backend/internal/service/operational/kanban_test.go
@@ -149,6 +149,10 @@ func (f *fakeKanbanRepository) CreateDefaultColumns(ctx context.Context, project
 	return nil
 }
 
+func (f *fakeKanbanRepository) WithTx(ctx context.Context, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
 func (f *fakeKanbanRepository) ListColumns(ctx context.Context, projectID string) ([]model.KanbanColumn, error) {
 	return nil, nil
 }

--- a/backend/internal/service/operational/kanban_test.go
+++ b/backend/internal/service/operational/kanban_test.go
@@ -173,6 +173,14 @@ func (f *fakeKanbanRepository) ListTasks(ctx context.Context, projectID string) 
 	return nil, nil
 }
 
+func (f *fakeKanbanRepository) ListTasksFiltered(ctx context.Context, projectID string, filter operationalrepo.ListKanbanTasksFilter) ([]model.KanbanTask, error) {
+	return nil, nil
+}
+
+func (f *fakeKanbanRepository) CountTasks(ctx context.Context, projectID string, filter operationalrepo.ListKanbanTasksFilter) (int, error) {
+	return 0, nil
+}
+
 func (f *fakeKanbanRepository) CreateTask(ctx context.Context, projectID string, params operationalrepo.CreateKanbanTaskParams) (model.KanbanTask, error) {
 	if f.createTaskFunc == nil {
 		return model.KanbanTask{}, nil

--- a/backend/migrations/20260702010000_kanban_task_search.down.sql
+++ b/backend/migrations/20260702010000_kanban_task_search.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_kanban_tasks_description_trgm;
+DROP INDEX IF EXISTS idx_kanban_tasks_title_trgm;

--- a/backend/migrations/20260702010000_kanban_task_search.up.sql
+++ b/backend/migrations/20260702010000_kanban_task_search.up.sql
@@ -1,0 +1,7 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX idx_kanban_tasks_title_trgm
+    ON kanban_tasks USING GIN (title gin_trgm_ops);
+
+CREATE INDEX idx_kanban_tasks_description_trgm
+    ON kanban_tasks USING GIN (description gin_trgm_ops);

--- a/backend/migrations/20260702010000_kanban_task_search.up.sql
+++ b/backend/migrations/20260702010000_kanban_task_search.up.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
-CREATE INDEX idx_kanban_tasks_title_trgm
+CREATE INDEX IF NOT EXISTS idx_kanban_tasks_title_trgm
     ON kanban_tasks USING GIN (title gin_trgm_ops);
 
-CREATE INDEX idx_kanban_tasks_description_trgm
+CREATE INDEX IF NOT EXISTS idx_kanban_tasks_description_trgm
     ON kanban_tasks USING GIN (description gin_trgm_ops);

--- a/backend/migrations/20260702020000_kanban_task_fields.down.sql
+++ b/backend/migrations/20260702020000_kanban_task_fields.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS kanban_task_fields;

--- a/backend/migrations/20260702020000_kanban_task_fields.up.sql
+++ b/backend/migrations/20260702020000_kanban_task_fields.up.sql
@@ -1,0 +1,32 @@
+CREATE TABLE kanban_task_fields (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL DEFAULT current_setting('app.current_tenant')::uuid REFERENCES tenants(id) ON DELETE CASCADE,
+    task_id UUID NOT NULL REFERENCES kanban_tasks (id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    value TEXT NOT NULL,
+    position INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_kanban_task_fields_name CHECK (length(btrim(name)) BETWEEN 1 AND 120),
+    CONSTRAINT chk_kanban_task_fields_value CHECK (length(btrim(value)) > 0)
+);
+
+CREATE INDEX idx_kanban_task_fields_task_id ON kanban_task_fields (task_id, position);
+
+ALTER TABLE kanban_task_fields
+    ADD CONSTRAINT uq_kanban_task_fields_task_name UNIQUE (task_id, name);
+
+ALTER TABLE kanban_task_fields ENABLE ROW LEVEL SECURITY;
+ALTER TABLE kanban_task_fields FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY tenant_isolation ON kanban_task_fields
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+CREATE INDEX idx_kanban_task_fields_tenant_id ON kanban_task_fields (tenant_id);
+
+DO $$ BEGIN
+    IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'kantor_app') THEN
+        EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON kanban_task_fields TO kantor_app';
+    END IF;
+END $$;

--- a/frontend/src/components/shared/drawer.tsx
+++ b/frontend/src/components/shared/drawer.tsx
@@ -30,8 +30,8 @@ interface DrawerContextValue {
 const DrawerContext = createContext<DrawerContextValue | null>(null);
 
 const sizeClassNames: Record<DrawerSize, string> = {
-  md: "max-w-[480px]",
-  lg: "max-w-[640px]",
+  md: "w-full max-w-[480px] md:w-[480px]",
+  lg: "w-full max-w-[640px] md:w-[640px]",
 };
 
 export function Drawer({
@@ -86,8 +86,12 @@ export const DrawerContent = forwardRef<
   const context = useDrawerContext();
   const contentRef = useRef<HTMLDivElement | null>(null);
 
+  const { open, rendered, dismissible, onOpenChange } = context;
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
+
   useEffect(() => {
-    if (!context.rendered) {
+    if (!rendered || !open) {
       return undefined;
     }
 
@@ -98,22 +102,26 @@ export const DrawerContent = forwardRef<
 
     const focusable = getFocusableElements(node);
     const target = focusable[0] ?? node;
-    window.setTimeout(() => {
-      if (context.open) {
-        target.focus();
-      }
-    }, 0);
+    const timeout = window.setTimeout(() => target.focus(), 0);
+
+    return () => window.clearTimeout(timeout);
+  }, [open, rendered]);
+
+  useEffect(() => {
+    if (!open || !dismissible) {
+      return undefined;
+    }
 
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && context.dismissible) {
+      if (event.key === "Escape") {
         event.preventDefault();
-        context.onOpenChange(false);
+        onOpenChangeRef.current(false);
       }
     };
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [context]);
+  }, [dismissible, open]);
 
   if (!context.rendered || typeof document === "undefined") {
     return null;
@@ -138,13 +146,13 @@ export const DrawerContent = forwardRef<
         }}
         type="button"
       />
-      <div className="absolute inset-y-0 right-0 flex justify-end">
+      <div className="pointer-events-none absolute inset-y-0 right-0 z-10 flex justify-end">
         <div
           aria-describedby={context.descriptionId}
           aria-labelledby={context.titleId}
           aria-modal="true"
           className={cn(
-            "flex h-full w-full flex-col overflow-hidden border-l border-border bg-surface shadow-xl outline-none",
+            "pointer-events-auto flex h-full flex-col overflow-hidden border-l border-border bg-surface shadow-xl outline-none",
             "motion-safe:data-[state=open]:animate-in motion-safe:data-[state=open]:slide-in-from-right motion-safe:data-[state=open]:duration-200",
             "motion-safe:data-[state=closed]:animate-out motion-safe:data-[state=closed]:slide-out-to-right motion-safe:data-[state=closed]:duration-150",
             sizeClassNames[size],

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
 	DndContext,
@@ -16,7 +16,14 @@ import { useQuery } from "@tanstack/react-query";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-
+import {
+	KanbanDialogs,
+	type ColumnModalState,
+} from "@/components/shared/kanban-dialogs";
+import { KanbanToolbar } from "@/components/shared/kanban-toolbar";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useKanbanDrag } from "@/hooks/use-kanban-drag";
+import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
 import {
 	ColumnOverlay,
 	TaskOverlay,
@@ -40,7 +47,7 @@ import {
 import type {
 	KanbanColumn,
 	KanbanFilters,
-	KanbanTask,
+	KanbanTaskListItem,
 	TaskFormValues,
 } from "@/types/kanban";
 import type { ProjectMember } from "@/types/project";
@@ -52,6 +59,7 @@ const taskSchema = z.object({
 	due_date: z.string(),
 	priority: z.enum(["low", "medium", "high", "critical"]),
 	label: z.string(),
+	fields: z.array(z.object({ name: z.string(), value: z.string() })),
 });
 
 const emptyTaskForm: TaskFormValues = {
@@ -61,6 +69,7 @@ const emptyTaskForm: TaskFormValues = {
 	due_date: "",
 	priority: "medium",
 	label: "",
+	fields: [],
 };
 
 const columnColorOptions = [
@@ -103,19 +112,19 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	const [columnToDelete, setColumnToDelete] = useState<KanbanColumn | null>(
 		null,
 	);
-	const [taskToDelete, setTaskToDelete] = useState<KanbanTask | null>(null);
+	const [taskToDelete, setTaskToDelete] = useState<KanbanTaskListItem | null>(null);
 
 	const columnsQuery = useQuery({
 		queryKey: kanbanKeys.columns(projectId),
 		queryFn: () => listKanbanColumns(projectId),
 	});
 
-	const [loadedTasks, setLoadedTasks] = useState<Record<string, KanbanTask[]>>(
+	const [loadedTasks, setLoadedTasks] = useState<Record<string, KanbanTaskListItem[]>>(
 		{},
 	);
 
 	const handleTasksLoaded = useCallback(
-		(columnId: string, columnTasks: KanbanTask[]) => {
+		(columnId: string, columnTasks: KanbanTaskListItem[]) => {
 			setLoadedTasks((current) =>
 				current[columnId] === columnTasks
 					? current
@@ -129,6 +138,7 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		resolver: zodResolver(taskSchema),
 		defaultValues: emptyTaskForm,
 	});
+
 	const {
 		createColumn: createColumnMutation,
 		updateColumn: updateColumnMutation,
@@ -169,6 +179,9 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		() => visibleColumnIds.flatMap((columnId) => loadedTasks[columnId] ?? []),
 		[loadedTasks, visibleColumnIds],
 	);
+	const { activeTask, activeColumn, handleDragStart, handleDragEnd } =
+		useKanbanDrag(projectId, columns, tasks);
+
 	const taskFilters = useMemo(
 		() => ({
 			search: searchTerm,
@@ -177,41 +190,35 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 			label: filters.label,
 			dueDate: filters.dueDate,
 		}),
-		[
-			filters.assignee,
-			filters.dueDate,
-			filters.label,
-			filters.priority,
-			searchTerm,
-		],
+		[filters.assignee, filters.dueDate, filters.label, filters.priority, searchTerm],
 	);
 
+	const tasksRef = useRef(tasks);
+	tasksRef.current = tasks;
+	const editingTaskId = taskModal?.mode === "edit" ? taskModal.taskId : null;
+
+
 	useEffect(() => {
-		if (!taskModal) {
+		if (!editingTaskId) {
 			form.reset(emptyTaskForm);
 			return;
 		}
 
-		if (taskModal.mode === "create") {
-			form.reset(emptyTaskForm);
-			return;
-		}
-
-		const task = tasks.find((item) => item.id === taskModal.taskId);
-		if (!task) {
-			form.reset(emptyTaskForm);
+		const summary = tasksRef.current.find((item) => item.id === editingTaskId);
+		if (!summary) {
 			return;
 		}
 
 		form.reset({
-			title: task.title,
-			description: task.description ?? "",
-			assignee_id: task.assignee_id ?? "",
-			due_date: task.due_date ? extractDateInputValue(task.due_date) : "",
-			priority: task.priority,
-			label: task.label ?? "",
-		});
-	}, [form, taskModal, tasks]);
+			title: summary.title,
+			description: summary.description ?? "",
+			assignee_id: summary.assignee_id ?? "",
+			due_date: summary.due_date ? extractDateInputValue(summary.due_date) : "",
+			priority: summary.priority,
+			label: summary.label ?? "",
+				});
+	}, [editingTaskId, form]);
+
 
 	async function handleQuickAdd(columnId: string) {
 		const title = quickDrafts[columnId]?.trim() ?? "";
@@ -279,8 +286,6 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		setColumnForm({ name: "", color: "#38BDF8" });
 	}
 
-	const { activeTask, activeColumn, handleDragStart, handleDragEnd } =
-		useKanbanDrag(projectId, columns, tasks);
 
 	if (columnsQuery.isLoading) {
 		return <Card className="p-8">Memuat board proyek...</Card>;
@@ -329,34 +334,34 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 										!filters.columnId || column.id === filters.columnId,
 								)
 								.map((column) => (
-								<KanbanColumnContainer
-									column={column}
-									filters={taskFilters}
-									key={column.id}
-									onDeleteColumn={() => setColumnToDelete(column)}
-									onEditColumn={() => startColumnEdit(column)}
-									onQuickAdd={() => void handleQuickAdd(column.id)}
-									onQuickDraftChange={(value) =>
-										setQuickDrafts((current) => ({
-											...current,
-											[column.id]: value,
-										}))
-									}
-									onTaskClick={(task) =>
-										setTaskModal({
-											mode: "edit",
-											columnId: task.column_id,
-											taskId: task.id,
-										})
-									}
-									onTaskCreate={() =>
-										setTaskModal({ mode: "create", columnId: column.id })
-									}
-									onTasksLoaded={handleTasksLoaded}
-									projectId={projectId}
-									quickDraft={quickDrafts[column.id] ?? ""}
-								/>
-							))}
+									<KanbanColumnContainer
+										column={column}
+										key={column.id}
+										onDeleteColumn={() => setColumnToDelete(column)}
+										onEditColumn={() => startColumnEdit(column)}
+										onQuickAdd={() => void handleQuickAdd(column.id)}
+										onQuickDraftChange={(value) =>
+											setQuickDrafts((current) => ({
+												...current,
+												[column.id]: value,
+											}))
+										}
+										onTaskClick={(task) =>
+											setTaskModal({
+												mode: "edit",
+												columnId: task.column_id,
+												taskId: task.id,
+											})
+										}
+										onTaskCreate={() =>
+											setTaskModal({ mode: "create", columnId: column.id })
+										}
+										filters={taskFilters}
+										onTasksLoaded={handleTasksLoaded}
+										projectId={projectId}
+										quickDraft={quickDrafts[column.id] ?? ""}
+									/>
+								))}
 						</div>
 					</div>
 				</SortableContext>
@@ -430,3 +435,4 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		</div>
 	);
 }
+

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -27,7 +27,6 @@ import {
 	type ColumnModalState,
 } from "@/components/shared/kanban-dialogs";
 import {
-	matchesFilters,
 } from "@/components/shared/kanban-dnd";
 import { useKanbanDrag } from "@/hooks/use-kanban-drag";
 import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
@@ -157,10 +156,14 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		() => Object.values(loadedTasks).flat(),
 		[loadedTasks],
 	);
-	const filterTasks = useCallback(
-		(columnTasks: KanbanTask[]) =>
-			columnTasks.filter((task) => matchesFilters(task, filters)),
-		[filters],
+	const taskFilters = useMemo(
+		() => ({
+			assigneeId: filters.assignee,
+			priority: filters.priority,
+			label: filters.label,
+			dueDate: filters.dueDate,
+		}),
+		[filters.assignee, filters.dueDate, filters.label, filters.priority],
 	);
 
 	useEffect(() => {
@@ -302,7 +305,7 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 							{columns.map((column) => (
 								<KanbanColumnContainer
 									column={column}
-									filterTasks={filterTasks}
+									filters={taskFilters}
 									key={column.id}
 									onDeleteColumn={() => setColumnToDelete(column)}
 									onEditColumn={() => startColumnEdit(column)}

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -26,8 +26,6 @@ import {
 	KanbanDialogs,
 	type ColumnModalState,
 } from "@/components/shared/kanban-dialogs";
-import {
-} from "@/components/shared/kanban-dnd";
 import { useKanbanDrag } from "@/hooks/use-kanban-drag";
 import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
 import { KanbanToolbar } from "@/components/shared/kanban-toolbar";

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -5,56 +5,41 @@ import {
 	DragOverlay,
 	PointerSensor,
 	closestCorners,
-	useDroppable,
 	useSensor,
 	useSensors,
-	type DragEndEvent,
-	type DragStartEvent,
 } from "@dnd-kit/core";
 import {
 	SortableContext,
-	arrayMove,
 	horizontalListSortingStrategy,
-	useSortable,
-	verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useForm, type UseFormReturn } from "react-hook-form";
+import { useQuery } from "@tanstack/react-query";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { GripVertical, Plus } from "lucide-react";
 
-import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+
 import {
-	Drawer,
-	DrawerBody,
-	DrawerClose,
-	DrawerContent,
-	DrawerDescription,
-	DrawerHeader,
-	DrawerTitle,
-} from "@/components/shared/drawer";
-import { FormModal } from "@/components/shared/form-modal";
-import { PermissionGate } from "@/components/shared/permission-gate";
-import { ProtectedAvatar } from "@/components/shared/protected-avatar";
-import { Button } from "@/components/ui/button";
+	ColumnOverlay,
+	KanbanColumnCard,
+	TaskOverlay,
+} from "@/components/shared/kanban-cards";
+import {
+	KanbanDialogs,
+	type ColumnModalState,
+} from "@/components/shared/kanban-dialogs";
+import {
+	matchesFilters,
+	sortTaskList,
+} from "@/components/shared/kanban-dnd";
+import { useKanbanDrag } from "@/hooks/use-kanban-drag";
+import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
+import { KanbanToolbar } from "@/components/shared/kanban-toolbar";
+import { TaskModal } from "@/components/shared/task-modal";
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { permissions } from "@/lib/permissions";
-import { extractDateInputValue, formatCalendarDate } from "@/lib/date";
-import { cn } from "@/lib/utils";
+import { extractDateInputValue } from "@/lib/date";
 import {
-	createKanbanColumn,
-	createKanbanTask,
-	deleteKanbanColumn,
-	deleteKanbanTask,
 	kanbanKeys,
 	listKanbanColumns,
 	listKanbanTasks,
-	moveKanbanTask,
-	reorderKanbanColumns,
-	updateKanbanColumn,
-	updateKanbanTask,
 } from "@/services/operational-kanban";
 import type {
 	KanbanColumn,
@@ -62,7 +47,7 @@ import type {
 	KanbanTask,
 	TaskFormValues,
 } from "@/types/kanban";
-import type { ProjectMember, ProjectPriority } from "@/types/project";
+import type { ProjectMember } from "@/types/project";
 
 const taskSchema = z.object({
 	title: z.string().trim().min(2, "Judul minimal 2 karakter").max(160),
@@ -96,22 +81,11 @@ interface KanbanBoardProps {
 	members: ProjectMember[];
 }
 
-interface DragSnapshot {
-	columns: KanbanColumn[];
-	tasks: KanbanTask[];
-}
-
-type ColumnModalState = { mode: "create" } | { mode: "edit"; columnId: string };
-
 type TaskModalState =
 	| { mode: "create"; columnId: string }
 	| { mode: "edit"; columnId: string; taskId: string };
 
-type DragTaskData = { type: "task"; task: KanbanTask };
-type DragColumnData = { type: "column"; column: KanbanColumn };
-
 export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
-	const queryClient = useQueryClient();
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
 	);
@@ -126,9 +100,6 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	const [columnForm, setColumnForm] = useState({ name: "", color: "#38BDF8" });
 	const [taskModal, setTaskModal] = useState<TaskModalState | null>(null);
 	const [boardError, setBoardError] = useState<string | null>(null);
-	const [activeTask, setActiveTask] = useState<KanbanTask | null>(null);
-	const [activeColumn, setActiveColumn] = useState<KanbanColumn | null>(null);
-	const [dragSnapshot, setDragSnapshot] = useState<DragSnapshot | null>(null);
 	const [columnToDelete, setColumnToDelete] = useState<KanbanColumn | null>(
 		null,
 	);
@@ -148,82 +119,34 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		resolver: zodResolver(taskSchema),
 		defaultValues: emptyTaskForm,
 	});
-
-	const createColumnMutation = useMutation({
-		mutationFn: (payload: { name: string; color?: string }) =>
-			createKanbanColumn(projectId, payload),
-		onSuccess: async () => {
+	const {
+		createColumn: createColumnMutation,
+		updateColumn: updateColumnMutation,
+		deleteColumn: deleteColumnMutation,
+		createTask: createTaskMutation,
+		updateTask: updateTaskMutation,
+		deleteTask: deleteTaskMutation,
+	} = useKanbanMutations(projectId, {
+		onError: setBoardError,
+		onColumnSaved: () => {
 			setColumnForm({ name: "", color: "#38BDF8" });
 			setColumnModal(null);
-			await invalidateBoard(queryClient, projectId);
 		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const updateColumnMutation = useMutation({
-		mutationFn: (payload: { columnId: string; name: string; color?: string }) =>
-			updateKanbanColumn(projectId, payload.columnId, {
-				name: payload.name,
-				color: payload.color,
-			}),
-		onSuccess: async () => {
-			setColumnModal(null);
-			await invalidateBoard(queryClient, projectId);
-		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const deleteColumnMutation = useMutation({
-		mutationFn: (columnId: string) => deleteKanbanColumn(projectId, columnId),
-		onSuccess: async () => {
-			setColumnToDelete(null);
-			await invalidateBoard(queryClient, projectId);
-		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const createTaskMutation = useMutation({
-		mutationFn: (payload: { column_id: string } & TaskFormValues) =>
-			createKanbanTask(projectId, payload),
-		onSuccess: async () => {
+		onColumnDeleted: () => setColumnToDelete(null),
+		onTaskSaved: () => {
 			form.reset(emptyTaskForm);
 			setTaskModal(null);
-			await invalidateBoard(queryClient, projectId);
 		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const updateTaskMutation = useMutation({
-		mutationFn: (payload: { taskId: string; values: TaskFormValues }) =>
-			updateKanbanTask(projectId, payload.taskId, payload.values),
-		onSuccess: async () => {
-			form.reset(emptyTaskForm);
-			setTaskModal(null);
-			await invalidateBoard(queryClient, projectId);
-		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
-	});
-
-	const deleteTaskMutation = useMutation({
-		mutationFn: (taskId: string) => deleteKanbanTask(projectId, taskId),
-		onSuccess: async () => {
+		onTaskDeleted: () => {
 			form.reset(emptyTaskForm);
 			setTaskModal(null);
 			setTaskToDelete(null);
-			await invalidateBoard(queryClient, projectId);
 		},
-		onError: (error) => setBoardError(extractErrorMessage(error)),
 	});
 
 	const columns = columnsQuery.data ?? [];
 	const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
 	const filteredTasks = tasks.filter((task) => matchesFilters(task, filters));
-	const activeFilterCount = [
-		filters.assignee,
-		filters.priority,
-		filters.label,
-		filters.dueDate,
-	].filter(Boolean).length;
 
 	useEffect(() => {
 		if (!taskModal) {
@@ -318,80 +241,8 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		setColumnForm({ name: "", color: "#38BDF8" });
 	}
 
-	function handleDragStart(event: DragStartEvent) {
-		const data = event.active.data.current;
-
-		if (isTaskDragData(data)) {
-			setActiveTask(data.task);
-			setDragSnapshot({ columns, tasks });
-			return;
-		}
-
-		if (isColumnDragData(data)) {
-			setActiveColumn(data.column);
-			setDragSnapshot({ columns, tasks });
-		}
-	}
-
-	function rollbackDrag() {
-		if (!dragSnapshot) {
-			return;
-		}
-
-		queryClient.setQueryData(
-			kanbanKeys.columns(projectId),
-			dragSnapshot.columns,
-		);
-		queryClient.setQueryData(kanbanKeys.tasks(projectId), dragSnapshot.tasks);
-	}
-
-	function resetDrag() {
-		setActiveTask(null);
-		setActiveColumn(null);
-		setDragSnapshot(null);
-	}
-
-	function handleDragEnd(event: DragEndEvent) {
-		if (!event.over) {
-			rollbackDrag();
-			resetDrag();
-			return;
-		}
-
-		const activeData = event.active.data.current;
-
-		if (isColumnDragData(activeData)) {
-			finishColumnDrag(
-				event,
-				columns,
-				tasks,
-				dragSnapshot,
-				queryClient,
-				projectId,
-			);
-			resetDrag();
-			return;
-		}
-
-		if (isTaskDragData(activeData)) {
-			const nextTasks = moveTaskInMemory(
-				dragSnapshot?.tasks ?? tasks,
-				activeData.task.id,
-				event.over.data.current,
-				event.over.id.toString(),
-			);
-
-			finishTaskDrag(
-				activeData.task.id,
-				nextTasks,
-				dragSnapshot,
-				queryClient,
-				projectId,
-			);
-		}
-
-		resetDrag();
-	}
+	const { activeTask, activeColumn, handleDragStart, handleDragEnd } =
+		useKanbanDrag(projectId, columns, tasks);
 
 	if (columnsQuery.isLoading || tasksQuery.isLoading) {
 		return <Card className="p-8">Memuat board proyek...</Card>;
@@ -412,111 +263,15 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 
 	return (
 		<div className="space-y-6">
-			<Card className="p-6">
-				<div className="flex flex-col gap-5">
-					<div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
-						<div>
-							<p className="mb-1 text-[11px] font-[700] uppercase tracking-[0.08em] text-ops">
-								Board proyek
-							</p>
-							<h4 className="text-[20px] font-[700] text-text-primary leading-tight">
-								Ruang kerja task proyek
-							</h4>
-							<p className="mt-1 max-w-3xl text-[13px] text-text-secondary">
-								Kelola task proyek dalam satu board, pindahkan kartu antar tahap
-								kerja, dan gunakan filter tanpa keluar dari halaman ini.
-							</p>
-						</div>
-
-						<PermissionGate permission={permissions.operationalColumnManage}>
-							<div className="flex w-full flex-col items-stretch gap-3 xl:w-auto xl:items-end">
-								<Button
-									variant="ops"
-									className="xl:self-end"
-									onClick={() => {
-										setBoardError(null);
-										startColumnCreate();
-									}}
-									type="button">
-									<Plus className="h-4 w-4" />
-									Kolom baru
-								</Button>
-							</div>
-						</PermissionGate>
-					</div>
-
-					<div className="grid gap-4 xl:grid-cols-[repeat(4,minmax(0,1fr))_auto]">
-						<select
-							className="flex h-[44px] w-full rounded-[6px] border border-transparent bg-surface-muted px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
-							onChange={(event) =>
-								setFilters((current) => ({
-									...current,
-									assignee: event.target.value,
-								}))
-							}
-							value={filters.assignee}>
-							<option value="">Semua PIC</option>
-							{members.map((member) => (
-								<option
-									key={member.user_id}
-									value={member.user_id}>
-									{member.full_name || member.user_email || member.user_id}
-								</option>
-							))}
-						</select>
-						<select
-							className="flex h-[44px] w-full rounded-[6px] border border-transparent bg-surface-muted px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
-							onChange={(event) =>
-								setFilters((current) => ({
-									...current,
-									priority: event.target.value,
-								}))
-							}
-							value={filters.priority}>
-							<option value="">Semua prioritas</option>
-							<option value="low">Rendah</option>
-							<option value="medium">Medium</option>
-							<option value="high">Tinggi</option>
-							<option value="critical">Kritis</option>
-						</select>
-						<Input
-							className="h-[44px] focus-visible:border-ops focus-visible:ring-ops/10"
-							onChange={(event) =>
-								setFilters((current) => ({
-									...current,
-									label: event.target.value,
-								}))
-							}
-							placeholder="Filter label"
-							value={filters.label}
-						/>
-						<Input
-							className="h-[44px] focus-visible:border-ops focus-visible:ring-ops/10"
-							onChange={(event) =>
-								setFilters((current) => ({
-									...current,
-									dueDate: event.target.value,
-								}))
-							}
-							type="date"
-							value={filters.dueDate}
-						/>
-						<Button
-							onClick={() =>
-								setFilters({
-									assignee: "",
-									priority: "",
-									label: "",
-									dueDate: "",
-								})
-							}
-							variant="secondary"
-							className="h-[44px]">
-							Reset {activeFilterCount > 0 ? `(${activeFilterCount})` : ""}
-						</Button>
-					</div>
-				</div>
-			</Card>
+			<KanbanToolbar
+				filters={filters}
+				members={members}
+				onColumnCreate={() => {
+					setBoardError(null);
+					startColumnCreate();
+				}}
+				onFiltersChange={setFilters}
+			/>
 
 			{boardError ? (
 				<Card className="p-4 text-[13px] font-[500] text-priority-high border-priority-high/20 bg-priority-high/5">
@@ -602,871 +357,36 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 				/>
 			) : null}
 
-			<FormModal
-				isLoading={
+			<KanbanDialogs
+				columnColorOptions={columnColorOptions}
+				columnForm={columnForm}
+				columnModal={columnModal}
+				columnToDelete={columnToDelete}
+				isColumnDeleting={deleteColumnMutation.isPending}
+				isColumnSaving={
 					createColumnMutation.isPending || updateColumnMutation.isPending
 				}
-				isOpen={Boolean(columnModal)}
-				onClose={() => {
-					setColumnModal(null);
-					setColumnForm({ name: "", color: "#38BDF8" });
-				}}
-				onSubmit={(event) => {
-					event.preventDefault();
-					handleColumnSubmit();
-				}}
-				size="sm"
-				submitLabel={
-					columnModal?.mode === "edit" ? "Simpan kolom" : "Buat kolom"
-				}
-				title={columnModal?.mode === "edit" ? "Edit kolom" : "Buat kolom"}
-				subtitle="Gunakan nama singkat dan warna aksen yang jelas agar kolom mudah dipindai di board.">
-				<div className="space-y-2">
-					<label className="text-[13px] font-[600] text-text-primary">
-						Nama kolom
-					</label>
-					<Input
-						className="focus-visible:border-ops focus-visible:ring-ops/10"
-						onChange={(event) =>
-							setColumnForm((current) => ({
-								...current,
-								name: event.target.value,
-							}))
-						}
-						placeholder="Review"
-						value={columnForm.name}
-					/>
-				</div>
-				<div className="space-y-2">
-					<p className="text-[13px] font-[600] text-text-primary">
-						Warna aksen
-					</p>
-					<div className="flex flex-wrap gap-2">
-						{columnColorOptions.map((color) => (
-							<button
-								aria-label={`Choose list color ${color}`}
-								className={cn(
-									"h-9 w-9 rounded-full border-2 transition hover:scale-105",
-									columnForm.color === color
-										? "border-foreground shadow-sm"
-										: "border-transparent",
-								)}
-								key={color}
-								onClick={() =>
-									setColumnForm((current) => ({ ...current, color }))
-								}
-								style={{ backgroundColor: color }}
-								type="button"
-							/>
-						))}
-					</div>
-				</div>
-			</FormModal>
-
-			<ConfirmDialog
-				confirmLabel="Hapus kolom"
-				description={
-					columnToDelete
-						? `Semua task di dalam "${columnToDelete.name}" akan ikut terhapus bersama kolom ini.`
-						: ""
-				}
-				isLoading={deleteColumnMutation.isPending}
-				isOpen={Boolean(columnToDelete)}
-				onClose={() => setColumnToDelete(null)}
-				onConfirm={() => {
+				isTaskDeleting={deleteTaskMutation.isPending}
+				onColumnDeleteClose={() => setColumnToDelete(null)}
+				onColumnDeleteConfirm={() => {
 					if (columnToDelete) {
 						deleteColumnMutation.mutate(columnToDelete.id);
 					}
 				}}
-				title={
-					columnToDelete ? `Hapus ${columnToDelete.name}?` : "Hapus kolom?"
-				}
-			/>
-
-			<ConfirmDialog
-				confirmLabel="Hapus task"
-				description={
-					taskToDelete
-						? `Task "${taskToDelete.title}" akan dihapus dari board ini.`
-						: ""
-				}
-				isLoading={deleteTaskMutation.isPending}
-				isOpen={Boolean(taskToDelete)}
-				onClose={() => setTaskToDelete(null)}
-				onConfirm={() => {
+				onColumnFormChange={setColumnForm}
+				onColumnModalClose={() => {
+					setColumnModal(null);
+					setColumnForm({ name: "", color: "#38BDF8" });
+				}}
+				onColumnSubmit={handleColumnSubmit}
+				onTaskDeleteClose={() => setTaskToDelete(null)}
+				onTaskDeleteConfirm={() => {
 					if (taskToDelete) {
 						deleteTaskMutation.mutate(taskToDelete.id);
 					}
 				}}
-				title={taskToDelete ? `Hapus ${taskToDelete.title}?` : "Hapus task?"}
+				taskToDelete={taskToDelete}
 			/>
 		</div>
 	);
-}
-
-function matchesFilters(task: KanbanTask, filters: KanbanFilters) {
-	if (filters.assignee && task.assignee_id !== filters.assignee) {
-		return false;
-	}
-	if (filters.priority && task.priority !== filters.priority) {
-		return false;
-	}
-	if (filters.label) {
-		const label = task.label?.toLowerCase() ?? "";
-		if (!label.includes(filters.label.toLowerCase())) {
-			return false;
-		}
-	}
-	if (
-		filters.dueDate &&
-		(!task.due_date || extractDateInputValue(task.due_date) !== filters.dueDate)
-	) {
-		return false;
-	}
-	return true;
-}
-
-function moveTaskInMemory(
-	tasks: KanbanTask[],
-	activeTaskId: string,
-	overData: unknown,
-	overId: string,
-) {
-	const activeTask = tasks.find((task) => task.id === activeTaskId);
-	if (!activeTask) {
-		return null;
-	}
-
-	const buckets = buildTaskBuckets(tasks);
-	const sourceList = [...(buckets[activeTask.column_id] ?? [])];
-	const sourceIndex = sourceList.findIndex((task) => task.id === activeTaskId);
-	if (sourceIndex < 0) {
-		return null;
-	}
-
-	const [movingTask] = sourceList.splice(sourceIndex, 1);
-	buckets[activeTask.column_id] = sourceList;
-
-	let destinationColumnId = activeTask.column_id;
-	let destinationIndex = sourceList.length;
-
-	if (isTaskDragData(overData)) {
-		destinationColumnId = overData.task.column_id;
-		const targetList =
-			destinationColumnId === activeTask.column_id
-				? sourceList
-				: [...(buckets[destinationColumnId] ?? [])];
-		const overIndex = targetList.findIndex(
-			(task) => task.id === overData.task.id,
-		);
-		destinationIndex = overIndex >= 0 ? overIndex : targetList.length;
-	} else if (isColumnDragData(overData)) {
-		destinationColumnId = overData.column.id;
-		const targetList =
-			destinationColumnId === activeTask.column_id
-				? sourceList
-				: [...(buckets[destinationColumnId] ?? [])];
-		destinationIndex = targetList.length;
-	} else {
-		const targetList = buckets[activeTask.column_id] ?? [];
-		const overIndex = targetList.findIndex((task) => task.id === overId);
-		destinationIndex = overIndex >= 0 ? overIndex : targetList.length;
-	}
-
-	const destinationList =
-		destinationColumnId === activeTask.column_id
-			? sourceList
-			: [...(buckets[destinationColumnId] ?? [])];
-	destinationList.splice(destinationIndex, 0, {
-		...movingTask!,
-		column_id: destinationColumnId,
-	});
-	buckets[destinationColumnId] = destinationList;
-
-	return flattenTaskBuckets(buckets);
-}
-
-function buildTaskBuckets(tasks: KanbanTask[]) {
-	const buckets: Record<string, KanbanTask[]> = {};
-	for (const task of [...tasks].sort(sortTaskList)) {
-		if (!buckets[task.column_id]) {
-			buckets[task.column_id] = [];
-		}
-		buckets[task.column_id]!.push(task);
-	}
-	return buckets;
-}
-
-function flattenTaskBuckets(buckets: Record<string, KanbanTask[]>) {
-	const nextTasks: KanbanTask[] = [];
-	for (const columnId of Object.keys(buckets)) {
-		buckets[columnId]!.forEach((task, index) => {
-			nextTasks.push({ ...task, column_id: columnId, position: index + 1 });
-		});
-	}
-	return nextTasks.sort(sortTaskList);
-}
-
-// function taskPlacementChanged(currentTasks: KanbanTask[], nextTasks: KanbanTask[], taskId: string) {
-//   const currentTask = currentTasks.find((task) => task.id === taskId);
-//   const nextTask = nextTasks.find((task) => task.id === taskId);
-
-//   if (!currentTask || !nextTask) {
-//     return false;
-//   }
-
-//   return currentTask.column_id !== nextTask.column_id || currentTask.position !== nextTask.position;
-// }
-
-function sortTaskList(left: KanbanTask, right: KanbanTask) {
-	if (left.column_id === right.column_id) {
-		return left.position - right.position;
-	}
-	return left.column_id.localeCompare(right.column_id);
-}
-
-async function invalidateBoard(
-	queryClient: ReturnType<typeof useQueryClient>,
-	projectId: string,
-) {
-	await queryClient.invalidateQueries({ queryKey: kanbanKeys.all(projectId) });
-}
-
-function finishTaskDrag(
-	taskId: string,
-	nextTasks: KanbanTask[] | null,
-	snapshot: DragSnapshot | null,
-	queryClient: ReturnType<typeof useQueryClient>,
-	projectId: string,
-) {
-	if (!snapshot || !nextTasks) {
-		return;
-	}
-
-	const previousTask = snapshot.tasks.find((task) => task.id === taskId);
-	const nextTask = nextTasks.find((task) => task.id === taskId);
-
-	if (!previousTask || !nextTask) {
-		queryClient.setQueryData(kanbanKeys.tasks(projectId), snapshot.tasks);
-		return;
-	}
-
-	if (
-		previousTask.column_id === nextTask.column_id &&
-		previousTask.position === nextTask.position
-	) {
-		return;
-	}
-
-	queryClient.setQueryData(kanbanKeys.tasks(projectId), nextTasks);
-	void moveKanbanTask(
-		projectId,
-		nextTask.id,
-		nextTask.column_id,
-		nextTask.position,
-	)
-		.then(async () => {
-			await invalidateBoard(queryClient, projectId);
-		})
-		.catch(async () => {
-			queryClient.setQueryData(kanbanKeys.tasks(projectId), snapshot.tasks);
-			await invalidateBoard(queryClient, projectId);
-		});
-}
-
-function finishColumnDrag(
-	event: DragEndEvent,
-	columns: KanbanColumn[],
-	tasks: KanbanTask[],
-	snapshot: DragSnapshot | null,
-	queryClient: ReturnType<typeof useQueryClient>,
-	projectId: string,
-) {
-	if (!snapshot) {
-		return;
-	}
-
-	const currentColumns =
-		queryClient.getQueryData<KanbanColumn[]>(kanbanKeys.columns(projectId)) ??
-		columns;
-	const activeIndex = currentColumns.findIndex(
-		(column) => column.id === event.active.id,
-	);
-	const currentTasks =
-		queryClient.getQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId)) ??
-		tasks;
-	const overColumnId = resolveOverColumnId(event, currentColumns, currentTasks);
-	const overIndex = currentColumns.findIndex(
-		(column) => column.id === overColumnId,
-	);
-	if (activeIndex < 0 || overIndex < 0 || activeIndex === overIndex) {
-		return;
-	}
-
-	const nextColumns = arrayMove(currentColumns, activeIndex, overIndex).map(
-		(column, index) => ({
-			...column,
-			position: index + 1,
-		}),
-	);
-
-	queryClient.setQueryData(kanbanKeys.columns(projectId), nextColumns);
-	void reorderKanbanColumns(
-		projectId,
-		nextColumns.map((column) => column.id),
-	)
-		.then(async () => {
-			await invalidateBoard(queryClient, projectId);
-		})
-		.catch(async () => {
-			queryClient.setQueryData(kanbanKeys.columns(projectId), snapshot.columns);
-			await invalidateBoard(queryClient, projectId);
-		});
-}
-
-function resolveOverColumnId(
-	event: DragEndEvent,
-	columns: KanbanColumn[],
-	tasks: KanbanTask[],
-) {
-	const overData = event.over?.data.current;
-	if (isColumnDragData(overData)) {
-		return overData.column.id;
-	}
-
-	const overId = event.over?.id?.toString();
-	if (!overId) {
-		return null;
-	}
-
-	if (columns.some((column) => column.id === overId)) {
-		return overId;
-	}
-
-	return tasks.find((task) => task.id === overId)?.column_id ?? null;
-}
-
-function isTaskDragData(value: unknown): value is DragTaskData {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		"type" in value &&
-		value.type === "task"
-	);
-}
-
-function isColumnDragData(value: unknown): value is DragColumnData {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		"type" in value &&
-		value.type === "column"
-	);
-}
-
-function extractErrorMessage(error: unknown) {
-	return error instanceof Error
-		? error.message
-		: "Terjadi kesalahan yang tidak terduga";
-}
-
-interface KanbanColumnCardProps {
-	column: KanbanColumn;
-	tasks: KanbanTask[];
-	quickDraft: string;
-	onQuickDraftChange: (value: string) => void;
-	onQuickAdd: () => void;
-	onTaskClick: (task: KanbanTask) => void;
-	onTaskCreate: () => void;
-	onEditColumn: () => void;
-	onDeleteColumn: () => void;
-}
-
-function KanbanColumnCard(props: KanbanColumnCardProps) {
-	const sortable = useSortable({
-		id: props.column.id,
-		data: { type: "column", column: props.column } satisfies DragColumnData,
-	});
-	const droppable = useDroppable({
-		id: `column-drop-${props.column.id}`,
-		data: { type: "column", column: props.column } satisfies DragColumnData,
-	});
-	const style = {
-		transform: CSS.Transform.toString(sortable.transform),
-		transition: sortable.transition,
-	};
-
-	return (
-		<div
-			className="w-[min(82vw,320px)] shrink-0 md:w-[320px]"
-			ref={sortable.setNodeRef}
-			style={style}>
-			<Card
-				className={cn(
-					"flex h-full min-h-[420px] flex-col border-border bg-surface-muted p-3 shadow-sm transition-all md:min-h-[500px] md:p-4",
-					sortable.isDragging && "opacity-70",
-					droppable.isOver && "border-ops/40 bg-ops/5 shadow-card",
-				)}
-				ref={droppable.setNodeRef}>
-				<div className="flex items-start justify-between gap-3">
-					<div className="flex items-center gap-3">
-						<button
-							{...sortable.attributes}
-							{...sortable.listeners}
-							className="rounded-[6px] border border-border bg-background px-2 py-1 text-[11px] font-[700] uppercase tracking-[0.08em] text-text-secondary hover:bg-surface-muted transition-colors cursor-grab"
-							type="button">
-							Geser
-						</button>
-						<div>
-							<div className="flex items-center gap-2">
-								<span
-									className="h-2.5 w-2.5 rounded-full"
-									style={{ backgroundColor: props.column.color ?? "#94A3B8" }}
-								/>
-								<h5 className="font-[600] text-[14px] text-text-primary truncate max-w-[120px]">
-									{props.column.name}
-								</h5>
-							</div>
-							<p className="text-[12px] font-[500] text-text-tertiary">
-								{props.tasks.length} task
-							</p>
-						</div>
-					</div>
-
-					<PermissionGate permission={permissions.operationalColumnManage}>
-						<div className="flex gap-2">
-							<Button
-								onClick={props.onEditColumn}
-								size="sm"
-								variant="secondary"
-								className="h-7 px-2 text-[11px]">
-								Edit
-							</Button>
-							<PermissionGate permission={permissions.operationalColumnManage}>
-								<Button
-									onClick={props.onDeleteColumn}
-									size="sm"
-									variant="ghost"
-									className="h-7 px-2 text-[11px]">
-									Hapus
-								</Button>
-							</PermissionGate>
-						</div>
-					</PermissionGate>
-				</div>
-
-				<div className="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 max-h-[460px]">
-					<SortableContext
-						items={props.tasks.map((task) => task.id)}
-						strategy={verticalListSortingStrategy}>
-						{props.tasks.map((task) => (
-							<KanbanTaskCard
-								key={task.id}
-								onClick={() => props.onTaskClick(task)}
-								task={task}
-							/>
-						))}
-					</SortableContext>
-
-					{props.tasks.length === 0 ? (
-						<div className="rounded-[12px] border border-dashed border-border bg-background/50 px-4 py-8 text-center text-[13px] font-[500] text-text-tertiary">
-							Belum ada task di kolom ini.
-						</div>
-					) : null}
-				</div>
-
-				<PermissionGate permission={permissions.operationalTaskCreate}>
-					<div className="mt-4 rounded-[12px] border border-border bg-background p-3 space-y-3">
-						<Input
-							className="focus-visible:border-ops focus-visible:ring-ops/10"
-							onChange={(event) => props.onQuickDraftChange(event.target.value)}
-							placeholder="Tambahkan task cepat"
-							value={props.quickDraft}
-						/>
-						<div className="flex gap-3">
-							<Button
-								variant="ops"
-								onClick={props.onQuickAdd}
-								size="sm">
-								Tambah cepat
-							</Button>
-							<Button
-								onClick={props.onTaskCreate}
-								size="sm"
-								variant="ghost">
-								Form lengkap
-							</Button>
-						</div>
-					</div>
-				</PermissionGate>
-			</Card>
-		</div>
-	);
-}
-
-function KanbanTaskCard({
-	task,
-	onClick,
-}: {
-	task: KanbanTask;
-	onClick: () => void;
-}) {
-	const sortable = useSortable({
-		id: task.id,
-		data: { type: "task", task } satisfies DragTaskData,
-	});
-	const style = {
-		transform: CSS.Transform.toString(sortable.transform),
-		transition: sortable.transition,
-	};
-
-	return (
-		<div
-			ref={sortable.setNodeRef}
-			style={style}>
-			<Card
-				className={cn(
-					"cursor-pointer p-4 shadow-sm transition-all hover:border-ops/30 hover:shadow-card group",
-					sortable.isDragging && "opacity-60 ring-2 ring-ops",
-				)}
-				onClick={onClick}>
-				<div className="flex items-start justify-between gap-3">
-					<div>
-						<div className="flex flex-wrap items-center gap-2 mb-2">
-							<PriorityBadge priority={task.priority} />
-							<AssignmentBadge assignedVia={task.assigned_via} />
-							{task.label ? (
-								<span className="rounded-full bg-surface-muted border border-border px-2 py-0.5 text-[11px] font-[600] uppercase tracking-wider text-text-secondary">
-									{task.label}
-								</span>
-							) : null}
-						</div>
-						<h6 className="text-[14px] font-[600] text-text-primary leading-tight">
-							{task.title}
-						</h6>
-					</div>
-					<button
-						{...sortable.attributes}
-						{...sortable.listeners}
-						aria-label={`Pindahkan task ${task.title}`}
-						className="rounded-[8px] border border-border bg-surface-muted p-2 text-text-tertiary transition hover:border-ops/40 hover:bg-ops/10 hover:text-ops active:cursor-grabbing"
-						onClick={(event) => event.stopPropagation()}
-						type="button">
-						<GripVertical className="h-4 w-4" />
-					</button>
-				</div>
-
-				{task.description ? (
-					<p className="mt-2 line-clamp-2 text-[12px] text-text-secondary leading-relaxed">
-						{task.description}
-					</p>
-				) : null}
-
-				<div className="mt-4 flex items-center justify-between gap-3 border-t border-border pt-4">
-					<div className="flex items-center gap-2">
-						<AvatarBadge
-							avatarUrl={task.avatar_url}
-							name={task.assignee_name}
-						/>
-						<span className="text-[12px] font-[500] text-text-secondary truncate max-w-[120px]">
-							{task.assignee_name ?? "Belum ada PIC"}
-						</span>
-					</div>
-					<span className="text-[11px] font-[600] text-text-tertiary uppercase tracking-wider">
-						{task.due_date ? formatDate(task.due_date) : "Tanpa deadline"}
-					</span>
-				</div>
-			</Card>
-		</div>
-	);
-}
-
-function TaskOverlay({ task }: { task: KanbanTask }) {
-	return (
-		<div className="w-[min(82vw,320px)] md:w-[320px]">
-			<Card className="border-ops shadow-2xl p-4 rotate-2">
-				<PriorityBadge priority={task.priority} />
-				<p className="mt-2 text-[14px] font-[600] text-text-primary leading-tight">
-					{task.title}
-				</p>
-			</Card>
-		</div>
-	);
-}
-
-function ColumnOverlay({
-	column,
-	taskCount,
-}: {
-	column: KanbanColumn;
-	taskCount: number;
-}) {
-	return (
-		<div className="w-[min(82vw,320px)] md:w-[320px]">
-			<Card className="border-ops shadow-2xl p-4 rotate-2">
-				<div className="flex items-center gap-2">
-					<span
-						className="h-2 w-2 rounded-full"
-						style={{ backgroundColor: column.color ?? "#94A3B8" }}
-					/>
-					<p className="text-[14px] font-[600] text-text-primary">
-						{column.name}
-					</p>
-				</div>
-				<p className="mt-1 text-[12px] font-[500] text-text-tertiary">
-					{taskCount} tasks
-				</p>
-			</Card>
-		</div>
-	);
-}
-
-function TaskModal({
-	mode,
-	form,
-	members,
-	isSubmitting,
-	isDeleting,
-	onSubmit,
-	onDelete,
-	onClose,
-}: {
-	mode: "create" | "edit";
-	form: UseFormReturn<TaskFormValues>;
-	members: ProjectMember[];
-	isSubmitting: boolean;
-	isDeleting: boolean;
-	onSubmit: (values: TaskFormValues) => void;
-	onDelete: () => void;
-	onClose: () => void;
-}) {
-	const {
-		register,
-		handleSubmit,
-		formState: { errors },
-	} = form;
-
-	return (
-		<Drawer
-			onOpenChange={(open) => (!open ? onClose() : undefined)}
-			open>
-			<DrawerContent size="lg">
-				<DrawerHeader className="flex items-start justify-between gap-4">
-					<div>
-						<p className="text-[11px] font-[700] uppercase tracking-[0.08em] text-ops mb-1">
-							{mode === "create" ? "Buat task" : "Detail task"}
-						</p>
-						<DrawerTitle>
-							{mode === "create" ? "Task baru" : "Edit task"}
-						</DrawerTitle>
-						<DrawerDescription>
-							{mode === "create"
-								? "Isi ringkasan task, PIC, dan due date tanpa keluar dari board."
-								: "Tinjau detail task, edit informasi pengerjaan, atau hapus task dari board."}
-						</DrawerDescription>
-					</div>
-					<DrawerClose />
-				</DrawerHeader>
-
-				<DrawerBody>
-					<form
-						className="space-y-6"
-						onSubmit={handleSubmit(onSubmit)}>
-						<div className="grid gap-2">
-							<label
-								className="text-[13px] font-[600] text-text-primary"
-								htmlFor="task-title">
-								Judul<span className="ml-0.5 text-priority-high">*</span>
-							</label>
-							<Input
-								className="focus-visible:border-ops focus-visible:ring-ops/10"
-								id="task-title"
-								{...register("title")}
-							/>
-							{errors.title ? (
-								<p className="text-[13px] font-[500] text-priority-high">
-									{errors.title.message}
-								</p>
-							) : null}
-						</div>
-
-						<div className="grid gap-2">
-							<label
-								className="text-[13px] font-[600] text-text-primary"
-								htmlFor="task-description">
-								Deskripsi
-							</label>
-							<textarea
-								className="min-h-32 w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10 disabled:cursor-not-allowed disabled:opacity-50"
-								id="task-description"
-								{...register("description")}
-							/>
-						</div>
-
-						<div className="grid gap-5 md:grid-cols-2">
-							<div className="grid gap-2">
-								<label
-									className="text-[13px] font-[600] text-text-primary"
-									htmlFor="task-assignee">
-									PIC
-								</label>
-								<select
-									className="flex h-[44px] w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
-									id="task-assignee"
-									{...register("assignee_id")}>
-									<option value="">Belum ditentukan</option>
-									{members.map((member) => (
-										<option
-											key={member.user_id}
-											value={member.user_id}>
-											{member.full_name || member.user_email || member.user_id}
-										</option>
-									))}
-								</select>
-							</div>
-
-							<div className="grid gap-2">
-								<label
-									className="text-[13px] font-[600] text-text-primary"
-									htmlFor="task-due-date">
-									Deadline
-								</label>
-								<Input
-									className="focus-visible:border-ops focus-visible:ring-ops/10"
-									id="task-due-date"
-									type="date"
-									{...register("due_date")}
-								/>
-							</div>
-						</div>
-
-						<div className="grid gap-5 md:grid-cols-2">
-							<div className="grid gap-2">
-								<label
-									className="text-[13px] font-[600] text-text-primary"
-									htmlFor="task-priority">
-									Prioritas
-								</label>
-								<select
-									className="flex h-[44px] w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
-									id="task-priority"
-									{...register("priority")}>
-									<option value="low">Rendah</option>
-									<option value="medium">Medium</option>
-									<option value="high">Tinggi</option>
-									<option value="critical">Kritis</option>
-								</select>
-							</div>
-
-							<div className="grid gap-2">
-								<label
-									className="text-[13px] font-[600] text-text-primary"
-									htmlFor="task-label">
-									Label
-								</label>
-								<Input
-									className="focus-visible:border-ops focus-visible:ring-ops/10"
-									id="task-label"
-									placeholder="Bug, desain, backend"
-									{...register("label")}
-								/>
-							</div>
-						</div>
-
-						<div className="flex flex-wrap gap-3 pt-4 border-t border-border">
-							<Button
-								variant="ops"
-								disabled={isSubmitting}
-								type="submit">
-								{isSubmitting
-									? "Menyimpan..."
-									: mode === "create"
-										? "Buat task"
-										: "Simpan perubahan"}
-							</Button>
-							{mode === "edit" ? (
-								<PermissionGate permission={permissions.operationalTaskDelete}>
-									<Button
-										disabled={isDeleting}
-										onClick={onDelete}
-										type="button"
-										variant="ghost">
-										{isDeleting ? "Menghapus..." : "Hapus task"}
-									</Button>
-								</PermissionGate>
-							) : null}
-						</div>
-					</form>
-				</DrawerBody>
-			</DrawerContent>
-		</Drawer>
-	);
-}
-
-function PriorityBadge({ priority }: { priority: ProjectPriority }) {
-	const tone =
-		priority === "critical"
-			? "bg-priority-critical-bg text-priority-critical"
-			: priority === "high"
-				? "bg-priority-high-bg text-priority-high"
-				: priority === "medium"
-					? "bg-priority-medium-bg text-priority-medium"
-					: "bg-surface-muted text-text-secondary border border-border";
-	const label =
-		priority === "critical"
-			? "kritis"
-			: priority === "high"
-				? "tinggi"
-				: priority === "medium"
-					? "medium"
-					: "rendah";
-
-	return (
-		<span
-			className={cn(
-				"rounded-[6px] px-2 py-0.5 text-[11px] font-[700] uppercase tracking-[0.08em]",
-				tone,
-			)}>
-			{label}
-		</span>
-	);
-}
-
-function AssignmentBadge({ assignedVia }: { assignedVia: "manual" | "auto" }) {
-	const tone =
-		assignedVia === "auto"
-			? "bg-ops/10 text-ops"
-			: "bg-surface-muted text-text-secondary border border-border";
-
-	return (
-		<span
-			className={cn(
-				"rounded-[6px] px-2 py-0.5 text-[11px] font-[700] uppercase tracking-[0.08em]",
-				tone,
-			)}>
-			{assignedVia === "auto" ? "otomatis" : "manual"}
-		</span>
-	);
-}
-
-function AvatarBadge({
-	name,
-	avatarUrl,
-}: {
-	name?: string | null;
-	avatarUrl?: string | null;
-}) {
-	return (
-		<ProtectedAvatar
-			alt={name ?? "Unassigned"}
-			avatarUrl={avatarUrl}
-			className="h-8 w-8 shadow-sm ring-2 ring-background"
-			fallbackClassName="bg-ops text-white"
-			iconClassName="h-4 w-4"
-		/>
-	);
-}
-
-function formatDate(value: string) {
-	return formatCalendarDate(value);
 }

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -29,6 +29,7 @@ import {
 import { useKanbanDrag } from "@/hooks/use-kanban-drag";
 import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
 import { KanbanToolbar } from "@/components/shared/kanban-toolbar";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { TaskModal } from "@/components/shared/task-modal";
 import { Card } from "@/components/ui/card";
 import { extractDateInputValue } from "@/lib/date";
@@ -89,7 +90,11 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		priority: "",
 		label: "",
 		dueDate: "",
+		search: "",
+		columnId: "",
 	});
+	const debouncedSearch = useDebouncedValue(filters.search, 500);
+	const searchTerm = debouncedSearch.trim();
 	const [quickDrafts, setQuickDrafts] = useState<Record<string, string>>({});
 	const [columnModal, setColumnModal] = useState<ColumnModalState | null>(null);
 	const [columnForm, setColumnForm] = useState({ name: "", color: "#38BDF8" });
@@ -156,12 +161,19 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	);
 	const taskFilters = useMemo(
 		() => ({
+			search: searchTerm,
 			assigneeId: filters.assignee,
 			priority: filters.priority,
 			label: filters.label,
 			dueDate: filters.dueDate,
 		}),
-		[filters.assignee, filters.dueDate, filters.label, filters.priority],
+		[
+			filters.assignee,
+			filters.dueDate,
+			filters.label,
+			filters.priority,
+			searchTerm,
+		],
 	);
 
 	useEffect(() => {
@@ -275,6 +287,7 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	return (
 		<div className="space-y-6">
 			<KanbanToolbar
+				columns={columns}
 				filters={filters}
 				members={members}
 				onColumnCreate={() => {
@@ -300,7 +313,12 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 					strategy={horizontalListSortingStrategy}>
 					<div className="-mx-1 overflow-x-auto px-1 pb-3">
 						<div className="flex min-w-max gap-3 md:gap-5">
-							{columns.map((column) => (
+							{columns
+								.filter(
+									(column) =>
+										!filters.columnId || column.id === filters.columnId,
+								)
+								.map((column) => (
 								<KanbanColumnContainer
 									column={column}
 									filters={taskFilters}

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
 	DndContext,
@@ -19,16 +19,15 @@ import { z } from "zod";
 
 import {
 	ColumnOverlay,
-	KanbanColumnCard,
 	TaskOverlay,
 } from "@/components/shared/kanban-cards";
+import { KanbanColumnContainer } from "@/components/shared/kanban-column-container";
 import {
 	KanbanDialogs,
 	type ColumnModalState,
 } from "@/components/shared/kanban-dialogs";
 import {
 	matchesFilters,
-	sortTaskList,
 } from "@/components/shared/kanban-dnd";
 import { useKanbanDrag } from "@/hooks/use-kanban-drag";
 import { useKanbanMutations } from "@/hooks/use-kanban-mutations";
@@ -39,7 +38,6 @@ import { extractDateInputValue } from "@/lib/date";
 import {
 	kanbanKeys,
 	listKanbanColumns,
-	listKanbanTasks,
 } from "@/services/operational-kanban";
 import type {
 	KanbanColumn,
@@ -110,10 +108,20 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 		queryFn: () => listKanbanColumns(projectId),
 	});
 
-	const tasksQuery = useQuery({
-		queryKey: kanbanKeys.tasks(projectId),
-		queryFn: () => listKanbanTasks(projectId),
-	});
+	const [loadedTasks, setLoadedTasks] = useState<Record<string, KanbanTask[]>>(
+		{},
+	);
+
+	const handleTasksLoaded = useCallback(
+		(columnId: string, columnTasks: KanbanTask[]) => {
+			setLoadedTasks((current) =>
+				current[columnId] === columnTasks
+					? current
+					: { ...current, [columnId]: columnTasks },
+			);
+		},
+		[],
+	);
 
 	const form = useForm<TaskFormValues>({
 		resolver: zodResolver(taskSchema),
@@ -145,8 +153,15 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	});
 
 	const columns = columnsQuery.data ?? [];
-	const tasks = useMemo(() => tasksQuery.data ?? [], [tasksQuery.data]);
-	const filteredTasks = tasks.filter((task) => matchesFilters(task, filters));
+	const tasks = useMemo(
+		() => Object.values(loadedTasks).flat(),
+		[loadedTasks],
+	);
+	const filterTasks = useCallback(
+		(columnTasks: KanbanTask[]) =>
+			columnTasks.filter((task) => matchesFilters(task, filters)),
+		[filters],
+	);
 
 	useEffect(() => {
 		if (!taskModal) {
@@ -244,19 +259,14 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	const { activeTask, activeColumn, handleDragStart, handleDragEnd } =
 		useKanbanDrag(projectId, columns, tasks);
 
-	if (columnsQuery.isLoading || tasksQuery.isLoading) {
+	if (columnsQuery.isLoading) {
 		return <Card className="p-8">Memuat board proyek...</Card>;
 	}
 
-	if (
-		columnsQuery.error instanceof Error ||
-		tasksQuery.error instanceof Error
-	) {
+	if (columnsQuery.error instanceof Error) {
 		return (
 			<Card className="p-8 text-error">
-				{(columnsQuery.error as Error | undefined)?.message ??
-					(tasksQuery.error as Error | undefined)?.message ??
-					"Gagal memuat board proyek"}
+				{columnsQuery.error.message ?? "Gagal memuat board proyek"}
 			</Card>
 		);
 	}
@@ -290,8 +300,10 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 					<div className="-mx-1 overflow-x-auto px-1 pb-3">
 						<div className="flex min-w-max gap-3 md:gap-5">
 							{columns.map((column) => (
-								<KanbanColumnCard
+								<KanbanColumnContainer
 									column={column}
+									filterTasks={filterTasks}
+									key={column.id}
 									onDeleteColumn={() => setColumnToDelete(column)}
 									onEditColumn={() => startColumnEdit(column)}
 									onQuickAdd={() => void handleQuickAdd(column.id)}
@@ -311,10 +323,9 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 									onTaskCreate={() =>
 										setTaskModal({ mode: "create", columnId: column.id })
 									}
+									onTasksLoaded={handleTasksLoaded}
+									projectId={projectId}
 									quickDraft={quickDrafts[column.id] ?? ""}
-									tasks={filteredTasks
-										.filter((task) => task.column_id === column.id)
-										.sort(sortTaskList)}
 								/>
 							))}
 						</div>

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -41,6 +41,7 @@ import { TaskModal } from "@/components/shared/task-modal";
 import { Card } from "@/components/ui/card";
 import { extractDateInputValue } from "@/lib/date";
 import {
+	getKanbanTask,
 	kanbanKeys,
 	listKanbanColumns,
 } from "@/services/operational-kanban";
@@ -197,6 +198,12 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	tasksRef.current = tasks;
 	const editingTaskId = taskModal?.mode === "edit" ? taskModal.taskId : null;
 
+	const editingTaskQuery = useQuery({
+		queryKey: kanbanKeys.task(projectId, editingTaskId ?? ""),
+		queryFn: () => getKanbanTask(projectId, editingTaskId as string),
+		enabled: Boolean(editingTaskId),
+	});
+	const editingTaskDetail = editingTaskQuery.data;
 
 	useEffect(() => {
 		if (!editingTaskId) {
@@ -216,8 +223,26 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 			due_date: summary.due_date ? extractDateInputValue(summary.due_date) : "",
 			priority: summary.priority,
 			label: summary.label ?? "",
-				});
+			fields: [],
+		});
 	}, [editingTaskId, form]);
+
+	// Custom fields are only returned by the task detail endpoint, so load them
+	// separately and populate the editor once they arrive — without clobbering
+	// any edits already made to the other fields.
+	useEffect(() => {
+		if (!editingTaskId || editingTaskDetail?.id !== editingTaskId) {
+			return;
+		}
+
+		form.setValue(
+			"fields",
+			(editingTaskDetail.fields ?? []).map((field) => ({
+				name: field.name,
+				value: field.value,
+			})),
+		);
+	}, [editingTaskId, editingTaskDetail, form]);
 
 
 	async function handleQuickAdd(columnId: string) {
@@ -382,6 +407,7 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 
 			{taskModal ? (
 				<TaskModal
+					error={boardError}
 					form={form}
 					isDeleting={deleteTaskMutation.isPending}
 					isSubmitting={

--- a/frontend/src/components/shared/kanban-board.tsx
+++ b/frontend/src/components/shared/kanban-board.tsx
@@ -155,9 +155,19 @@ export function KanbanBoard({ projectId, members }: KanbanBoardProps) {
 	});
 
 	const columns = columnsQuery.data ?? [];
+	const visibleColumnIds = useMemo(
+		() =>
+			columns
+				.filter((column) => !filters.columnId || column.id === filters.columnId)
+				.map((column) => column.id),
+		[columns, filters.columnId],
+	);
+	// Derive the working task list from only the currently-visible columns so a
+	// hidden (column filter) or deleted column's stale loadedTasks entries do not
+	// leak into drag state, the overlay count, or the task-modal lookup.
 	const tasks = useMemo(
-		() => Object.values(loadedTasks).flat(),
-		[loadedTasks],
+		() => visibleColumnIds.flatMap((columnId) => loadedTasks[columnId] ?? []),
+		[loadedTasks, visibleColumnIds],
 	);
 	const taskFilters = useMemo(
 		() => ({

--- a/frontend/src/components/shared/kanban-cards.tsx
+++ b/frontend/src/components/shared/kanban-cards.tsx
@@ -1,0 +1,340 @@
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical } from "lucide-react";
+
+import { PermissionGate } from "@/components/shared/permission-gate";
+import { ProtectedAvatar } from "@/components/shared/protected-avatar";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { formatCalendarDate } from "@/lib/date";
+import { permissions } from "@/lib/permissions";
+import { cn } from "@/lib/utils";
+import type { DragColumnData, DragTaskData } from "@/components/shared/kanban-dnd";
+import type {
+	KanbanColumn,
+	KanbanTask,
+} from "@/types/kanban";
+import type { ProjectPriority } from "@/types/project";
+
+export interface KanbanColumnCardProps {
+	column: KanbanColumn;
+	tasks: KanbanTask[];
+	quickDraft: string;
+	onQuickDraftChange: (value: string) => void;
+	onQuickAdd: () => void;
+	onTaskClick: (task: KanbanTask) => void;
+	onTaskCreate: () => void;
+	onEditColumn: () => void;
+	onDeleteColumn: () => void;
+}
+
+export function KanbanColumnCard(props: KanbanColumnCardProps) {
+	const sortable = useSortable({
+		id: props.column.id,
+		data: { type: "column", column: props.column } satisfies DragColumnData,
+	});
+	const droppable = useDroppable({
+		id: `column-drop-${props.column.id}`,
+		data: { type: "column", column: props.column } satisfies DragColumnData,
+	});
+	const style = {
+		transform: CSS.Transform.toString(sortable.transform),
+		transition: sortable.transition,
+	};
+
+	return (
+		<div
+			className="w-[min(82vw,320px)] shrink-0 md:w-[320px]"
+			ref={sortable.setNodeRef}
+			style={style}>
+			<Card
+				className={cn(
+					"flex h-full min-h-[420px] flex-col border-border bg-surface-muted p-3 shadow-sm transition-all md:min-h-[500px] md:p-4",
+					sortable.isDragging && "opacity-70",
+					droppable.isOver && "border-ops/40 bg-ops/5 shadow-card",
+				)}
+				ref={droppable.setNodeRef}>
+				<div className="flex items-start justify-between gap-3">
+					<div className="flex items-center gap-3">
+						<button
+							{...sortable.attributes}
+							{...sortable.listeners}
+							className="rounded-[6px] border border-border bg-background px-2 py-1 text-[11px] font-[700] uppercase tracking-[0.08em] text-text-secondary hover:bg-surface-muted transition-colors cursor-grab"
+							type="button">
+							Geser
+						</button>
+						<div>
+							<div className="flex items-center gap-2">
+								<span
+									className="h-2.5 w-2.5 rounded-full"
+									style={{ backgroundColor: props.column.color ?? "#94A3B8" }}
+								/>
+								<h5 className="font-[600] text-[14px] text-text-primary truncate max-w-[120px]">
+									{props.column.name}
+								</h5>
+							</div>
+							<p className="text-[12px] font-[500] text-text-tertiary">
+								{props.tasks.length} task
+							</p>
+						</div>
+					</div>
+
+					<PermissionGate permission={permissions.operationalColumnManage}>
+						<div className="flex gap-2">
+							<Button
+								onClick={props.onEditColumn}
+								size="sm"
+								variant="secondary"
+								className="h-7 px-2 text-[11px]">
+								Edit
+							</Button>
+							<PermissionGate permission={permissions.operationalColumnManage}>
+								<Button
+									onClick={props.onDeleteColumn}
+									size="sm"
+									variant="ghost"
+									className="h-7 px-2 text-[11px]">
+									Hapus
+								</Button>
+							</PermissionGate>
+						</div>
+					</PermissionGate>
+				</div>
+
+				<div className="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 max-h-[460px]">
+					<SortableContext
+						items={props.tasks.map((task) => task.id)}
+						strategy={verticalListSortingStrategy}>
+						{props.tasks.map((task) => (
+							<KanbanTaskCard
+								key={task.id}
+								onClick={() => props.onTaskClick(task)}
+								task={task}
+							/>
+						))}
+					</SortableContext>
+
+					{props.tasks.length === 0 ? (
+						<div className="rounded-[12px] border border-dashed border-border bg-background/50 px-4 py-8 text-center text-[13px] font-[500] text-text-tertiary">
+							Belum ada task di kolom ini.
+						</div>
+					) : null}
+
+				</div>
+
+				<PermissionGate permission={permissions.operationalTaskCreate}>
+					<div className="mt-4 rounded-[12px] border border-border bg-background p-3 space-y-3">
+						<Input
+							className="focus-visible:border-ops focus-visible:ring-ops/10"
+							onChange={(event) => props.onQuickDraftChange(event.target.value)}
+							placeholder="Tambahkan task cepat"
+							value={props.quickDraft}
+						/>
+						<div className="flex gap-3">
+							<Button
+								variant="ops"
+								onClick={props.onQuickAdd}
+								size="sm">
+								Tambah cepat
+							</Button>
+							<Button
+								onClick={props.onTaskCreate}
+								size="sm"
+								variant="ghost">
+								Form lengkap
+							</Button>
+						</div>
+					</div>
+				</PermissionGate>
+			</Card>
+		</div>
+	);
+}
+
+export function KanbanTaskCard({
+	task,
+	onClick,
+}: {
+	task: KanbanTask;
+	onClick: () => void;
+}) {
+	const sortable = useSortable({
+		id: task.id,
+		data: { type: "task", task } satisfies DragTaskData,
+	});
+	const style = {
+		transform: CSS.Transform.toString(sortable.transform),
+		transition: sortable.transition,
+	};
+
+	return (
+		<div
+			ref={sortable.setNodeRef}
+			style={style}>
+			<Card
+				className={cn(
+					"cursor-pointer p-4 shadow-sm transition-all hover:border-ops/30 hover:shadow-card group",
+					sortable.isDragging && "opacity-60 ring-2 ring-ops",
+				)}
+				onClick={onClick}>
+				<div className="flex items-start justify-between gap-3">
+					<div>
+						<div className="flex flex-wrap items-center gap-2 mb-2">
+							<PriorityBadge priority={task.priority} />
+							<AssignmentBadge assignedVia={task.assigned_via} />
+							{task.label ? (
+								<span className="rounded-full bg-surface-muted border border-border px-2 py-0.5 text-[11px] font-[600] uppercase tracking-wider text-text-secondary">
+									{task.label}
+								</span>
+							) : null}
+						</div>
+						<h6 className="text-[14px] font-[600] text-text-primary leading-tight">
+							{task.title}
+						</h6>
+					</div>
+					<button
+						{...sortable.attributes}
+						{...sortable.listeners}
+						aria-label={`Pindahkan task ${task.title}`}
+						className="rounded-[8px] border border-border bg-surface-muted p-2 text-text-tertiary transition hover:border-ops/40 hover:bg-ops/10 hover:text-ops active:cursor-grabbing"
+						onClick={(event) => event.stopPropagation()}
+						type="button">
+						<GripVertical className="h-4 w-4" />
+					</button>
+				</div>
+
+				{task.description ? (
+					<p className="mt-2 line-clamp-2 text-[12px] text-text-secondary leading-relaxed">
+						{task.description}
+					</p>
+				) : null}
+
+				<div className="mt-4 flex items-center justify-between gap-3 border-t border-border pt-4">
+					<div className="flex items-center gap-2">
+						<AvatarBadge
+							avatarUrl={task.avatar_url}
+							name={task.assignee_name}
+						/>
+						<span className="text-[12px] font-[500] text-text-secondary truncate max-w-[120px]">
+							{task.assignee_name ?? "Belum ada PIC"}
+						</span>
+					</div>
+					<span className="text-[11px] font-[600] text-text-tertiary uppercase tracking-wider">
+						{task.due_date ? formatDate(task.due_date) : "Tanpa deadline"}
+					</span>
+				</div>
+			</Card>
+		</div>
+	);
+}
+
+export function TaskOverlay({ task }: { task: KanbanTask }) {
+	return (
+		<div className="w-[min(82vw,320px)] md:w-[320px]">
+			<Card className="border-ops shadow-2xl p-4 rotate-2">
+				<PriorityBadge priority={task.priority} />
+				<p className="mt-2 text-[14px] font-[600] text-text-primary leading-tight">
+					{task.title}
+				</p>
+			</Card>
+		</div>
+	);
+}
+
+export function ColumnOverlay({
+	column,
+	taskCount,
+}: {
+	column: KanbanColumn;
+	taskCount: number;
+}) {
+	return (
+		<div className="w-[min(82vw,320px)] md:w-[320px]">
+			<Card className="border-ops shadow-2xl p-4 rotate-2">
+				<div className="flex items-center gap-2">
+					<span
+						className="h-2 w-2 rounded-full"
+						style={{ backgroundColor: column.color ?? "#94A3B8" }}
+					/>
+					<p className="text-[14px] font-[600] text-text-primary">
+						{column.name}
+					</p>
+				</div>
+				<p className="mt-1 text-[12px] font-[500] text-text-tertiary">
+					{taskCount} tasks
+				</p>
+			</Card>
+		</div>
+	);
+}
+
+function PriorityBadge({ priority }: { priority: ProjectPriority }) {
+	const tone =
+		priority === "critical"
+			? "bg-priority-critical-bg text-priority-critical"
+			: priority === "high"
+				? "bg-priority-high-bg text-priority-high"
+				: priority === "medium"
+					? "bg-priority-medium-bg text-priority-medium"
+					: "bg-surface-muted text-text-secondary border border-border";
+	const label =
+		priority === "critical"
+			? "kritis"
+			: priority === "high"
+				? "tinggi"
+				: priority === "medium"
+					? "medium"
+					: "rendah";
+
+	return (
+		<span
+			className={cn(
+				"rounded-[6px] px-2 py-0.5 text-[11px] font-[700] uppercase tracking-[0.08em]",
+				tone,
+			)}>
+			{label}
+		</span>
+	);
+}
+
+function AssignmentBadge({ assignedVia }: { assignedVia: "manual" | "auto" }) {
+	const tone =
+		assignedVia === "auto"
+			? "bg-ops/10 text-ops"
+			: "bg-surface-muted text-text-secondary border border-border";
+
+	return (
+		<span
+			className={cn(
+				"rounded-[6px] px-2 py-0.5 text-[11px] font-[700] uppercase tracking-[0.08em]",
+				tone,
+			)}>
+			{assignedVia === "auto" ? "otomatis" : "manual"}
+		</span>
+	);
+}
+
+function AvatarBadge({
+	name,
+	avatarUrl,
+}: {
+	name?: string | null;
+	avatarUrl?: string | null;
+}) {
+	return (
+		<ProtectedAvatar
+			alt={name ?? "Unassigned"}
+			avatarUrl={avatarUrl}
+			className="h-8 w-8 shadow-sm ring-2 ring-background"
+			fallbackClassName="bg-ops text-white"
+			iconClassName="h-4 w-4"
+		/>
+	);
+}
+
+function formatDate(value: string) {
+	return formatCalendarDate(value);
+}
+

--- a/frontend/src/components/shared/kanban-cards.tsx
+++ b/frontend/src/components/shared/kanban-cards.tsx
@@ -14,13 +14,13 @@ import { cn } from "@/lib/utils";
 import type { DragColumnData, DragTaskData } from "@/components/shared/kanban-dnd";
 import type {
 	KanbanColumn,
-	KanbanTask,
+	KanbanTaskListItem,
 } from "@/types/kanban";
 import type { ProjectPriority } from "@/types/project";
 
 export interface KanbanColumnCardProps {
 	column: KanbanColumn;
-	tasks: KanbanTask[];
+	tasks: KanbanTaskListItem[];
 	totalTasks: number;
 	hasMore: boolean;
 	isLoadingTasks: boolean;
@@ -29,7 +29,7 @@ export interface KanbanColumnCardProps {
 	quickDraft: string;
 	onQuickDraftChange: (value: string) => void;
 	onQuickAdd: () => void;
-	onTaskClick: (task: KanbanTask) => void;
+	onTaskClick: (task: KanbanTaskListItem) => void;
 	onTaskCreate: () => void;
 	onEditColumn: () => void;
 	onDeleteColumn: () => void;
@@ -178,7 +178,7 @@ export function KanbanTaskCard({
 	task,
 	onClick,
 }: {
-	task: KanbanTask;
+	task: KanbanTaskListItem;
 	onClick: () => void;
 }) {
 	const sortable = useSortable({
@@ -251,7 +251,7 @@ export function KanbanTaskCard({
 	);
 }
 
-export function TaskOverlay({ task }: { task: KanbanTask }) {
+export function TaskOverlay({ task }: { task: KanbanTaskListItem }) {
 	return (
 		<div className="w-[min(82vw,320px)] md:w-[320px]">
 			<Card className="border-ops shadow-2xl p-4 rotate-2">

--- a/frontend/src/components/shared/kanban-cards.tsx
+++ b/frontend/src/components/shared/kanban-cards.tsx
@@ -21,6 +21,11 @@ import type { ProjectPriority } from "@/types/project";
 export interface KanbanColumnCardProps {
 	column: KanbanColumn;
 	tasks: KanbanTask[];
+	totalTasks: number;
+	hasMore: boolean;
+	isLoadingTasks: boolean;
+	isFetchingMore: boolean;
+	onLoadMore: () => void;
 	quickDraft: string;
 	onQuickDraftChange: (value: string) => void;
 	onQuickAdd: () => void;
@@ -76,7 +81,7 @@ export function KanbanColumnCard(props: KanbanColumnCardProps) {
 								</h5>
 							</div>
 							<p className="text-[12px] font-[500] text-text-tertiary">
-								{props.tasks.length} task
+								{props.totalTasks} task
 							</p>
 						</div>
 					</div>
@@ -103,7 +108,18 @@ export function KanbanColumnCard(props: KanbanColumnCardProps) {
 					</PermissionGate>
 				</div>
 
-				<div className="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 max-h-[460px]">
+				<div
+					className="mt-4 flex-1 space-y-3 overflow-y-auto pr-1 max-h-[460px]"
+					onScroll={(event) => {
+						const el = event.currentTarget;
+						if (
+							props.hasMore &&
+							!props.isFetchingMore &&
+							el.scrollHeight - el.scrollTop - el.clientHeight < 120
+						) {
+							props.onLoadMore();
+						}
+					}}>
 					<SortableContext
 						items={props.tasks.map((task) => task.id)}
 						strategy={verticalListSortingStrategy}>
@@ -116,12 +132,17 @@ export function KanbanColumnCard(props: KanbanColumnCardProps) {
 						))}
 					</SortableContext>
 
-					{props.tasks.length === 0 ? (
+					{props.tasks.length === 0 && !props.isLoadingTasks ? (
 						<div className="rounded-[12px] border border-dashed border-border bg-background/50 px-4 py-8 text-center text-[13px] font-[500] text-text-tertiary">
 							Belum ada task di kolom ini.
 						</div>
 					) : null}
 
+					{props.isLoadingTasks || props.isFetchingMore ? (
+						<p className="py-3 text-center text-[12px] font-[500] text-text-tertiary">
+							Memuat task...
+						</p>
+					) : null}
 				</div>
 
 				<PermissionGate permission={permissions.operationalTaskCreate}>

--- a/frontend/src/components/shared/kanban-column-container.tsx
+++ b/frontend/src/components/shared/kanban-column-container.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+
+import { KanbanColumnCard } from "@/components/shared/kanban-cards";
+import { sortTaskList } from "@/components/shared/kanban-dnd";
+import { useKanbanColumnTasks } from "@/hooks/use-kanban-column-tasks";
+import type { KanbanColumn, KanbanTask } from "@/types/kanban";
+
+interface KanbanColumnContainerProps {
+	projectId: string;
+	column: KanbanColumn;
+	filterTasks: (tasks: KanbanTask[]) => KanbanTask[];
+	onTasksLoaded: (columnId: string, tasks: KanbanTask[]) => void;
+	onTaskClick: (task: KanbanTask) => void;
+	onTaskCreate: () => void;
+	onEditColumn: () => void;
+	onDeleteColumn: () => void;
+	quickDraft: string;
+	onQuickDraftChange: (value: string) => void;
+	onQuickAdd: () => void;
+}
+
+export function KanbanColumnContainer({
+	projectId,
+	column,
+	filterTasks,
+	onTasksLoaded,
+	...rest
+}: KanbanColumnContainerProps) {
+	const { tasks, total, hasMore, isLoading, isFetchingMore, fetchMore } =
+		useKanbanColumnTasks(projectId, column.id);
+
+	useEffect(() => {
+		onTasksLoaded(column.id, tasks);
+	}, [column.id, onTasksLoaded, tasks]);
+
+	const visibleTasks = filterTasks(tasks).sort(sortTaskList);
+
+	return (
+		<KanbanColumnCard
+			column={column}
+			hasMore={hasMore}
+			isFetchingMore={isFetchingMore}
+			isLoadingTasks={isLoading}
+			onLoadMore={fetchMore}
+			tasks={visibleTasks}
+			totalTasks={total}
+			{...rest}
+		/>
+	);
+}

--- a/frontend/src/components/shared/kanban-column-container.tsx
+++ b/frontend/src/components/shared/kanban-column-container.tsx
@@ -1,17 +1,17 @@
 import { useEffect } from "react";
 
 import { KanbanColumnCard } from "@/components/shared/kanban-cards";
-import type { KanbanTaskQuery } from "@/services/operational-kanban";
 import { sortTaskList } from "@/components/shared/kanban-dnd";
 import { useKanbanColumnTasks } from "@/hooks/use-kanban-column-tasks";
-import type { KanbanColumn, KanbanTask } from "@/types/kanban";
+import type { KanbanTaskQuery } from "@/services/operational-kanban";
+import type { KanbanColumn, KanbanTaskListItem } from "@/types/kanban";
 
 interface KanbanColumnContainerProps {
 	projectId: string;
 	column: KanbanColumn;
 	filters: KanbanTaskQuery;
-	onTasksLoaded: (columnId: string, tasks: KanbanTask[]) => void;
-	onTaskClick: (task: KanbanTask) => void;
+	onTasksLoaded: (columnId: string, tasks: KanbanTaskListItem[]) => void;
+	onTaskClick: (task: KanbanTaskListItem) => void;
 	onTaskCreate: () => void;
 	onEditColumn: () => void;
 	onDeleteColumn: () => void;

--- a/frontend/src/components/shared/kanban-column-container.tsx
+++ b/frontend/src/components/shared/kanban-column-container.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { KanbanColumnCard } from "@/components/shared/kanban-cards";
+import type { KanbanTaskQuery } from "@/services/operational-kanban";
 import { sortTaskList } from "@/components/shared/kanban-dnd";
 import { useKanbanColumnTasks } from "@/hooks/use-kanban-column-tasks";
 import type { KanbanColumn, KanbanTask } from "@/types/kanban";
@@ -8,7 +9,7 @@ import type { KanbanColumn, KanbanTask } from "@/types/kanban";
 interface KanbanColumnContainerProps {
 	projectId: string;
 	column: KanbanColumn;
-	filterTasks: (tasks: KanbanTask[]) => KanbanTask[];
+	filters: KanbanTaskQuery;
 	onTasksLoaded: (columnId: string, tasks: KanbanTask[]) => void;
 	onTaskClick: (task: KanbanTask) => void;
 	onTaskCreate: () => void;
@@ -22,18 +23,18 @@ interface KanbanColumnContainerProps {
 export function KanbanColumnContainer({
 	projectId,
 	column,
-	filterTasks,
+	filters,
 	onTasksLoaded,
 	...rest
 }: KanbanColumnContainerProps) {
 	const { tasks, total, hasMore, isLoading, isFetchingMore, fetchMore } =
-		useKanbanColumnTasks(projectId, column.id);
+		useKanbanColumnTasks(projectId, column.id, filters);
 
 	useEffect(() => {
 		onTasksLoaded(column.id, tasks);
 	}, [column.id, onTasksLoaded, tasks]);
 
-	const visibleTasks = filterTasks(tasks).sort(sortTaskList);
+	const visibleTasks = [...tasks].sort(sortTaskList);
 
 	return (
 		<KanbanColumnCard

--- a/frontend/src/components/shared/kanban-dialogs.tsx
+++ b/frontend/src/components/shared/kanban-dialogs.tsx
@@ -2,7 +2,7 @@ import { ConfirmDialog } from "@/components/shared/confirm-dialog";
 import { FormModal } from "@/components/shared/form-modal";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import type { KanbanColumn, KanbanTask } from "@/types/kanban";
+import type { KanbanColumn, KanbanTaskListItem } from "@/types/kanban";
 
 export type ColumnModalState =
 	| { mode: "create" }
@@ -21,7 +21,7 @@ interface KanbanDialogsProps {
 	isColumnDeleting: boolean;
 	isTaskDeleting: boolean;
 	columnToDelete: KanbanColumn | null;
-	taskToDelete: KanbanTask | null;
+	taskToDelete: KanbanTaskListItem | null;
 	onColumnFormChange: (
 		updater: (current: ColumnFormValues) => ColumnFormValues,
 	) => void;

--- a/frontend/src/components/shared/kanban-dialogs.tsx
+++ b/frontend/src/components/shared/kanban-dialogs.tsx
@@ -1,0 +1,142 @@
+import { ConfirmDialog } from "@/components/shared/confirm-dialog";
+import { FormModal } from "@/components/shared/form-modal";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import type { KanbanColumn, KanbanTask } from "@/types/kanban";
+
+export type ColumnModalState =
+	| { mode: "create" }
+	| { mode: "edit"; columnId: string };
+
+export interface ColumnFormValues {
+	name: string;
+	color: string;
+}
+
+interface KanbanDialogsProps {
+	columnModal: ColumnModalState | null;
+	columnForm: ColumnFormValues;
+	columnColorOptions: string[];
+	isColumnSaving: boolean;
+	isColumnDeleting: boolean;
+	isTaskDeleting: boolean;
+	columnToDelete: KanbanColumn | null;
+	taskToDelete: KanbanTask | null;
+	onColumnFormChange: (
+		updater: (current: ColumnFormValues) => ColumnFormValues,
+	) => void;
+	onColumnModalClose: () => void;
+	onColumnSubmit: () => void;
+	onColumnDeleteClose: () => void;
+	onColumnDeleteConfirm: () => void;
+	onTaskDeleteClose: () => void;
+	onTaskDeleteConfirm: () => void;
+}
+
+export function KanbanDialogs({
+	columnModal,
+	columnForm,
+	columnColorOptions,
+	isColumnSaving,
+	isColumnDeleting,
+	isTaskDeleting,
+	columnToDelete,
+	taskToDelete,
+	onColumnFormChange,
+	onColumnModalClose,
+	onColumnSubmit,
+	onColumnDeleteClose,
+	onColumnDeleteConfirm,
+	onTaskDeleteClose,
+	onTaskDeleteConfirm,
+}: KanbanDialogsProps) {
+	return (
+		<>
+		<FormModal
+			isLoading={isColumnSaving}
+			isOpen={Boolean(columnModal)}
+			onClose={onColumnModalClose}
+			onSubmit={(event) => {
+				event.preventDefault();
+				onColumnSubmit();
+			}}
+			size="sm"
+			submitLabel={
+				columnModal?.mode === "edit" ? "Simpan kolom" : "Buat kolom"
+			}
+			title={columnModal?.mode === "edit" ? "Edit kolom" : "Buat kolom"}
+			subtitle="Gunakan nama singkat dan warna aksen yang jelas agar kolom mudah dipindai di board.">
+			<div className="space-y-2">
+				<label className="text-[13px] font-[600] text-text-primary">
+					Nama kolom
+				</label>
+				<Input
+					className="focus-visible:border-ops focus-visible:ring-ops/10"
+					onChange={(event) =>
+						onColumnFormChange((current) => ({
+							...current,
+							name: event.target.value,
+						}))
+					}
+					placeholder="Review"
+					value={columnForm.name}
+				/>
+			</div>
+			<div className="space-y-2">
+				<p className="text-[13px] font-[600] text-text-primary">
+					Warna aksen
+				</p>
+				<div className="flex flex-wrap gap-2">
+					{columnColorOptions.map((color) => (
+						<button
+							aria-label={`Choose list color ${color}`}
+							className={cn(
+								"h-9 w-9 rounded-full border-2 transition hover:scale-105",
+								columnForm.color === color
+									? "border-foreground shadow-sm"
+									: "border-transparent",
+							)}
+							key={color}
+							onClick={() =>
+								onColumnFormChange((current) => ({ ...current, color }))
+							}
+							style={{ backgroundColor: color }}
+							type="button"
+						/>
+					))}
+				</div>
+			</div>
+		</FormModal>
+
+		<ConfirmDialog
+			confirmLabel="Hapus kolom"
+			description={
+				columnToDelete
+					? `Semua task di dalam "${columnToDelete.name}" akan ikut terhapus bersama kolom ini.`
+					: ""
+			}
+			isLoading={isColumnDeleting}
+			isOpen={Boolean(columnToDelete)}
+			onClose={onColumnDeleteClose}
+			onConfirm={onColumnDeleteConfirm}
+			title={
+				columnToDelete ? `Hapus ${columnToDelete.name}?` : "Hapus kolom?"
+			}
+		/>
+
+		<ConfirmDialog
+			confirmLabel="Hapus task"
+			description={
+				taskToDelete
+					? `Task "${taskToDelete.title}" akan dihapus dari board ini.`
+					: ""
+			}
+			isLoading={isTaskDeleting}
+			isOpen={Boolean(taskToDelete)}
+			onClose={onTaskDeleteClose}
+			onConfirm={onTaskDeleteConfirm}
+			title={taskToDelete ? `Hapus ${taskToDelete.title}?` : "Hapus task?"}
+		/>
+		</>
+	);
+}

--- a/frontend/src/components/shared/kanban-dnd.ts
+++ b/frontend/src/components/shared/kanban-dnd.ts
@@ -135,19 +135,85 @@ export function sortTaskList(
 	return left.column_id.localeCompare(right.column_id);
 }
 
+interface TaskPageShape {
+	items: KanbanTask[];
+	total: number;
+	limit: number;
+	offset: number;
+	has_more: boolean;
+}
+
+interface TaskInfiniteShape {
+	pages: TaskPageShape[];
+	pageParams: unknown[];
+}
+
 export function setTasksCache(
 	queryClient: ReturnType<typeof useQueryClient>,
 	projectId: string,
 	tasks: KanbanTask[],
 ) {
-	queryClient.setQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId), tasks);
+	const byId = new Map(tasks.map((task) => [task.id, task]));
+	const entries = queryClient.getQueriesData<TaskInfiniteShape>({
+		queryKey: kanbanKeys.tasks(projectId),
+	});
+
+	for (const [queryKey, current] of entries) {
+		if (!current?.pages) {
+			continue;
+		}
+
+		const columnIndex = queryKey.indexOf("column");
+		const columnId =
+			columnIndex >= 0 ? (queryKey[columnIndex + 1] as string) : undefined;
+
+		const loaded = current.pages.flatMap((page) => page.items);
+		const known = new Set(loaded.map((item) => item.id));
+		const next = loaded
+			.map((item) => byId.get(item.id) ?? item)
+			.filter((item) => !columnId || item.column_id === columnId);
+
+		if (columnId) {
+			for (const task of tasks) {
+				if (task.column_id === columnId && !known.has(task.id)) {
+					next.push(task);
+				}
+			}
+		}
+		next.sort(sortTaskList);
+
+		let cursor = 0;
+		queryClient.setQueryData<TaskInfiniteShape>(queryKey, {
+			...current,
+			pages: current.pages.map((page, index) => {
+				const size =
+					index === current.pages.length - 1
+						? next.length - cursor
+						: page.items.length;
+				const items = next.slice(cursor, cursor + Math.max(size, 0));
+				cursor += items.length;
+				return { ...page, items };
+			}),
+		});
+	}
 }
 
 export function getTasksCache(
 	queryClient: ReturnType<typeof useQueryClient>,
 	projectId: string,
 ) {
-	return queryClient.getQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId));
+	const entries = queryClient.getQueriesData<TaskInfiniteShape>({
+		queryKey: kanbanKeys.tasks(projectId),
+	});
+
+	const tasks: KanbanTask[] = [];
+	for (const [, data] of entries) {
+		for (const page of data?.pages ?? []) {
+			tasks.push(...page.items);
+		}
+	}
+
+	return tasks.length > 0 ? tasks : undefined;
 }
 
 export async function invalidateBoard(

--- a/frontend/src/components/shared/kanban-dnd.ts
+++ b/frontend/src/components/shared/kanban-dnd.ts
@@ -7,18 +7,21 @@ import {
 	moveKanbanTask,
 	reorderKanbanColumns,
 } from "@/services/operational-kanban";
-import type { KanbanColumn, KanbanTask } from "@/types/kanban";
+import type {
+	KanbanColumn,
+	KanbanTaskListItem,
+} from "@/types/kanban";
 
 export interface DragSnapshot {
 	columns: KanbanColumn[];
-	tasks: KanbanTask[];
+	tasks: KanbanTaskListItem[];
 }
 
-export type DragTaskData = { type: "task"; task: KanbanTask };
+export type DragTaskData = { type: "task"; task: KanbanTaskListItem };
 export type DragColumnData = { type: "column"; column: KanbanColumn };
 
 export function moveTaskInMemory(
-	tasks: KanbanTask[],
+	tasks: KanbanTaskListItem[],
 	activeTaskId: string,
 	overData: unknown,
 	overId: string,
@@ -77,8 +80,8 @@ export function moveTaskInMemory(
 	return flattenTaskBuckets(buckets);
 }
 
-function buildTaskBuckets(tasks: KanbanTask[]) {
-	const buckets: Record<string, KanbanTask[]> = {};
+function buildTaskBuckets(tasks: KanbanTaskListItem[]) {
+	const buckets: Record<string, KanbanTaskListItem[]> = {};
 	for (const task of [...tasks].sort(sortTaskList)) {
 		if (!buckets[task.column_id]) {
 			buckets[task.column_id] = [];
@@ -88,8 +91,8 @@ function buildTaskBuckets(tasks: KanbanTask[]) {
 	return buckets;
 }
 
-function flattenTaskBuckets(buckets: Record<string, KanbanTask[]>) {
-	const nextTasks: KanbanTask[] = [];
+function flattenTaskBuckets(buckets: Record<string, KanbanTaskListItem[]>) {
+	const nextTasks: KanbanTaskListItem[] = [];
 	for (const columnId of Object.keys(buckets)) {
 		buckets[columnId]!.forEach((task, index) => {
 			nextTasks.push({ ...task, column_id: columnId, position: index + 1 });
@@ -109,7 +112,7 @@ export function sortTaskList(
 }
 
 interface TaskPageShape {
-	items: KanbanTask[];
+	items: KanbanTaskListItem[];
 	total: number;
 	limit: number;
 	offset: number;
@@ -124,7 +127,7 @@ interface TaskInfiniteShape {
 export function setTasksCache(
 	queryClient: ReturnType<typeof useQueryClient>,
 	projectId: string,
-	tasks: KanbanTask[],
+	tasks: KanbanTaskListItem[],
 ) {
 	const byId = new Map(tasks.map((task) => [task.id, task]));
 	const entries = queryClient.getQueriesData<TaskInfiniteShape>({
@@ -179,7 +182,7 @@ export function getTasksCache(
 		queryKey: kanbanKeys.tasks(projectId),
 	});
 
-	const tasks: KanbanTask[] = [];
+	const tasks: KanbanTaskListItem[] = [];
 	for (const [, data] of entries) {
 		for (const page of data?.pages ?? []) {
 			tasks.push(...page.items);
@@ -198,7 +201,7 @@ export async function invalidateBoard(
 
 export function finishTaskDrag(
 	taskId: string,
-	nextTasks: KanbanTask[] | null,
+	nextTasks: KanbanTaskListItem[] | null,
 	snapshot: DragSnapshot | null,
 	queryClient: ReturnType<typeof useQueryClient>,
 	projectId: string,
@@ -241,7 +244,7 @@ export function finishTaskDrag(
 export function finishColumnDrag(
 	event: DragEndEvent,
 	columns: KanbanColumn[],
-	tasks: KanbanTask[],
+	tasks: KanbanTaskListItem[],
 	snapshot: DragSnapshot | null,
 	queryClient: ReturnType<typeof useQueryClient>,
 	projectId: string,
@@ -291,7 +294,7 @@ export function finishColumnDrag(
 function resolveOverColumnId(
 	event: DragEndEvent,
 	columns: KanbanColumn[],
-	tasks: KanbanTask[],
+	tasks: KanbanTaskListItem[],
 ) {
 	const overData = event.over?.data.current;
 	if (isColumnDragData(overData)) {

--- a/frontend/src/components/shared/kanban-dnd.ts
+++ b/frontend/src/components/shared/kanban-dnd.ts
@@ -2,17 +2,12 @@ import type { DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import type { useQueryClient } from "@tanstack/react-query";
 
-import { extractDateInputValue } from "@/lib/date";
 import {
 	kanbanKeys,
 	moveKanbanTask,
 	reorderKanbanColumns,
 } from "@/services/operational-kanban";
-import type {
-	KanbanColumn,
-	KanbanFilters,
-	KanbanTask,
-} from "@/types/kanban";
+import type { KanbanColumn, KanbanTask } from "@/types/kanban";
 
 export interface DragSnapshot {
 	columns: KanbanColumn[];
@@ -21,28 +16,6 @@ export interface DragSnapshot {
 
 export type DragTaskData = { type: "task"; task: KanbanTask };
 export type DragColumnData = { type: "column"; column: KanbanColumn };
-
-export function matchesFilters(task: KanbanTask, filters: KanbanFilters) {
-	if (filters.assignee && task.assignee_id !== filters.assignee) {
-		return false;
-	}
-	if (filters.priority && task.priority !== filters.priority) {
-		return false;
-	}
-	if (filters.label) {
-		const label = task.label?.toLowerCase() ?? "";
-		if (!label.includes(filters.label.toLowerCase())) {
-			return false;
-		}
-	}
-	if (
-		filters.dueDate &&
-		(!task.due_date || extractDateInputValue(task.due_date) !== filters.dueDate)
-	) {
-		return false;
-	}
-	return true;
-}
 
 export function moveTaskInMemory(
 	tasks: KanbanTask[],

--- a/frontend/src/components/shared/kanban-dnd.ts
+++ b/frontend/src/components/shared/kanban-dnd.ts
@@ -1,0 +1,296 @@
+import type { DragEndEvent } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
+import type { useQueryClient } from "@tanstack/react-query";
+
+import { extractDateInputValue } from "@/lib/date";
+import {
+	kanbanKeys,
+	moveKanbanTask,
+	reorderKanbanColumns,
+} from "@/services/operational-kanban";
+import type {
+	KanbanColumn,
+	KanbanFilters,
+	KanbanTask,
+} from "@/types/kanban";
+
+export interface DragSnapshot {
+	columns: KanbanColumn[];
+	tasks: KanbanTask[];
+}
+
+export type DragTaskData = { type: "task"; task: KanbanTask };
+export type DragColumnData = { type: "column"; column: KanbanColumn };
+
+export function matchesFilters(task: KanbanTask, filters: KanbanFilters) {
+	if (filters.assignee && task.assignee_id !== filters.assignee) {
+		return false;
+	}
+	if (filters.priority && task.priority !== filters.priority) {
+		return false;
+	}
+	if (filters.label) {
+		const label = task.label?.toLowerCase() ?? "";
+		if (!label.includes(filters.label.toLowerCase())) {
+			return false;
+		}
+	}
+	if (
+		filters.dueDate &&
+		(!task.due_date || extractDateInputValue(task.due_date) !== filters.dueDate)
+	) {
+		return false;
+	}
+	return true;
+}
+
+export function moveTaskInMemory(
+	tasks: KanbanTask[],
+	activeTaskId: string,
+	overData: unknown,
+	overId: string,
+) {
+	const activeTask = tasks.find((task) => task.id === activeTaskId);
+	if (!activeTask) {
+		return null;
+	}
+
+	const buckets = buildTaskBuckets(tasks);
+	const sourceList = [...(buckets[activeTask.column_id] ?? [])];
+	const sourceIndex = sourceList.findIndex((task) => task.id === activeTaskId);
+	if (sourceIndex < 0) {
+		return null;
+	}
+
+	const [movingTask] = sourceList.splice(sourceIndex, 1);
+	buckets[activeTask.column_id] = sourceList;
+
+	let destinationColumnId = activeTask.column_id;
+	let destinationIndex = sourceList.length;
+
+	if (isTaskDragData(overData)) {
+		destinationColumnId = overData.task.column_id;
+		const targetList =
+			destinationColumnId === activeTask.column_id
+				? sourceList
+				: [...(buckets[destinationColumnId] ?? [])];
+		const overIndex = targetList.findIndex(
+			(task) => task.id === overData.task.id,
+		);
+		destinationIndex = overIndex >= 0 ? overIndex : targetList.length;
+	} else if (isColumnDragData(overData)) {
+		destinationColumnId = overData.column.id;
+		const targetList =
+			destinationColumnId === activeTask.column_id
+				? sourceList
+				: [...(buckets[destinationColumnId] ?? [])];
+		destinationIndex = targetList.length;
+	} else {
+		const targetList = buckets[activeTask.column_id] ?? [];
+		const overIndex = targetList.findIndex((task) => task.id === overId);
+		destinationIndex = overIndex >= 0 ? overIndex : targetList.length;
+	}
+
+	const destinationList =
+		destinationColumnId === activeTask.column_id
+			? sourceList
+			: [...(buckets[destinationColumnId] ?? [])];
+	destinationList.splice(destinationIndex, 0, {
+		...movingTask!,
+		column_id: destinationColumnId,
+	});
+	buckets[destinationColumnId] = destinationList;
+
+	return flattenTaskBuckets(buckets);
+}
+
+function buildTaskBuckets(tasks: KanbanTask[]) {
+	const buckets: Record<string, KanbanTask[]> = {};
+	for (const task of [...tasks].sort(sortTaskList)) {
+		if (!buckets[task.column_id]) {
+			buckets[task.column_id] = [];
+		}
+		buckets[task.column_id]!.push(task);
+	}
+	return buckets;
+}
+
+function flattenTaskBuckets(buckets: Record<string, KanbanTask[]>) {
+	const nextTasks: KanbanTask[] = [];
+	for (const columnId of Object.keys(buckets)) {
+		buckets[columnId]!.forEach((task, index) => {
+			nextTasks.push({ ...task, column_id: columnId, position: index + 1 });
+		});
+	}
+	return nextTasks.sort(sortTaskList);
+}
+
+export function sortTaskList(
+	left: { column_id: string; position: number },
+	right: { column_id: string; position: number },
+) {
+	if (left.column_id === right.column_id) {
+		return left.position - right.position;
+	}
+	return left.column_id.localeCompare(right.column_id);
+}
+
+export function setTasksCache(
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+	tasks: KanbanTask[],
+) {
+	queryClient.setQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId), tasks);
+}
+
+export function getTasksCache(
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+) {
+	return queryClient.getQueryData<KanbanTask[]>(kanbanKeys.tasks(projectId));
+}
+
+export async function invalidateBoard(
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+) {
+	await queryClient.invalidateQueries({ queryKey: kanbanKeys.all(projectId) });
+}
+
+export function finishTaskDrag(
+	taskId: string,
+	nextTasks: KanbanTask[] | null,
+	snapshot: DragSnapshot | null,
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+) {
+	if (!snapshot || !nextTasks) {
+		return;
+	}
+
+	const previousTask = snapshot.tasks.find((task) => task.id === taskId);
+	const nextTask = nextTasks.find((task) => task.id === taskId);
+
+	if (!previousTask || !nextTask) {
+		setTasksCache(queryClient, projectId, snapshot.tasks);
+		return;
+	}
+
+	if (
+		previousTask.column_id === nextTask.column_id &&
+		previousTask.position === nextTask.position
+	) {
+		return;
+	}
+
+	setTasksCache(queryClient, projectId, nextTasks);
+	void moveKanbanTask(
+		projectId,
+		nextTask.id,
+		nextTask.column_id,
+		nextTask.position,
+	)
+		.then(async () => {
+			await invalidateBoard(queryClient, projectId);
+		})
+		.catch(async () => {
+			setTasksCache(queryClient, projectId, snapshot.tasks);
+			await invalidateBoard(queryClient, projectId);
+		});
+}
+
+export function finishColumnDrag(
+	event: DragEndEvent,
+	columns: KanbanColumn[],
+	tasks: KanbanTask[],
+	snapshot: DragSnapshot | null,
+	queryClient: ReturnType<typeof useQueryClient>,
+	projectId: string,
+) {
+	if (!snapshot) {
+		return;
+	}
+
+	const currentColumns =
+		queryClient.getQueryData<KanbanColumn[]>(kanbanKeys.columns(projectId)) ??
+		columns;
+	const activeIndex = currentColumns.findIndex(
+		(column) => column.id === event.active.id,
+	);
+	const currentTasks =
+		getTasksCache(queryClient, projectId) ??
+		tasks;
+	const overColumnId = resolveOverColumnId(event, currentColumns, currentTasks);
+	const overIndex = currentColumns.findIndex(
+		(column) => column.id === overColumnId,
+	);
+	if (activeIndex < 0 || overIndex < 0 || activeIndex === overIndex) {
+		return;
+	}
+
+	const nextColumns = arrayMove(currentColumns, activeIndex, overIndex).map(
+		(column, index) => ({
+			...column,
+			position: index + 1,
+		}),
+	);
+
+	queryClient.setQueryData(kanbanKeys.columns(projectId), nextColumns);
+	void reorderKanbanColumns(
+		projectId,
+		nextColumns.map((column) => column.id),
+	)
+		.then(async () => {
+			await invalidateBoard(queryClient, projectId);
+		})
+		.catch(async () => {
+			queryClient.setQueryData(kanbanKeys.columns(projectId), snapshot.columns);
+			await invalidateBoard(queryClient, projectId);
+		});
+}
+
+function resolveOverColumnId(
+	event: DragEndEvent,
+	columns: KanbanColumn[],
+	tasks: KanbanTask[],
+) {
+	const overData = event.over?.data.current;
+	if (isColumnDragData(overData)) {
+		return overData.column.id;
+	}
+
+	const overId = event.over?.id?.toString();
+	if (!overId) {
+		return null;
+	}
+
+	if (columns.some((column) => column.id === overId)) {
+		return overId;
+	}
+
+	return tasks.find((task) => task.id === overId)?.column_id ?? null;
+}
+
+export function isTaskDragData(value: unknown): value is DragTaskData {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		value.type === "task"
+	);
+}
+
+export function isColumnDragData(value: unknown): value is DragColumnData {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		value.type === "column"
+	);
+}
+
+export function extractErrorMessage(error: unknown) {
+	return error instanceof Error
+		? error.message
+		: "Terjadi kesalahan yang tidak terduga";
+}

--- a/frontend/src/components/shared/kanban-toolbar.tsx
+++ b/frontend/src/components/shared/kanban-toolbar.tsx
@@ -1,4 +1,4 @@
-import { Plus, Search } from "lucide-react";
+import { Plus, Search, X } from "lucide-react";
 
 import { PermissionGate } from "@/components/shared/permission-gate";
 import { Button } from "@/components/ui/button";
@@ -85,11 +85,29 @@ export function KanbanToolbar({
 									search: event.target.value,
 								}))
 							}
+							onKeyDown={(event) => {
+								if (event.key === "Escape" && filters.search) {
+									event.preventDefault();
+									onFiltersChange((current) => ({ ...current, search: "" }));
+								}
+							}}
 							placeholder="Cari judul atau deskripsi task"
 							type="text"
 							value={filters.search}
 						/>
-						<Search className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-tertiary" />
+						{filters.search ? (
+							<button
+								aria-label="Bersihkan pencarian"
+								className="absolute right-2 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-[4px] text-text-tertiary transition-colors hover:bg-surface-muted hover:text-text-primary"
+								onClick={() =>
+									onFiltersChange((current) => ({ ...current, search: "" }))
+								}
+								type="button">
+								<X className="h-4 w-4" />
+							</button>
+						) : (
+							<Search className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-tertiary" />
+						)}
 					</div>
 					<select
 						aria-label="Filter kolom task"

--- a/frontend/src/components/shared/kanban-toolbar.tsx
+++ b/frontend/src/components/shared/kanban-toolbar.tsx
@@ -1,11 +1,11 @@
-import { Plus } from "lucide-react";
+import { Plus, Search } from "lucide-react";
 
 import { PermissionGate } from "@/components/shared/permission-gate";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { permissions } from "@/lib/permissions";
-import type { KanbanFilters } from "@/types/kanban";
+import type { KanbanColumn, KanbanFilters } from "@/types/kanban";
 import type { ProjectMember } from "@/types/project";
 
 const emptyFilters: KanbanFilters = {
@@ -13,9 +13,12 @@ const emptyFilters: KanbanFilters = {
 	priority: "",
 	label: "",
 	dueDate: "",
+	search: "",
+	columnId: "",
 };
 
 interface KanbanToolbarProps {
+	columns: KanbanColumn[];
 	members: ProjectMember[];
 	filters: KanbanFilters;
 	onFiltersChange: (
@@ -25,6 +28,7 @@ interface KanbanToolbarProps {
 }
 
 export function KanbanToolbar({
+	columns,
 	members,
 	filters,
 	onFiltersChange,
@@ -35,6 +39,8 @@ export function KanbanToolbar({
 		filters.priority,
 		filters.label,
 		filters.dueDate,
+		filters.search,
+		filters.columnId,
 	].filter(Boolean).length;
 
 	return (
@@ -66,6 +72,44 @@ export function KanbanToolbar({
 							</Button>
 						</div>
 					</PermissionGate>
+				</div>
+
+				<div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,240px)]">
+					<div className="relative">
+						<Input
+							aria-label="Cari task"
+							className="h-[44px] pr-10 focus-visible:border-ops focus-visible:ring-ops/10"
+							onChange={(event) =>
+								onFiltersChange((current) => ({
+									...current,
+									search: event.target.value,
+								}))
+							}
+							placeholder="Cari judul atau deskripsi task"
+							type="text"
+							value={filters.search}
+						/>
+						<Search className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-tertiary" />
+					</div>
+					<select
+						aria-label="Filter kolom task"
+						className="flex h-[44px] w-full rounded-[6px] border border-transparent bg-surface-muted px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
+						onChange={(event) =>
+							onFiltersChange((current) => ({
+								...current,
+								columnId: event.target.value,
+							}))
+						}
+						value={filters.columnId}>
+						<option value="">Semua kolom</option>
+						{columns.map((column) => (
+							<option
+								key={column.id}
+								value={column.id}>
+								{column.name}
+							</option>
+						))}
+					</select>
 				</div>
 
 				<div className="grid gap-4 xl:grid-cols-[repeat(4,minmax(0,1fr))_auto]">

--- a/frontend/src/components/shared/kanban-toolbar.tsx
+++ b/frontend/src/components/shared/kanban-toolbar.tsx
@@ -1,0 +1,137 @@
+import { Plus } from "lucide-react";
+
+import { PermissionGate } from "@/components/shared/permission-gate";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { permissions } from "@/lib/permissions";
+import type { KanbanFilters } from "@/types/kanban";
+import type { ProjectMember } from "@/types/project";
+
+const emptyFilters: KanbanFilters = {
+	assignee: "",
+	priority: "",
+	label: "",
+	dueDate: "",
+};
+
+interface KanbanToolbarProps {
+	members: ProjectMember[];
+	filters: KanbanFilters;
+	onFiltersChange: (
+		updater: (current: KanbanFilters) => KanbanFilters,
+	) => void;
+	onColumnCreate: () => void;
+}
+
+export function KanbanToolbar({
+	members,
+	filters,
+	onFiltersChange,
+	onColumnCreate,
+}: KanbanToolbarProps) {
+	const activeFilterCount = [
+		filters.assignee,
+		filters.priority,
+		filters.label,
+		filters.dueDate,
+	].filter(Boolean).length;
+
+	return (
+		<Card className="p-6">
+			<div className="flex flex-col gap-5">
+				<div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+					<div>
+						<p className="mb-1 text-[11px] font-[700] uppercase tracking-[0.08em] text-ops">
+							Board proyek
+						</p>
+						<h4 className="text-[20px] font-[700] text-text-primary leading-tight">
+							Ruang kerja task proyek
+						</h4>
+						<p className="mt-1 max-w-3xl text-[13px] text-text-secondary">
+							Kelola task proyek dalam satu board, pindahkan kartu antar tahap
+							kerja, dan gunakan filter tanpa keluar dari halaman ini.
+						</p>
+					</div>
+
+					<PermissionGate permission={permissions.operationalColumnManage}>
+						<div className="flex w-full flex-col items-stretch gap-3 xl:w-auto xl:items-end">
+							<Button
+								variant="ops"
+								className="xl:self-end"
+								onClick={onColumnCreate}
+								type="button">
+								<Plus className="h-4 w-4" />
+								Kolom baru
+							</Button>
+						</div>
+					</PermissionGate>
+				</div>
+
+				<div className="grid gap-4 xl:grid-cols-[repeat(4,minmax(0,1fr))_auto]">
+					<select
+						className="flex h-[44px] w-full rounded-[6px] border border-transparent bg-surface-muted px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
+						onChange={(event) =>
+							onFiltersChange((current) => ({
+								...current,
+								assignee: event.target.value,
+							}))
+						}
+						value={filters.assignee}>
+						<option value="">Semua PIC</option>
+						{members.map((member) => (
+							<option
+								key={member.user_id}
+								value={member.user_id}>
+								{member.full_name || member.user_email || member.user_id}
+							</option>
+						))}
+					</select>
+					<select
+						className="flex h-[44px] w-full rounded-[6px] border border-transparent bg-surface-muted px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10"
+						onChange={(event) =>
+							onFiltersChange((current) => ({
+								...current,
+								priority: event.target.value,
+							}))
+						}
+						value={filters.priority}>
+						<option value="">Semua prioritas</option>
+						<option value="low">Rendah</option>
+						<option value="medium">Medium</option>
+						<option value="high">Tinggi</option>
+						<option value="critical">Kritis</option>
+					</select>
+					<Input
+						className="h-[44px] focus-visible:border-ops focus-visible:ring-ops/10"
+						onChange={(event) =>
+							onFiltersChange((current) => ({
+								...current,
+								label: event.target.value,
+							}))
+						}
+						placeholder="Filter label"
+						value={filters.label}
+					/>
+					<Input
+						className="h-[44px] focus-visible:border-ops focus-visible:ring-ops/10"
+						onChange={(event) =>
+							onFiltersChange((current) => ({
+								...current,
+								dueDate: event.target.value,
+							}))
+						}
+						type="date"
+						value={filters.dueDate}
+					/>
+					<Button
+						onClick={() => onFiltersChange(() => emptyFilters)}
+						variant="secondary"
+						className="h-[44px]">
+						Reset {activeFilterCount > 0 ? `(${activeFilterCount})` : ""}
+					</Button>
+				</div>
+			</div>
+		</Card>
+	);
+}

--- a/frontend/src/components/shared/task-field-editor.tsx
+++ b/frontend/src/components/shared/task-field-editor.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import {
+	DndContext,
+	KeyboardSensor,
+	PointerSensor,
+	closestCenter,
+	useSensor,
+	useSensors,
+	type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+	SortableContext,
+	arrayMove,
+	sortableKeyboardCoordinates,
+	verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { Plus } from "lucide-react";
+
+import { TaskFieldRow } from "@/components/shared/task-field-row";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { TaskFieldDraft } from "@/types/kanban";
+
+const suggestedFieldNames = ["Problem", "Solution", "Outcome", "Reference"];
+
+const fieldKey = (field: TaskFieldDraft) => field.name.trim().toLowerCase();
+
+interface TaskFieldEditorProps {
+	fields: TaskFieldDraft[];
+	onChange: (fields: TaskFieldDraft[]) => void;
+}
+
+export function TaskFieldEditor({ fields, onChange }: TaskFieldEditorProps) {
+	const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+	const [draftName, setDraftName] = useState("");
+	const sensors = useSensors(
+		useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+		useSensor(KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		}),
+	);
+
+	const usedNames = new Set(fields.map(fieldKey));
+	const availableSuggestions = suggestedFieldNames.filter(
+		(name) => !usedNames.has(name.toLowerCase()),
+	);
+	const canAddDraft =
+		Boolean(draftName.trim()) && !usedNames.has(draftName.trim().toLowerCase());
+
+	function addField(name: string) {
+		const trimmed = name.trim();
+		if (!trimmed || usedNames.has(trimmed.toLowerCase())) {
+			return;
+		}
+
+		onChange([...fields, { name: trimmed, value: "" }]);
+		setExpanded((current) => ({ ...current, [trimmed.toLowerCase()]: true }));
+	}
+
+	function handleDragEnd(event: DragEndEvent) {
+		const { active, over } = event;
+		if (!over || active.id === over.id) {
+			return;
+		}
+
+		const from = fields.findIndex((field) => fieldKey(field) === active.id);
+		const to = fields.findIndex((field) => fieldKey(field) === over.id);
+		if (from === -1 || to === -1) {
+			return;
+		}
+
+		onChange(arrayMove(fields, from, to));
+	}
+
+	return (
+		<div className="space-y-3">
+			{availableSuggestions.length > 0 ? (
+				<div className="hidden flex-wrap gap-2 md:flex">
+					{availableSuggestions.map((name) => (
+						<Button
+							className="h-8 shrink-0 px-3 text-[13px]"
+							key={name}
+							onClick={() => addField(name)}
+							size="sm"
+							type="button"
+							variant="outline">
+							Add {name}
+							<Plus className="h-3.5 w-3.5" />
+						</Button>
+					))}
+				</div>
+			) : null}
+
+			<div className="flex gap-2">
+				<Input
+					className="h-9 focus-visible:border-ops focus-visible:ring-ops/10"
+					onChange={(event) => setDraftName(event.target.value)}
+					onKeyDown={(event) => {
+						if (event.key === "Enter") {
+							event.preventDefault();
+							addField(draftName);
+							setDraftName("");
+						}
+					}}
+					placeholder="Add column"
+					value={draftName}
+				/>
+				<Button
+					aria-label="Tambah kolom baru"
+					className="h-9 shrink-0 px-3"
+					disabled={!canAddDraft}
+					onClick={() => {
+						addField(draftName);
+						setDraftName("");
+					}}
+					size="sm"
+					type="button"
+					variant="outline">
+					<Plus className="h-4 w-4" />
+				</Button>
+			</div>
+
+			<DndContext
+				collisionDetection={closestCenter}
+				onDragEnd={handleDragEnd}
+				sensors={sensors}>
+				<SortableContext
+					items={fields.map(fieldKey)}
+					strategy={verticalListSortingStrategy}>
+					<div className="space-y-2">
+						{fields.map((field, index) => {
+							const key = fieldKey(field);
+
+							return (
+								<TaskFieldRow
+									field={field}
+									id={key}
+									isExpanded={expanded[key] ?? false}
+									key={key}
+									onRemove={() =>
+										onChange(
+											fields.filter((_, position) => position !== index),
+										)
+									}
+									onToggle={() =>
+										setExpanded((current) => ({
+											...current,
+											[key]: !(current[key] ?? false),
+										}))
+									}
+									onValueChange={(value) =>
+										onChange(
+											fields.map((item, position) =>
+												position === index ? { ...item, value } : item,
+											),
+										)
+									}
+								/>
+							);
+						})}
+					</div>
+				</SortableContext>
+			</DndContext>
+		</div>
+	);
+}

--- a/frontend/src/components/shared/task-field-editor.tsx
+++ b/frontend/src/components/shared/task-field-editor.tsx
@@ -19,7 +19,11 @@ import { Plus } from "lucide-react";
 import { TaskFieldRow } from "@/components/shared/task-field-row";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import type { TaskFieldDraft } from "@/types/kanban";
+import {
+	MAX_TASK_FIELD_NAME,
+	MAX_TASK_FIELDS,
+	type TaskFieldDraft,
+} from "@/types/kanban";
 
 const suggestedFieldNames = ["Problem", "Solution", "Outcome", "Reference"];
 
@@ -41,19 +45,25 @@ export function TaskFieldEditor({ fields, onChange }: TaskFieldEditorProps) {
 	);
 
 	const usedNames = new Set(fields.map(fieldKey));
+	const atFieldLimit = fields.length >= MAX_TASK_FIELDS;
 	const availableSuggestions = suggestedFieldNames.filter(
 		(name) => !usedNames.has(name.toLowerCase()),
 	);
 	const canAddDraft =
-		Boolean(draftName.trim()) && !usedNames.has(draftName.trim().toLowerCase());
+		Boolean(draftName.trim()) &&
+		!usedNames.has(draftName.trim().toLowerCase()) &&
+		!atFieldLimit;
 
 	function addField(name: string) {
 		const trimmed = name.trim();
-		if (!trimmed || usedNames.has(trimmed.toLowerCase())) {
+		if (!trimmed || usedNames.has(trimmed.toLowerCase()) || atFieldLimit) {
 			return;
 		}
 
-		onChange([...fields, { name: trimmed, value: "" }]);
+		onChange([
+			...fields,
+			{ name: trimmed.slice(0, MAX_TASK_FIELD_NAME), value: "" },
+		]);
 		setExpanded((current) => ({ ...current, [trimmed.toLowerCase()]: true }));
 	}
 
@@ -79,6 +89,7 @@ export function TaskFieldEditor({ fields, onChange }: TaskFieldEditorProps) {
 					{availableSuggestions.map((name) => (
 						<Button
 							className="h-8 shrink-0 px-3 text-[13px]"
+							disabled={atFieldLimit}
 							key={name}
 							onClick={() => addField(name)}
 							size="sm"
@@ -94,6 +105,8 @@ export function TaskFieldEditor({ fields, onChange }: TaskFieldEditorProps) {
 			<div className="flex gap-2">
 				<Input
 					className="h-9 focus-visible:border-ops focus-visible:ring-ops/10"
+					disabled={atFieldLimit}
+					maxLength={MAX_TASK_FIELD_NAME}
 					onChange={(event) => setDraftName(event.target.value)}
 					onKeyDown={(event) => {
 						if (event.key === "Enter") {
@@ -119,6 +132,12 @@ export function TaskFieldEditor({ fields, onChange }: TaskFieldEditorProps) {
 					<Plus className="h-4 w-4" />
 				</Button>
 			</div>
+
+			{atFieldLimit ? (
+				<p className="text-[12px] text-text-tertiary">
+					Maksimal {MAX_TASK_FIELDS} kolom per task.
+				</p>
+			) : null}
 
 			<DndContext
 				collisionDetection={closestCenter}

--- a/frontend/src/components/shared/task-field-row.tsx
+++ b/frontend/src/components/shared/task-field-row.tsx
@@ -4,7 +4,7 @@ import { ChevronDown, ChevronRight, GripVertical, Trash2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import type { TaskFieldDraft } from "@/types/kanban";
+import { MAX_TASK_FIELD_VALUE, type TaskFieldDraft } from "@/types/kanban";
 
 interface TaskFieldRowProps {
 	id: string;
@@ -77,6 +77,7 @@ export function TaskFieldRow({
 				<div className="border-t border-border px-3 py-3">
 					<textarea
 						className="min-h-24 w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:ring-4 focus-visible:ring-ops/10"
+						maxLength={MAX_TASK_FIELD_VALUE}
 						onChange={(event) => onValueChange(event.target.value)}
 						placeholder={`Isi ${field.name}`}
 						value={field.value}

--- a/frontend/src/components/shared/task-field-row.tsx
+++ b/frontend/src/components/shared/task-field-row.tsx
@@ -1,0 +1,88 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { ChevronDown, ChevronRight, GripVertical, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { TaskFieldDraft } from "@/types/kanban";
+
+interface TaskFieldRowProps {
+	id: string;
+	field: TaskFieldDraft;
+	isExpanded: boolean;
+	onToggle: () => void;
+	onRemove: () => void;
+	onValueChange: (value: string) => void;
+}
+
+export function TaskFieldRow({
+	id,
+	field,
+	isExpanded,
+	onToggle,
+	onRemove,
+	onValueChange,
+}: TaskFieldRowProps) {
+	const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+		useSortable({ id });
+
+	return (
+		<div
+			className={cn(
+				"rounded-[8px] border border-border bg-surface",
+				isDragging && "z-10 opacity-80 shadow-card",
+			)}
+			ref={setNodeRef}
+			style={{
+				transform: CSS.Transform.toString(transform),
+				transition,
+			}}>
+			<div className="flex items-center gap-1 px-2 py-2">
+				<button
+					aria-label={`Geser kolom ${field.name}`}
+					className="shrink-0 cursor-grab touch-none rounded-[6px] p-1.5 text-text-tertiary transition-colors hover:bg-surface-muted hover:text-text-secondary active:cursor-grabbing"
+					type="button"
+					{...attributes}
+					{...listeners}>
+					<GripVertical className="h-4 w-4" />
+				</button>
+
+				<button
+					aria-expanded={isExpanded}
+					className="flex min-w-0 flex-1 items-center gap-2 rounded-[6px] px-1 py-1 text-left transition-colors hover:bg-surface-muted"
+					onClick={onToggle}
+					type="button">
+					{isExpanded ? (
+						<ChevronDown className="h-4 w-4 shrink-0 text-text-tertiary" />
+					) : (
+						<ChevronRight className="h-4 w-4 shrink-0 text-text-tertiary" />
+					)}
+					<span className="truncate text-[13px] font-[600] text-text-primary">
+						{field.name}
+					</span>
+				</button>
+
+				<Button
+					aria-label={`Hapus kolom ${field.name}`}
+					className="h-7 w-7 shrink-0 px-0 text-text-tertiary hover:text-priority-high"
+					onClick={onRemove}
+					size="icon"
+					type="button"
+					variant="ghost">
+					<Trash2 className="h-4 w-4" />
+				</Button>
+			</div>
+
+			{isExpanded ? (
+				<div className="border-t border-border px-3 py-3">
+					<textarea
+						className="min-h-24 w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:ring-4 focus-visible:ring-ops/10"
+						onChange={(event) => onValueChange(event.target.value)}
+						placeholder={`Isi ${field.name}`}
+						value={field.value}
+					/>
+				</div>
+			) : null}
+		</div>
+	);
+}

--- a/frontend/src/components/shared/task-modal-fields.tsx
+++ b/frontend/src/components/shared/task-modal-fields.tsx
@@ -1,0 +1,126 @@
+import type { UseFormReturn } from "react-hook-form";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import type { TaskFormValues } from "@/types/kanban";
+import type { ProjectMember } from "@/types/project";
+
+const selectClassName =
+	"flex h-[44px] w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10";
+
+export function TaskTitleField({
+	form,
+	className,
+}: {
+	form: UseFormReturn<TaskFormValues>;
+	className?: string;
+}) {
+	const {
+		register,
+		formState: { errors },
+	} = form;
+
+	return (
+		<div className={cn("grid gap-2", className)}>
+			<label
+				className="text-[13px] font-[600] text-text-primary"
+				htmlFor="task-title">
+				Judul<span className="ml-0.5 text-priority-high">*</span>
+			</label>
+			<Input
+				className="focus-visible:border-ops focus-visible:ring-ops/10"
+				id="task-title"
+				{...register("title")}
+			/>
+			{errors.title ? (
+				<p className="text-[13px] font-[500] text-priority-high">
+					{errors.title.message}
+				</p>
+			) : null}
+		</div>
+	);
+}
+
+export function TaskMetaFields({
+	form,
+	members,
+	className,
+	idPrefix = "task",
+}: {
+	form: UseFormReturn<TaskFormValues>;
+	members: ProjectMember[];
+	className?: string;
+	idPrefix?: string;
+}) {
+	const { register } = form;
+
+	return (
+		<div className={cn("grid gap-5 md:grid-cols-2", className)}>
+			<div className="grid gap-2">
+				<label
+					className="text-[13px] font-[600] text-text-primary"
+					htmlFor={`${idPrefix}-assignee`}>
+					PIC
+				</label>
+				<select
+					className={selectClassName}
+					id={`${idPrefix}-assignee`}
+					{...register("assignee_id")}>
+					<option value="">Belum ditentukan</option>
+					{members.map((member) => (
+						<option
+							key={member.user_id}
+							value={member.user_id}>
+							{member.full_name || member.user_email || member.user_id}
+						</option>
+					))}
+				</select>
+			</div>
+
+			<div className="grid gap-2">
+				<label
+					className="text-[13px] font-[600] text-text-primary"
+					htmlFor={`${idPrefix}-due-date`}>
+					Deadline
+				</label>
+				<Input
+					className="focus-visible:border-ops focus-visible:ring-ops/10"
+					id={`${idPrefix}-due-date`}
+					type="date"
+					{...register("due_date")}
+				/>
+			</div>
+
+			<div className="grid gap-2">
+				<label
+					className="text-[13px] font-[600] text-text-primary"
+					htmlFor={`${idPrefix}-priority`}>
+					Prioritas
+				</label>
+				<select
+					className={selectClassName}
+					id={`${idPrefix}-priority`}
+					{...register("priority")}>
+					<option value="low">Rendah</option>
+					<option value="medium">Medium</option>
+					<option value="high">Tinggi</option>
+					<option value="critical">Kritis</option>
+				</select>
+			</div>
+
+			<div className="grid gap-2">
+				<label
+					className="text-[13px] font-[600] text-text-primary"
+					htmlFor={`${idPrefix}-label`}>
+					Label
+				</label>
+				<Input
+					className="focus-visible:border-ops focus-visible:ring-ops/10"
+					id={`${idPrefix}-label`}
+					placeholder="Bug, desain, backend"
+					{...register("label")}
+				/>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/components/shared/task-modal.tsx
+++ b/frontend/src/components/shared/task-modal.tsx
@@ -1,0 +1,129 @@
+import type { UseFormReturn } from "react-hook-form";
+
+import {
+	Drawer,
+	DrawerClose,
+	DrawerContent,
+	DrawerDescription,
+	DrawerHeader,
+	DrawerTitle,
+} from "@/components/shared/drawer";
+import { PermissionGate } from "@/components/shared/permission-gate";
+import {
+	TaskMetaFields,
+	TaskTitleField,
+} from "@/components/shared/task-modal-fields";
+import { Button } from "@/components/ui/button";
+import { permissions } from "@/lib/permissions";
+import type { TaskFormValues } from "@/types/kanban";
+import type { ProjectMember } from "@/types/project";
+
+export function TaskModal({
+	mode,
+	form,
+	members,
+	isSubmitting,
+	isDeleting,
+	onSubmit,
+	onDelete,
+	onClose,
+}: {
+	mode: "create" | "edit";
+	form: UseFormReturn<TaskFormValues>;
+	members: ProjectMember[];
+	isSubmitting: boolean;
+	isDeleting: boolean;
+	onSubmit: (values: TaskFormValues) => void;
+	onDelete: () => void;
+	onClose: () => void;
+}) {
+	const { register, handleSubmit } = form;
+
+	return (
+		<Drawer
+			onOpenChange={(open) => (!open ? onClose() : undefined)}
+			open>
+			<DrawerContent size="lg">
+				<form
+					className="flex h-full min-h-0 flex-col"
+					onSubmit={handleSubmit(onSubmit)}>
+					<DrawerHeader className="shrink-0">
+						<div className="flex items-start justify-between gap-4">
+							<div>
+								<p className="text-[11px] font-[700] uppercase tracking-[0.08em] text-ops mb-1">
+									{mode === "create" ? "Buat task" : "Detail task"}
+								</p>
+								<DrawerTitle>
+									{mode === "create" ? "Task baru" : "Edit task"}
+								</DrawerTitle>
+								<DrawerDescription>
+									{mode === "create"
+										? "Isi ringkasan task, PIC, dan due date tanpa keluar dari board."
+										: "Tinjau detail task, edit informasi pengerjaan, atau hapus task dari board."}
+								</DrawerDescription>
+							</div>
+							<DrawerClose />
+						</div>
+					</DrawerHeader>
+
+					<div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto px-6 pb-4 pt-6 [scrollbar-gutter:stable]">
+						<TaskTitleField form={form} />
+
+						<div className="grid gap-2">
+							<label
+								className="text-[13px] font-[600] text-text-primary"
+								htmlFor="task-description">
+								Deskripsi
+							</label>
+							<textarea
+								className="min-h-32 w-full rounded-[6px] border border-border bg-surface px-3 py-2 text-[14px] text-text-primary shadow-sm outline-none transition-all placeholder:text-text-tertiary focus-visible:border-ops focus-visible:bg-surface focus-visible:ring-4 focus-visible:ring-ops/10 disabled:cursor-not-allowed disabled:opacity-50"
+								id="task-description"
+								{...register("description")}
+							/>
+						</div>
+
+						<TaskMetaFields
+							className="md:hidden"
+							form={form}
+							idPrefix="task-m"
+							members={members}
+						/>
+
+					</div>
+
+					<div className="shrink-0 border-t border-border bg-surface px-6 pb-5 pt-5">
+						<TaskMetaFields
+							className="mb-5 hidden md:grid"
+							form={form}
+							members={members}
+						/>
+
+						<div className="flex flex-wrap gap-3">
+							<Button
+								variant="ops"
+								disabled={isSubmitting}
+								type="submit">
+								{isSubmitting
+									? "Menyimpan..."
+									: mode === "create"
+										? "Buat task"
+										: "Simpan perubahan"}
+							</Button>
+							{mode === "edit" ? (
+								<PermissionGate permission={permissions.operationalTaskDelete}>
+									<Button
+										disabled={isDeleting}
+										onClick={onDelete}
+										type="button"
+										variant="ghost">
+										{isDeleting ? "Menghapus..." : "Hapus task"}
+									</Button>
+								</PermissionGate>
+							) : null}
+						</div>
+					</div>
+				</form>
+			</DrawerContent>
+		</Drawer>
+	);
+}

--- a/frontend/src/components/shared/task-modal.tsx
+++ b/frontend/src/components/shared/task-modal.tsx
@@ -9,13 +9,14 @@ import {
 	DrawerTitle,
 } from "@/components/shared/drawer";
 import { PermissionGate } from "@/components/shared/permission-gate";
+import { TaskFieldEditor } from "@/components/shared/task-field-editor";
 import {
 	TaskMetaFields,
 	TaskTitleField,
 } from "@/components/shared/task-modal-fields";
 import { Button } from "@/components/ui/button";
 import { permissions } from "@/lib/permissions";
-import type { TaskFormValues } from "@/types/kanban";
+import type { TaskFieldDraft, TaskFormValues } from "@/types/kanban";
 import type { ProjectMember } from "@/types/project";
 
 export function TaskModal({
@@ -37,7 +38,12 @@ export function TaskModal({
 	onDelete: () => void;
 	onClose: () => void;
 }) {
-	const { register, handleSubmit } = form;
+	const { register, handleSubmit, watch, setValue } = form;
+	const fields = watch("fields") ?? [];
+
+	function handleFieldsChange(next: TaskFieldDraft[]) {
+		setValue("fields", next, { shouldDirty: true });
+	}
 
 	return (
 		<Drawer
@@ -81,6 +87,11 @@ export function TaskModal({
 								{...register("description")}
 							/>
 						</div>
+
+						<TaskFieldEditor
+							fields={fields}
+							onChange={handleFieldsChange}
+						/>
 
 						<TaskMetaFields
 							form={form}

--- a/frontend/src/components/shared/task-modal.tsx
+++ b/frontend/src/components/shared/task-modal.tsx
@@ -25,6 +25,7 @@ export function TaskModal({
 	members,
 	isSubmitting,
 	isDeleting,
+	error,
 	onSubmit,
 	onDelete,
 	onClose,
@@ -34,6 +35,7 @@ export function TaskModal({
 	members: ProjectMember[];
 	isSubmitting: boolean;
 	isDeleting: boolean;
+	error?: string | null;
 	onSubmit: (values: TaskFormValues) => void;
 	onDelete: () => void;
 	onClose: () => void;
@@ -100,6 +102,11 @@ export function TaskModal({
 					</div>
 
 					<div className="shrink-0 border-t border-border bg-surface px-6 pb-5 pt-5">
+						{error ? (
+							<p className="mb-3 rounded-[6px] border border-priority-high/20 bg-priority-high/5 px-3 py-2 text-[13px] font-[500] text-priority-high">
+								{error}
+							</p>
+						) : null}
 						<div className="flex flex-wrap gap-3">
 							<Button
 								variant="ops"

--- a/frontend/src/components/shared/task-modal.tsx
+++ b/frontend/src/components/shared/task-modal.tsx
@@ -83,21 +83,12 @@ export function TaskModal({
 						</div>
 
 						<TaskMetaFields
-							className="md:hidden"
 							form={form}
-							idPrefix="task-m"
 							members={members}
 						/>
-
 					</div>
 
 					<div className="shrink-0 border-t border-border bg-surface px-6 pb-5 pt-5">
-						<TaskMetaFields
-							className="mb-5 hidden md:grid"
-							form={form}
-							members={members}
-						/>
-
 						<div className="flex flex-wrap gap-3">
 							<Button
 								variant="ops"

--- a/frontend/src/hooks/use-debounced-value.ts
+++ b/frontend/src/hooks/use-debounced-value.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-export function useDebouncedValue<T>(value: T, delayMs = 300) {
+export function useDebouncedValue<T>(value: T, delayMs = 500) {
 	const [debounced, setDebounced] = useState(value);
 
 	useEffect(() => {

--- a/frontend/src/hooks/use-debounced-value.ts
+++ b/frontend/src/hooks/use-debounced-value.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useDebouncedValue<T>(value: T, delayMs = 300) {
+	const [debounced, setDebounced] = useState(value);
+
+	useEffect(() => {
+		const timeout = window.setTimeout(() => setDebounced(value), delayMs);
+		return () => window.clearTimeout(timeout);
+	}, [value, delayMs]);
+
+	return debounced;
+}

--- a/frontend/src/hooks/use-kanban-column-tasks.ts
+++ b/frontend/src/hooks/use-kanban-column-tasks.ts
@@ -4,6 +4,7 @@ import {
 	kanbanKeys,
 	kanbanPageSize,
 	listKanbanTasks,
+	type KanbanTaskQuery,
 } from "@/services/operational-kanban";
 import type { KanbanTask } from "@/types/kanban";
 
@@ -20,12 +21,14 @@ export interface ColumnTasksResult {
 export function useKanbanColumnTasks(
 	projectId: string,
 	columnId: string,
+	filters: KanbanTaskQuery,
 ): ColumnTasksResult {
 	const query = useInfiniteQuery({
-		queryKey: kanbanKeys.columnTasks(projectId, columnId, {}),
+		queryKey: kanbanKeys.columnTasks(projectId, columnId, filters),
 		initialPageParam: 0,
 		queryFn: ({ pageParam }) =>
 			listKanbanTasks(projectId, {
+				...filters,
 				columnId,
 				limit: kanbanPageSize,
 				offset: pageParam,

--- a/frontend/src/hooks/use-kanban-column-tasks.ts
+++ b/frontend/src/hooks/use-kanban-column-tasks.ts
@@ -6,10 +6,10 @@ import {
 	listKanbanTasks,
 	type KanbanTaskQuery,
 } from "@/services/operational-kanban";
-import type { KanbanTask } from "@/types/kanban";
+import type { KanbanTaskListItem } from "@/types/kanban";
 
 export interface ColumnTasksResult {
-	tasks: KanbanTask[];
+	tasks: KanbanTaskListItem[];
 	total: number;
 	hasMore: boolean;
 	isLoading: boolean;

--- a/frontend/src/hooks/use-kanban-column-tasks.ts
+++ b/frontend/src/hooks/use-kanban-column-tasks.ts
@@ -1,0 +1,52 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import {
+	kanbanKeys,
+	kanbanPageSize,
+	listKanbanTasks,
+} from "@/services/operational-kanban";
+import type { KanbanTask } from "@/types/kanban";
+
+export interface ColumnTasksResult {
+	tasks: KanbanTask[];
+	total: number;
+	hasMore: boolean;
+	isLoading: boolean;
+	isFetchingMore: boolean;
+	error: Error | null;
+	fetchMore: () => void;
+}
+
+export function useKanbanColumnTasks(
+	projectId: string,
+	columnId: string,
+): ColumnTasksResult {
+	const query = useInfiniteQuery({
+		queryKey: kanbanKeys.columnTasks(projectId, columnId, {}),
+		initialPageParam: 0,
+		queryFn: ({ pageParam }) =>
+			listKanbanTasks(projectId, {
+				columnId,
+				limit: kanbanPageSize,
+				offset: pageParam,
+			}),
+		getNextPageParam: (lastPage) =>
+			lastPage.has_more ? lastPage.offset + lastPage.items.length : undefined,
+	});
+
+	const pages = query.data?.pages ?? [];
+
+	return {
+		tasks: pages.flatMap((page) => page.items),
+		total: pages[0]?.total ?? 0,
+		hasMore: Boolean(query.hasNextPage),
+		isLoading: query.isLoading,
+		isFetchingMore: query.isFetchingNextPage,
+		error: query.error as Error | null,
+		fetchMore: () => {
+			if (query.hasNextPage && !query.isFetchingNextPage) {
+				void query.fetchNextPage();
+			}
+		},
+	};
+}

--- a/frontend/src/hooks/use-kanban-drag.ts
+++ b/frontend/src/hooks/use-kanban-drag.ts
@@ -14,16 +14,16 @@ import {
 import { kanbanKeys } from "@/services/operational-kanban";
 import type {
 	KanbanColumn,
-	KanbanTask,
+	KanbanTaskListItem,
 } from "@/types/kanban";
 
 export function useKanbanDrag(
 	projectId: string,
 	columns: KanbanColumn[],
-	tasks: KanbanTask[],
+	tasks: KanbanTaskListItem[],
 ) {
 	const queryClient = useQueryClient();
-	const [activeTask, setActiveTask] = useState<KanbanTask | null>(null);
+	const [activeTask, setActiveTask] = useState<KanbanTaskListItem | null>(null);
 	const [activeColumn, setActiveColumn] = useState<KanbanColumn | null>(null);
 	const [dragSnapshot, setDragSnapshot] = useState<DragSnapshot | null>(null);
 

--- a/frontend/src/hooks/use-kanban-drag.ts
+++ b/frontend/src/hooks/use-kanban-drag.ts
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+	finishColumnDrag,
+	finishTaskDrag,
+	isColumnDragData,
+	isTaskDragData,
+	moveTaskInMemory,
+	setTasksCache,
+	type DragSnapshot,
+} from "@/components/shared/kanban-dnd";
+import { kanbanKeys } from "@/services/operational-kanban";
+import type {
+	KanbanColumn,
+	KanbanTask,
+} from "@/types/kanban";
+
+export function useKanbanDrag(
+	projectId: string,
+	columns: KanbanColumn[],
+	tasks: KanbanTask[],
+) {
+	const queryClient = useQueryClient();
+	const [activeTask, setActiveTask] = useState<KanbanTask | null>(null);
+	const [activeColumn, setActiveColumn] = useState<KanbanColumn | null>(null);
+	const [dragSnapshot, setDragSnapshot] = useState<DragSnapshot | null>(null);
+
+	function resetDrag() {
+		setActiveTask(null);
+		setActiveColumn(null);
+		setDragSnapshot(null);
+	}
+
+	function rollbackDrag() {
+		if (!dragSnapshot) {
+			return;
+		}
+
+		queryClient.setQueryData(
+			kanbanKeys.columns(projectId),
+			dragSnapshot.columns,
+		);
+		setTasksCache(queryClient, projectId, dragSnapshot.tasks);
+	}
+
+	function handleDragStart(event: DragStartEvent) {
+		const data = event.active.data.current;
+
+		if (isTaskDragData(data)) {
+			setActiveTask(data.task);
+			setDragSnapshot({ columns, tasks });
+			return;
+		}
+
+		if (isColumnDragData(data)) {
+			setActiveColumn(data.column);
+			setDragSnapshot({ columns, tasks });
+		}
+	}
+
+	function handleDragEnd(event: DragEndEvent) {
+		if (!event.over) {
+			rollbackDrag();
+			resetDrag();
+			return;
+		}
+
+		const activeData = event.active.data.current;
+
+		if (isColumnDragData(activeData)) {
+			finishColumnDrag(
+				event,
+				columns,
+				tasks,
+				dragSnapshot,
+				queryClient,
+				projectId,
+			);
+			resetDrag();
+			return;
+		}
+
+		if (isTaskDragData(activeData)) {
+			const nextTasks = moveTaskInMemory(
+				dragSnapshot?.tasks ?? tasks,
+				activeData.task.id,
+				event.over.data.current,
+				event.over.id.toString(),
+			);
+
+			finishTaskDrag(
+				activeData.task.id,
+				nextTasks,
+				dragSnapshot,
+				queryClient,
+				projectId,
+			);
+		}
+
+		resetDrag();
+	}
+
+	return { activeTask, activeColumn, handleDragStart, handleDragEnd };
+}

--- a/frontend/src/hooks/use-kanban-mutations.ts
+++ b/frontend/src/hooks/use-kanban-mutations.ts
@@ -1,0 +1,102 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+	extractErrorMessage,
+	invalidateBoard,
+} from "@/components/shared/kanban-dnd";
+import {
+	createKanbanColumn,
+	createKanbanTask,
+	deleteKanbanColumn,
+	deleteKanbanTask,
+	updateKanbanColumn,
+	updateKanbanTask,
+} from "@/services/operational-kanban";
+import type { TaskFormValues } from "@/types/kanban";
+
+interface KanbanMutationCallbacks {
+	onError: (message: string) => void;
+	onColumnSaved: () => void;
+	onColumnDeleted: () => void;
+	onTaskSaved: () => void;
+	onTaskDeleted: () => void;
+}
+
+export function useKanbanMutations(
+	projectId: string,
+	callbacks: KanbanMutationCallbacks,
+) {
+	const queryClient = useQueryClient();
+	const handleError = (error: unknown) =>
+		callbacks.onError(extractErrorMessage(error));
+
+	const createColumn = useMutation({
+		mutationFn: (payload: { name: string; color?: string }) =>
+			createKanbanColumn(projectId, payload),
+		onSuccess: async () => {
+			callbacks.onColumnSaved();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const updateColumn = useMutation({
+		mutationFn: (payload: { columnId: string; name: string; color?: string }) =>
+			updateKanbanColumn(projectId, payload.columnId, {
+				name: payload.name,
+				color: payload.color,
+			}),
+		onSuccess: async () => {
+			callbacks.onColumnSaved();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const deleteColumn = useMutation({
+		mutationFn: (columnId: string) => deleteKanbanColumn(projectId, columnId),
+		onSuccess: async () => {
+			callbacks.onColumnDeleted();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const createTask = useMutation({
+		mutationFn: (payload: { column_id: string } & TaskFormValues) =>
+			createKanbanTask(projectId, payload),
+		onSuccess: async () => {
+			callbacks.onTaskSaved();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const updateTask = useMutation({
+		mutationFn: (payload: { taskId: string; values: TaskFormValues }) =>
+			updateKanbanTask(projectId, payload.taskId, payload.values),
+		onSuccess: async () => {
+			callbacks.onTaskSaved();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	const deleteTask = useMutation({
+		mutationFn: (taskId: string) => deleteKanbanTask(projectId, taskId),
+		onSuccess: async () => {
+			callbacks.onTaskDeleted();
+			await invalidateBoard(queryClient, projectId);
+		},
+		onError: handleError,
+	});
+
+	return {
+		createColumn,
+		updateColumn,
+		deleteColumn,
+		createTask,
+		updateTask,
+		deleteTask,
+	};
+}

--- a/frontend/src/services/operational-kanban.ts
+++ b/frontend/src/services/operational-kanban.ts
@@ -4,6 +4,10 @@ import type { KanbanColumn, KanbanTask, TaskFormValues } from "@/types/kanban";
 
 export interface KanbanTaskQuery {
   columnId?: string;
+  assigneeId?: string;
+  priority?: string;
+  label?: string;
+  dueDate?: string;
   limit?: number;
   offset?: number;
 }
@@ -23,7 +27,15 @@ export const kanbanKeys = {
   columns: (projectId: string) => [...kanbanKeys.all(projectId), "columns"] as const,
   tasks: (projectId: string) => [...kanbanKeys.all(projectId), "tasks"] as const,
   columnTasks: (projectId: string, columnId: string, query: KanbanTaskQuery) =>
-    [...kanbanKeys.tasks(projectId), "column", columnId, query.limit ?? ""] as const,
+    [
+      ...kanbanKeys.tasks(projectId),
+      "column",
+      columnId,
+      query.assigneeId ?? "",
+      query.priority ?? "",
+      query.label ?? "",
+      query.dueDate ?? "",
+    ] as const,
 };
 
 export async function listKanbanColumns(projectId: string) {
@@ -85,6 +97,18 @@ export async function listKanbanTasks(projectId: string, query: KanbanTaskQuery 
   const params = new URLSearchParams();
   if (query.columnId) {
     params.set("column_id", query.columnId);
+  }
+  if (query.assigneeId) {
+    params.set("assignee_id", query.assigneeId);
+  }
+  if (query.priority) {
+    params.set("priority", query.priority);
+  }
+  if (query.label?.trim()) {
+    params.set("label", query.label.trim());
+  }
+  if (query.dueDate) {
+    params.set("due_date", query.dueDate);
   }
   params.set("limit", String(query.limit ?? kanbanPageSize));
   params.set("offset", String(query.offset ?? 0));

--- a/frontend/src/services/operational-kanban.ts
+++ b/frontend/src/services/operational-kanban.ts
@@ -1,6 +1,11 @@
 ﻿import { authRequestJSON } from "@/lib/api-client";
 import { toUTCDateOnlyISOString } from "@/lib/date";
-import type { KanbanColumn, KanbanTask, TaskFormValues } from "@/types/kanban";
+import type {
+  KanbanColumn,
+  KanbanTask,
+  KanbanTaskListItem,
+  TaskFormValues,
+} from "@/types/kanban";
 
 export interface KanbanTaskQuery {
   search?: string;
@@ -14,7 +19,7 @@ export interface KanbanTaskQuery {
 }
 
 export interface KanbanTaskPage {
-  items: KanbanTask[];
+  items: KanbanTaskListItem[];
   total: number;
   limit: number;
   offset: number;
@@ -27,6 +32,8 @@ export const kanbanKeys = {
   all: (projectId: string) => ["operational", "projects", projectId, "kanban"] as const,
   columns: (projectId: string) => [...kanbanKeys.all(projectId), "columns"] as const,
   tasks: (projectId: string) => [...kanbanKeys.all(projectId), "tasks"] as const,
+  task: (projectId: string, taskId: string) =>
+    [...kanbanKeys.tasks(projectId), "detail", taskId] as const,
   columnTasks: (projectId: string, columnId: string, query: KanbanTaskQuery) =>
     [
       ...kanbanKeys.tasks(projectId),
@@ -125,6 +132,14 @@ export async function listKanbanTasks(projectId: string, query: KanbanTaskQuery 
   );
 }
 
+
+export async function getKanbanTask(projectId: string, taskId: string) {
+  return authRequestJSON<KanbanTask>(
+    `/operational/projects/${projectId}/tasks/${taskId}`,
+    { method: "GET" },
+  );
+}
+
 export async function createKanbanTask(projectId: string, input: { column_id: string } & TaskFormValues) {
   return authRequestJSON<KanbanTask>(
     `/operational/projects/${projectId}/tasks`,
@@ -185,5 +200,16 @@ function serializeTaskForm(input: Partial<{ column_id: string }> & TaskFormValue
     due_date: input.due_date ? toUTCDateOnlyISOString(input.due_date) : null,
     priority: input.priority,
     label: input.label.trim() || null,
+    fields: serializeTaskFields(input.fields),
   };
+}
+
+function serializeTaskFields(fields: TaskFormValues["fields"] | undefined) {
+  if (!fields?.length) {
+    return [];
+  }
+
+  return fields
+    .map((field) => ({ name: field.name.trim(), value: field.value.trim() }))
+    .filter((field) => field.name.length > 0 && field.value.length > 0);
 }

--- a/frontend/src/services/operational-kanban.ts
+++ b/frontend/src/services/operational-kanban.ts
@@ -2,10 +2,28 @@
 import { toUTCDateOnlyISOString } from "@/lib/date";
 import type { KanbanColumn, KanbanTask, TaskFormValues } from "@/types/kanban";
 
+export interface KanbanTaskQuery {
+  columnId?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface KanbanTaskPage {
+  items: KanbanTask[];
+  total: number;
+  limit: number;
+  offset: number;
+  has_more: boolean;
+}
+
+export const kanbanPageSize = 20;
+
 export const kanbanKeys = {
   all: (projectId: string) => ["operational", "projects", projectId, "kanban"] as const,
   columns: (projectId: string) => [...kanbanKeys.all(projectId), "columns"] as const,
   tasks: (projectId: string) => [...kanbanKeys.all(projectId), "tasks"] as const,
+  columnTasks: (projectId: string, columnId: string, query: KanbanTaskQuery) =>
+    [...kanbanKeys.tasks(projectId), "column", columnId, query.limit ?? ""] as const,
 };
 
 export async function listKanbanColumns(projectId: string) {
@@ -63,9 +81,16 @@ export async function reorderKanbanColumns(projectId: string, columnIds: string[
   );
 }
 
-export async function listKanbanTasks(projectId: string) {
-  return authRequestJSON<KanbanTask[]>(
-    `/operational/projects/${projectId}/tasks`,
+export async function listKanbanTasks(projectId: string, query: KanbanTaskQuery = {}) {
+  const params = new URLSearchParams();
+  if (query.columnId) {
+    params.set("column_id", query.columnId);
+  }
+  params.set("limit", String(query.limit ?? kanbanPageSize));
+  params.set("offset", String(query.offset ?? 0));
+
+  return authRequestJSON<KanbanTaskPage>(
+    `/operational/projects/${projectId}/tasks?${params.toString()}`,
     { method: "GET" },
   );
 }

--- a/frontend/src/services/operational-kanban.ts
+++ b/frontend/src/services/operational-kanban.ts
@@ -3,6 +3,7 @@ import { toUTCDateOnlyISOString } from "@/lib/date";
 import type { KanbanColumn, KanbanTask, TaskFormValues } from "@/types/kanban";
 
 export interface KanbanTaskQuery {
+  search?: string;
   columnId?: string;
   assigneeId?: string;
   priority?: string;
@@ -31,6 +32,7 @@ export const kanbanKeys = {
       ...kanbanKeys.tasks(projectId),
       "column",
       columnId,
+      query.search ?? "",
       query.assigneeId ?? "",
       query.priority ?? "",
       query.label ?? "",
@@ -95,6 +97,10 @@ export async function reorderKanbanColumns(projectId: string, columnIds: string[
 
 export async function listKanbanTasks(projectId: string, query: KanbanTaskQuery = {}) {
   const params = new URLSearchParams();
+  const search = query.search?.trim();
+  if (search) {
+    params.set("q", search);
+  }
   if (query.columnId) {
     params.set("column_id", query.columnId);
   }

--- a/frontend/src/types/kanban.ts
+++ b/frontend/src/types/kanban.ts
@@ -25,6 +25,12 @@ export interface TaskFieldDraft {
   value: string;
 }
 
+// Custom task-field limits. Keep in sync with the backend validation in
+// backend/internal/dto/operational/kanban_task_field.go.
+export const MAX_TASK_FIELDS = 50;
+export const MAX_TASK_FIELD_NAME = 120;
+export const MAX_TASK_FIELD_VALUE = 20000;
+
 export interface KanbanTaskListItem {
   id: string;
   column_id: string;

--- a/frontend/src/types/kanban.ts
+++ b/frontend/src/types/kanban.ts
@@ -10,6 +10,36 @@ export interface KanbanColumn {
   created_at: string;
 }
 
+export interface KanbanTaskField {
+  id: string;
+  task_id: string;
+  name: string;
+  value: string;
+  position: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TaskFieldDraft {
+  name: string;
+  value: string;
+}
+
+export interface KanbanTaskListItem {
+  id: string;
+  column_id: string;
+  title: string;
+  description?: string | null;
+  assignee_id?: string | null;
+  assignee_name?: string | null;
+  avatar_url?: string | null;
+  due_date?: string | null;
+  priority: ProjectPriority;
+  label?: string | null;
+  assigned_via: "manual" | "auto";
+  position: number;
+}
+
 export interface KanbanTask {
   id: string;
   column_id: string;
@@ -27,6 +57,7 @@ export interface KanbanTask {
   created_by: string;
   created_at: string;
   updated_at: string;
+  fields?: KanbanTaskField[] | null;
 }
 
 export interface KanbanFilters {
@@ -45,4 +76,5 @@ export interface TaskFormValues {
   due_date: string;
   priority: ProjectPriority;
   label: string;
+  fields: TaskFieldDraft[];
 }

--- a/frontend/src/types/kanban.ts
+++ b/frontend/src/types/kanban.ts
@@ -34,6 +34,8 @@ export interface KanbanFilters {
   priority: string;
   label: string;
   dueDate: string;
+  search: string;
+  columnId: string;
 }
 
 export interface TaskFormValues {


### PR DESCRIPTION
> **Stacked PR 7 of 7 — merge in order.**
> Depends on #151, PR 2–6. Built on top of `feat/kanban-task-custom-columns-api`.
> GitHub does not allow a fork branch as a base, so this targets `main` directly:
> until the PRs before it merge, this diff also shows their changes.
> Once they land, this diff narrows to only what is listed below.
> #151 → #152 → #153 → #154 → #155 → #156 → #157

## Summary

Brings the custom fields from PR 6 into the task modal, and trims the board list response to only what the cards actually render.

## What changed

**Task modal**
- One-click suggestions: Problem, Solution, Outcome, Reference
- A free-text field to add any other column name
- Columns can be reordered by dragging, expanded, and deleted
- Clicking anywhere on a column's header row toggles it open
- Header and action buttons stay fixed while the middle section scrolls
- On small screens, PIC, deadline, priority, and label move into the scrollable area below the columns

**Payload**
- The board list no longer ships custom fields or unused metadata
- A task's fields load when its modal opens, via `GET /tasks/{id}`
- Per-task payload: **861 → 348 bytes (−60%)**

## Why

Fields are only useful if they can be filled in without leaving the board. Keeping them out of the list response matters just as much: field values are free text and can be long, so shipping them for every card on every page load would undo the payload work from PR 2.

### Personal context

The four defaults are deliberately not code-specific. "Link Github" as a default would be wrong for our marketing and HR boards — but Problem, Solution, Outcome, and Reference apply to a campaign or a hiring task just as well as to a bug. Anyone who wants a GitHub link can still add it by name on the tasks where it fits.

## Behaviour worth knowing

Adding a column and leaving it empty is fine. Nothing is saved for it, no validation error is raised, and it can be added again later. Only filled columns persist.

## Verification

Tested on **952 tasks, 7 columns, 5 members**:

- All 15 modal interactions driven in a real browser: typing title and description, each suggestion button, creating a custom column, filling it, expand and collapse, delete, the drag handle, and saving with an empty column present
- Saved task verified in the database with the correct title, description, PIC, deadline, priority, label, and fields — with the empty column correctly absent
- Board list confirmed to carry no `fields` array: **348 bytes per task, 6.8 KB per column page**
- Opening a task fires one `GET /tasks/{id}` — 858 bytes, 10 ms
- Search, all six filters, pagination, and drag-and-drop all still pass with this on top
- `tsc`, `eslint`, and production build pass; no console errors

## Risk if we don't merge this

PR 6's fields exist in the API with no way to use them from the board.

## Risk of merging this

Moderate, concentrated in the modal:

- **The modal was restructured** for the fixed header, scrolling middle, and fixed footer. Verified at desktop and mobile widths, with no overlapping fields at either.
- **Task data now comes from two places** — the list for the summary, `GET /tasks/{id}` for the fields. The modal opens immediately with the list data and fills in the fields when they arrive, so a slow detail request delays the custom columns only, not the modal.
- Trimming the list response removes fields the cards never read. Every board interaction that consumes task data — cards, drag-and-drop, filters — was re-tested against the trimmed shape.

## Screenshots

**Before — task modal with only description**

<img width="1920" height="971" alt="image" src="https://github.com/user-attachments/assets/e028d70b-68c5-4264-a65e-ef10b90aab9a" />

**After — suggestions and Add column below the description**

<img width="1920" height="971" alt="image" src="https://github.com/user-attachments/assets/33d07afe-82f8-4b04-a6f4-d89edffcb42b" />
